### PR TITLE
Integrate web3 cookie jar and add dashboard

### DIFF
--- a/packages/client/src/components/Layout/Header.tsx
+++ b/packages/client/src/components/Layout/Header.tsx
@@ -2,6 +2,7 @@ import { type RemixiconComponentType, RiGithubLine, RiTwitterLine } from "@remix
 import type React from "react";
 import { APP_NAME } from "@/config";
 import { useApp } from "@/providers/app";
+import { CookieJarIcon } from "@/components/UI/CookieJar";
 
 type HeaderProps = Record<string, never>;
 
@@ -29,7 +30,8 @@ export const Header: React.FC<HeaderProps> = () => {
         <img src="/icon.png" alt="APP_NAME Logo" className=" w-12 lg:w-20" />
         <h1 className="text-xl lg:text-3xl font-bold">{APP_NAME}</h1>
       </div>
-      <div className="flex gap-2">
+      <div className="flex gap-2 items-center">
+        <CookieJarIcon />
         {filterLinks.map(({ Icon, link, action, title }) => (
           <a
             key={title}

--- a/packages/client/src/components/UI/CookieJar/Dashboard.tsx
+++ b/packages/client/src/components/UI/CookieJar/Dashboard.tsx
@@ -1,0 +1,182 @@
+import { RiCloseLine, RiExternalLinkLine, RiFileCopyLine, RiWalletLine } from "@remixicon/react";
+import React, { useEffect, useMemo, useState } from "react";
+import { createPublicClient, formatEther, getAddress, http, isAddress } from "viem";
+import { celo } from "viem/chains";
+import { cn } from "@/utils/cn";
+
+export interface CookieJarDashboardProps {
+  className?: string;
+  onClose?: () => void;
+  jarAddress?: string;
+}
+
+const DEFAULT_JAR = "0x4E7eBA1BF7b982f4E482d5cE082a7Dd24d12A321" as const;
+
+export const CookieJarDashboard: React.FC<CookieJarDashboardProps> = ({
+  className,
+  onClose,
+  jarAddress,
+}) => {
+  const [isClosing, setIsClosing] = useState(false);
+  const [balanceWei, setBalanceWei] = useState<bigint | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const address = useMemo(() => {
+    const addr = (jarAddress || DEFAULT_JAR).trim();
+    try {
+      return getAddress(addr);
+    } catch (_e) {
+      return isAddress(addr) ? (addr as `0x${string}`) : DEFAULT_JAR;
+    }
+  }, [jarAddress]);
+
+  useEffect(() => {
+    let cancelled = false;
+    const rpc = celo.rpcUrls.default.http[0];
+    const client = createPublicClient({ chain: celo, transport: http(rpc) });
+    client
+      .getBalance({ address })
+      .then((res) => {
+        if (!cancelled) setBalanceWei(res);
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e?.message || "Failed to load balance");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [address]);
+
+  const handleClose = () => {
+    setIsClosing(true);
+    setTimeout(() => onClose?.(), 300);
+  };
+
+  const balanceDisplay = useMemo(() => {
+    if (balanceWei === null) return "—";
+    try {
+      return `${Number(formatEther(balanceWei)).toLocaleString(undefined, { maximumFractionDigits: 4 })} CELO`;
+    } catch {
+      return "—";
+    }
+  }, [balanceWei]);
+
+  const explorerUrl = `https://celoscan.io/address/${address}`;
+
+  const onCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(address);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // ignore
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        "fixed inset-0 bg-black/20 backdrop-blur-sm z-[10001] flex items-end justify-center",
+        isClosing ? "modal-backdrop-exit" : "modal-backdrop-enter"
+      )}
+      data-testid="cookie-jar-modal-overlay"
+      onClick={handleClose}
+      onKeyDown={(e) => {
+        if (e.key === "Escape") handleClose();
+      }}
+      tabIndex={-1}
+    >
+      <div
+        className={cn(
+          "bg-white rounded-t-3xl shadow-2xl w-full overflow-hidden flex flex-col",
+          isClosing ? "modal-slide-exit" : "modal-slide-enter",
+          className
+        )}
+        style={{ height: "70vh" }}
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        data-testid="cookie-jar-modal"
+      >
+        <div className="flex items-center justify-between p-4 border-b border-border flex-shrink-0">
+          <div className="flex items-center gap-3 min-w-0">
+            <div className="w-9 h-9 rounded-lg bg-emerald-50 text-emerald-700 grid place-items-center">
+              <RiWalletLine className="w-5 h-5" />
+            </div>
+            <div className="min-w-0">
+              <h2 className="text-lg font-semibold truncate">Cookie Jar</h2>
+              <p className="text-sm text-slate-600 truncate">Celo • {address}</p>
+            </div>
+          </div>
+          <button onClick={handleClose} className="btn-icon rounded-full" aria-label="Close modal">
+            <RiCloseLine className="w-5 h-5 focus:text-primary active:text-primary" />
+          </button>
+        </div>
+
+        <div className="p-4 flex-1 min-h-0 overflow-y-auto space-y-6">
+          <section className="space-y-2">
+            <h3 className="text-sm font-medium text-slate-700">Jar Address</h3>
+            <div className="flex items-center gap-2">
+              <code className="px-2 py-1 rounded bg-slate-50 border border-slate-200 text-xs break-all">
+                {address}
+              </code>
+              <button
+                className="btn-icon"
+                onClick={onCopy}
+                title="Copy address"
+                aria-label="Copy address"
+              >
+                <RiFileCopyLine className="w-4 h-4" />
+              </button>
+              {copied && <span className="text-xs text-emerald-600">Copied!</span>}
+            </div>
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-sm font-medium text-slate-700">Native Balance</h3>
+            <div className="flex items-center justify-between rounded-lg border border-slate-200 p-3 bg-slate-50">
+              <span className="text-lg font-semibold">{balanceDisplay}</span>
+              <a
+                href={explorerUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 text-sm text-emerald-700 hover:underline"
+              >
+                <RiExternalLinkLine className="w-4 h-4" />
+                Open on explorer
+              </a>
+            </div>
+            {error && <p className="text-xs text-red-600">{error}</p>}
+          </section>
+
+          <section className="space-y-2">
+            <h3 className="text-sm font-medium text-slate-700">Manage & Claim</h3>
+            <p className="text-sm text-slate-600">
+              Barebones integration: view balance and open external app to manage or claim from this
+              jar.
+            </p>
+            <div className="flex flex-wrap gap-2">
+              <a
+                href="https://www.cookiejar.wtf/"
+                target="_blank"
+                rel="noreferrer"
+                className="px-3 py-2 rounded-lg border border-emerald-200 text-emerald-700 hover:bg-emerald-50 text-sm"
+              >
+                Open Cookie Jar dApp
+              </a>
+              <a
+                href={explorerUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="px-3 py-2 rounded-lg border border-slate-200 hover:bg-slate-50 text-sm"
+              >
+                View Contract
+              </a>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/client/src/components/UI/CookieJar/Icon.tsx
+++ b/packages/client/src/components/UI/CookieJar/Icon.tsx
@@ -1,0 +1,42 @@
+import { RiWalletLine } from "@remixicon/react";
+import React, { useState } from "react";
+import { useIntl } from "react-intl";
+import { cn } from "@/utils/cn";
+import { CookieJarDashboard } from "./Dashboard";
+
+interface CookieJarIconProps {
+  className?: string;
+  jarAddress?: string;
+}
+
+export const CookieJarIcon: React.FC<CookieJarIconProps> = ({ className, jarAddress }) => {
+  const intl = useIntl();
+  const [showDashboard, setShowDashboard] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setShowDashboard(true)}
+        className={cn(
+          "relative p-1 rounded-lg border transition-all duration-200",
+          "hover:shadow-lg hover:scale-105 active:scale-95",
+          "flex items-center justify-center w-8 h-8 tap-target-lg",
+          "focus:outline-none focus:ring-2 focus:ring-emerald-200 focus:border-emerald-600 active:border-emerald-600",
+          "bg-white border-slate-200 text-slate-500",
+          className
+        )}
+        aria-label={intl.formatMessage({
+          id: "app.cookieJar.openButton",
+          defaultMessage: "Open cookie jar",
+        })}
+        data-testid="cookie-jar-icon"
+      >
+        <RiWalletLine className="w-4 h-4" />
+      </button>
+
+      {showDashboard && (
+        <CookieJarDashboard jarAddress={jarAddress} onClose={() => setShowDashboard(false)} />
+      )}
+    </>
+  );
+};

--- a/packages/client/src/components/UI/CookieJar/index.ts
+++ b/packages/client/src/components/UI/CookieJar/index.ts
@@ -1,0 +1,2 @@
+export { CookieJarIcon } from "./Icon";
+export { CookieJarDashboard } from "./Dashboard";

--- a/packages/client/src/components/UI/TopNav/TopNav.tsx
+++ b/packages/client/src/components/UI/TopNav/TopNav.tsx
@@ -5,6 +5,7 @@ import { useOffline } from "@/hooks";
 import { cn } from "@/utils/cn";
 import { GardenNotifications } from "@/views/Home/Garden/Notifications";
 import { Button } from "../Button";
+import { CookieJarIcon } from "@/components/UI/CookieJar";
 
 type TopNavProps = {
   onBackClick?: (e: React.SyntheticEvent<HTMLButtonElement>) => void;
@@ -184,7 +185,10 @@ export const TopNav: React.FC<TopNavProps> = ({
       </div>
 
       <div className="flex grow" />
-      {garden && <NotificationCenter {...props} garden={garden} />}
+      <div className="flex items-center gap-2">
+        <CookieJarIcon />
+        {garden && <NotificationCenter {...props} garden={garden} />}
+      </div>
     </div>
   );
 };

--- a/packages/client/src/views/Home/index.tsx
+++ b/packages/client/src/views/Home/index.tsx
@@ -7,6 +7,7 @@ import { GardenCardSkeleton } from "@/components/UI/Card/GardenCardSkeleton";
 
 import { WorkDashboardIcon } from "@/components/UI/WorkDashboard/Icon";
 import { useBrowserNavigation, useNavigateToTop } from "@/hooks";
+import { CookieJarIcon } from "@/components/UI/CookieJar";
 
 const Gardens: React.FC = () => {
   const navigate = useNavigateToTop();
@@ -76,7 +77,8 @@ const Gardens: React.FC = () => {
         <>
           <div className="flex justify-between items-center w-full py-6 px-4 sm:px-6 md:px-12">
             <h4 className="font-semibold flex-1">{intl.formatMessage({ id: "app.home" })}</h4>
-            <div className="flex-shrink-0 ml-4">
+            <div className="flex-shrink-0 ml-4 flex items-center gap-2">
+              <CookieJarIcon />
               <WorkDashboardIcon />
             </div>
           </div>


### PR DESCRIPTION
Adds a barebones Web3 Cookie Jar dashboard with top-nav access to explore integration and display Celo balance.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7a945c8-3980-4ac4-92a7-3a4f6cfd2168">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7a945c8-3980-4ac4-92a7-3a4f6cfd2168">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

