### PR TITLE
Explore greenpill dnft integration and spec

### DIFF
--- a/packages/api/src/server.ts
+++ b/packages/api/src/server.ts
@@ -197,6 +197,89 @@ fastify.patch<{
   }
 );
 
+// Badges routes (basic implementation)
+fastify.get<{
+  Querystring: { wallet?: string };
+}>("/badges", async (request: FastifyRequest<{ Querystring: { wallet?: string } }>, reply) => {
+  try {
+    const { wallet } = request.query || {};
+    const chainId = Number(process.env.GREENPILL_CHAIN_ID || 84532);
+    const contract = process.env.GREENPILL_CONTRACT || null;
+
+    // Placeholder/mock badge until Atlantis integration is configured
+    const badge = {
+      key: "greenpill",
+      type: "nft",
+      title: "Greenpill",
+      state: "unknown",
+      progress: null,
+      images: {
+        small: `${process.env.PUBLIC_URL || ""}/images/avatar.png`,
+        large: `${process.env.PUBLIC_URL || ""}/images/app-mock.png`,
+      },
+      details: {
+        description: "A dynamic NFT that turns green as you earn impact.",
+        howToUrl: "https://www.atlantisp2p.com/howtogp",
+        explorerUrl: contract && wallet ? null : null,
+      },
+      chain: {
+        chainId,
+        contract,
+        tokenId: null as string | null,
+      },
+      owned: false,
+      updatedAt: new Date().toISOString(),
+    };
+
+    return reply.send({ badges: [badge] });
+  } catch (error) {
+    fastify.log.error("Badges API Error:", error);
+    return reply.status(500).send({ error: "Internal server error" });
+  }
+});
+
+fastify.get<{
+  Querystring: { wallet?: string };
+}>(
+  "/badges/greenpill",
+  async (request: FastifyRequest<{ Querystring: { wallet?: string } }>, reply) => {
+    try {
+      const { wallet } = request.query || {};
+      const chainId = Number(process.env.GREENPILL_CHAIN_ID || 84532);
+      const contract = process.env.GREENPILL_CONTRACT || null;
+
+      const badge = {
+        key: "greenpill",
+        type: "nft",
+        title: "Greenpill",
+        state: "unknown",
+        progress: null,
+        images: {
+          small: `${process.env.PUBLIC_URL || ""}/images/avatar.png`,
+          large: `${process.env.PUBLIC_URL || ""}/images/app-mock.png`,
+        },
+        details: {
+          description: "A dynamic NFT that turns green as you earn impact.",
+          howToUrl: "https://www.atlantisp2p.com/howtogp",
+          explorerUrl: contract && wallet ? null : null,
+        },
+        chain: {
+          chainId,
+          contract,
+          tokenId: null as string | null,
+        },
+        owned: false,
+        updatedAt: new Date().toISOString(),
+      };
+
+      return reply.send(badge);
+    } catch (error) {
+      fastify.log.error("Greenpill badge API Error:", error);
+      return reply.status(500).send({ error: "Internal server error" });
+    }
+  }
+);
+
 // Health check
 fastify.get("/health", async (request: FastifyRequest, reply: FastifyReply) => {
   return reply.send({
@@ -218,6 +301,8 @@ fastify.get("/", async (request: FastifyRequest, reply: FastifyReply) => {
       users: "/api/users",
       subscribe: "/api/subscribe",
       updateUser: "/api/users/me",
+      badges: "/api/badges",
+      greenpill: "/api/badges/greenpill",
     },
   });
 });
@@ -244,6 +329,8 @@ const start = async () => {
     fastify.log.info(`📊 Health check: http://localhost:${PORT}/api/health`);
     fastify.log.info(`👥 Users endpoint: http://localhost:${PORT}/api/users`);
     fastify.log.info(`📧 Subscribe endpoint: http://localhost:${PORT}/api/subscribe`);
+    fastify.log.info(`🏅 Badges endpoint: http://localhost:${PORT}/api/badges`);
+    fastify.log.info(`🟢 Greenpill endpoint: http://localhost:${PORT}/api/badges/greenpill`);
     fastify.log.info(`🌍 Environment: ${process.env.NODE_ENV || "development"}`);
   } catch (err) {
     fastify.log.error(err);

--- a/packages/client/src/App.tsx
+++ b/packages/client/src/App.tsx
@@ -6,12 +6,15 @@ import { AppErrorBoundary } from "@/components/UI/ErrorBoundary/AppErrorBoundary
 import { queryClient } from "@/modules/react-query";
 import "@/modules/service-worker"; // Initialize service worker
 import { router } from "@/router";
+import { BadgesProvider } from "@/providers/badges";
 
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <AppErrorBoundary>
-        <RouterProvider router={router} />
+        <BadgesProvider>
+          <RouterProvider router={router} />
+        </BadgesProvider>
       </AppErrorBoundary>
     </QueryClientProvider>
   );

--- a/packages/client/src/components/UI/Badge/GreenpillBadgeCard.tsx
+++ b/packages/client/src/components/UI/Badge/GreenpillBadgeCard.tsx
@@ -1,0 +1,78 @@
+import { RiExternalLinkLine, RiLeafFill, RiSparklingLine } from "@remixicon/react";
+import React from "react";
+import { Card } from "@/components/UI/Card/Card";
+import { Badge as UIBadge } from "@/components/UI/Badge/Badge";
+import { Button } from "@/components/UI/Button";
+import type { Badge } from "@/modules/badges";
+
+export const GreenpillBadgeCard: React.FC<{
+  badge?: Badge;
+  onMint?: () => void;
+}> = ({ badge, onMint }) => {
+  const state = badge?.state ?? "unknown";
+  const owned = Boolean(badge?.owned);
+
+  const stateLabel = state === "green" ? "Green" : state === "red" ? "Red" : state;
+  const image = badge?.images?.large || "/images/app-mock.png";
+
+  return (
+    <Card className="flex flex-col gap-3 p-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <UIBadge
+            variant="pill"
+            tint={state === "green" ? "tertiary" : state === "red" ? "destructive" : "muted"}
+          >
+            {stateLabel}
+          </UIBadge>
+          <h6 className="font-semibold">Greenpill</h6>
+        </div>
+        {owned && <RiLeafFill className="w-4 text-emerald-600" />}
+      </div>
+
+      <div className="rounded-xl overflow-hidden bg-slate-50 w-full aspect-[16/9]">
+        <img src={image} alt="Greenpill badge" className="w-full h-full object-cover" />
+      </div>
+
+      {badge?.progress && (
+        <div className="flex flex-col gap-1">
+          <div className="flex justify-between text-xs text-slate-600">
+            <span>Impact</span>
+            <span>
+              {badge.progress.current} / {badge.progress.target} {badge.progress.unit}
+            </span>
+          </div>
+          <div className="w-full h-2 bg-slate-200 rounded-full overflow-hidden">
+            <div
+              className="h-full bg-emerald-500"
+              style={{
+                width: `${Math.min(100, Math.round((badge.progress.current / badge.progress.target) * 100))}%`,
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        {!owned && (
+          <Button
+            size="small"
+            onClick={onMint}
+            leadingIcon={<RiSparklingLine className="w-4" />}
+            label="Mint Greenpill"
+          />
+        )}
+        {badge?.details?.howToUrl && (
+          <a href={badge.details.howToUrl} target="_blank" rel="noreferrer">
+            <Button
+              mode="ghost"
+              size="small"
+              leadingIcon={<RiExternalLinkLine className="w-4" />}
+              label="How to earn IPs"
+            />
+          </a>
+        )}
+      </div>
+    </Card>
+  );
+};

--- a/packages/client/src/i18n/en.json
+++ b/packages/client/src/i18n/en.json
@@ -175,6 +175,7 @@
   "app.profile.storage.duration.7days": "7 days",
   "app.profile.storage.duration.30days": "30 days",
   "app.profile.storage.duration.90days": "90 days",
+  "app.profile.badges": "Badges",
   "app.settings.language": "Language",
   "app.settings.selectLanguage": "Select your desired language",
   "app.title": "Welcome to the App",

--- a/packages/client/src/i18n/es.json
+++ b/packages/client/src/i18n/es.json
@@ -178,6 +178,7 @@
   "app.profile.storage.duration.7days": "7 días",
   "app.profile.storage.duration.30days": "30 días",
   "app.profile.storage.duration.90days": "90 días",
+  "app.profile.badges": "Insignias",
   "app.settings.language": "Idioma",
   "app.settings.selectLanguage": "Selecciona tu idioma deseado",
   "app.title": "Bienvenido a la App",

--- a/packages/client/src/i18n/pt.json
+++ b/packages/client/src/i18n/pt.json
@@ -178,6 +178,7 @@
   "app.profile.storage.duration.7days": "7 dias",
   "app.profile.storage.duration.30days": "30 dias",
   "app.profile.storage.duration.90days": "90 dias",
+  "app.profile.badges": "Insígnias",
   "app.settings.language": "Idioma",
   "app.settings.selectLanguage": "Selecione seu idioma desejado",
   "app.title": "Bem-vindo ao App",

--- a/packages/client/src/modules/badges.ts
+++ b/packages/client/src/modules/badges.ts
@@ -1,0 +1,38 @@
+export type Badge = {
+  key: string;
+  type: "nft" | "achievement" | string;
+  title: string;
+  state: "red" | "orange" | "green" | "unknown" | string;
+  progress: { current: number; target: number; unit: string } | null;
+  images: { small?: string; large?: string };
+  details: { description?: string; howToUrl?: string; explorerUrl?: string | null };
+  chain?: { chainId?: number; contract?: string | null; tokenId?: string | null };
+  owned: boolean;
+  updatedAt: string;
+};
+
+function getApiBase() {
+  return import.meta.env.DEV ? "http://localhost:3000" : "https://api.greengoods.app";
+}
+
+export async function fetchBadges(wallet?: string): Promise<Badge[]> {
+  const base = getApiBase();
+  const url = new URL(`${base}/badges`);
+  if (wallet) url.searchParams.set("wallet", wallet);
+  const res = await fetch(url.toString(), { credentials: "include" });
+  if (!res.ok) return [];
+  const json = (await res.json()) as { badges?: Badge[] } | Badge[];
+  // Support both envelope and raw array
+  const list = Array.isArray(json) ? (json as Badge[]) : json.badges || [];
+  return list;
+}
+
+export async function fetchGreenpillBadge(wallet?: string): Promise<Badge | null> {
+  const base = getApiBase();
+  const url = new URL(`${base}/badges/greenpill`);
+  if (wallet) url.searchParams.set("wallet", wallet);
+  const res = await fetch(url.toString(), { credentials: "include" });
+  if (!res.ok) return null;
+  const badge = (await res.json()) as Badge;
+  return badge;
+}

--- a/packages/client/src/providers/badges.tsx
+++ b/packages/client/src/providers/badges.tsx
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import React, { useContext, useMemo } from "react";
+import { fetchBadges, type Badge } from "@/modules/badges";
+import { useUser } from "@/providers/user";
+
+interface BadgesContextValue {
+  badges: Badge[];
+  isLoading: boolean;
+  error?: unknown;
+  refetch: () => void;
+  greenpill: Badge | undefined;
+}
+
+const BadgesContext = React.createContext<BadgesContextValue>({
+  badges: [],
+  isLoading: false,
+  refetch: () => {},
+  greenpill: undefined,
+});
+
+export const useBadges = () => useContext(BadgesContext);
+
+export const BadgesProvider = ({ children }: { children: React.ReactNode }) => {
+  const { smartAccountAddress } = useUser();
+  const {
+    data: badges,
+    isLoading,
+    error,
+    refetch,
+  } = useQuery<Badge[]>({
+    queryKey: ["badges", smartAccountAddress],
+    queryFn: () => fetchBadges(smartAccountAddress || undefined),
+    staleTime: 60_000,
+    gcTime: 5 * 60_000,
+    enabled: true,
+  });
+
+  const greenpill = useMemo(() => (badges || []).find((b) => b.key === "greenpill"), [badges]);
+
+  return (
+    <BadgesContext.Provider
+      value={{
+        badges: badges || [],
+        isLoading,
+        error,
+        refetch: () => {
+          void refetch();
+        },
+        greenpill,
+      }}
+    >
+      {children}
+    </BadgesContext.Provider>
+  );
+};

--- a/packages/client/src/views/Profile/Badges.tsx
+++ b/packages/client/src/views/Profile/Badges.tsx
@@ -1,0 +1,27 @@
+import { RiMedal2Line } from "@remixicon/react";
+import React from "react";
+import { GreenpillBadgeCard } from "@/components/UI/Badge/GreenpillBadgeCard";
+import { useBadges } from "@/providers/badges";
+
+export const ProfileBadges: React.FC = () => {
+  const { greenpill, isLoading } = useBadges();
+
+  function handleMint() {
+    window.open("https://www.atlantisp2p.com/greenpillnft", "_blank");
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <h6 className="flex items-center gap-2">
+        <RiMedal2Line className="w-4" /> Badges
+      </h6>
+      {isLoading ? (
+        <div className="text-sm text-slate-600">Loading...</div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3">
+          <GreenpillBadgeCard badge={greenpill} onMint={handleMint} />
+        </div>
+      )}
+    </div>
+  );
+};

--- a/packages/client/src/views/Profile/index.tsx
+++ b/packages/client/src/views/Profile/index.tsx
@@ -1,4 +1,4 @@
-import { RiHeadphoneLine, RiSettings2Fill } from "@remixicon/react";
+import { RiHeadphoneLine, RiMedal2Line, RiSettings2Fill } from "@remixicon/react";
 import { useState } from "react";
 import { useIntl } from "react-intl";
 import { Profile as UserProfile } from "@/components/UI/Profile/Profile";
@@ -7,6 +7,7 @@ import { useUser } from "@/providers/user";
 import { formatAddress } from "@/utils/text";
 import { ProfileAccount } from "./Account";
 import { ProfileHelp } from "./Help";
+import { ProfileBadges } from "./Badges";
 
 const Profile: React.FC = () => {
   const { user, smartAccountAddress } = useUser();
@@ -21,6 +22,14 @@ const Profile: React.FC = () => {
         description: "Account",
       }),
       icon: <RiSettings2Fill className="w-4" />,
+    },
+    {
+      id: "badges",
+      label: intl.formatMessage({
+        id: "app.profile.badges",
+        description: "Badges",
+      }),
+      icon: <RiMedal2Line className="w-4" />,
     },
     {
       id: "help",
@@ -38,6 +47,8 @@ const Profile: React.FC = () => {
         return <ProfileAccount />;
       case "help":
         return <ProfileHelp />;
+      case "badges":
+        return <ProfileBadges />;
       default:
         return <ProfileAccount />;
     }


### PR DESCRIPTION
Implements a basic Greenpill dNFT badge integration with a new profile tab.

This PR sets up the necessary frontend and backend infrastructure for displaying Greenpill dNFTs as badges on user profiles, including new API endpoints, client-side data fetching, and a dedicated 'Badges' tab. The badge data is currently mocked, awaiting final contract and API details from Atlantis.

---
<a href="https://cursor.com/background-agent?bcId=bc-34475cf3-d24c-4d7f-ab41-17357253780f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-34475cf3-d24c-4d7f-ab41-17357253780f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

