### PR TITLE
Root garden join bug fix

### DIFF
--- a/packages/shared/src/hooks/garden/useAutoJoinRootGarden.ts
+++ b/packages/shared/src/hooks/garden/useAutoJoinRootGarden.ts
@@ -22,6 +22,7 @@ import { simulateJoinGarden } from "../../utils/contract/simulation";
 import { isAlreadyGardenerError } from "../../utils/errors/contract-errors";
 import { useUser } from "../auth/useUser";
 import { useGardens } from "../blockchain/useBaseLists";
+import { addPendingJoin } from "./useJoinGarden";
 import { queryInvalidation, queryKeys } from "../query-keys";
 
 const ROOT_GARDEN_PROMPTED_KEY = "rootGardenPrompted";
@@ -263,6 +264,9 @@ export function useAutoJoinRootGarden(autoJoin = false) {
       try {
         await executeJoin(gardenId, sessionOverride);
 
+        // Store pending join for immediate UI feedback (before indexer processes event)
+        addPendingJoin(gardenId, targetAddress);
+
         // Set appropriate localStorage flags
         localStorage.setItem(ROOT_GARDEN_PROMPTED_KEY, "true");
         const onboardKey = getOnboardedKey(targetAddress);
@@ -312,6 +316,9 @@ export function useAutoJoinRootGarden(autoJoin = false) {
       } catch (error) {
         // Special handling for AlreadyGardener error - not actually an error
         if (isAlreadyGardenerError(error)) {
+          // Store pending join for immediate UI feedback
+          addPendingJoin(gardenId, targetAddress);
+
           localStorage.setItem(ROOT_GARDEN_PROMPTED_KEY, "true");
           const onboardKey = getOnboardedKey(targetAddress);
           localStorage.setItem(onboardKey, "true");

--- a/packages/shared/src/hooks/garden/useJoinGarden.ts
+++ b/packages/shared/src/hooks/garden/useJoinGarden.ts
@@ -52,7 +52,12 @@ function getPendingJoins(): Record<string, { address: string; timestamp: number 
   }
 }
 
-function addPendingJoin(gardenId: string, userAddress: string) {
+/**
+ * Store a pending join for immediate UI feedback.
+ * Used when joining a garden but before the indexer has processed the event.
+ * Exported for use by useAutoJoinRootGarden hook.
+ */
+export function addPendingJoin(gardenId: string, userAddress: string) {
   if (typeof window === "undefined") return;
   const pending = getPendingJoins();
   pending[gardenId] = { address: userAddress, timestamp: Date.now() };

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -60,6 +60,7 @@ export type { GardenPermissions } from "./garden/useGardenPermissions";
 export { useGardenPermissions } from "./garden/useGardenPermissions";
 export { GardenTab, useGardenTabs } from "./garden/useGardenTabs";
 export {
+  addPendingJoin,
   checkGardenOpenJoining,
   isGardenMember,
   useJoinGarden,


### PR DESCRIPTION
Add `addPendingJoin` calls to `useAutoJoinRootGarden` to provide immediate UI feedback after joining the root garden.

Previously, `useAutoJoinRootGarden` did not call `addPendingJoin()`, causing `isGardenMember()` to return `false` until the indexer processed the blockchain event. This resulted in the UI incorrectly showing the user as not a member of the root garden for several seconds after joining.

---
<a href="https://cursor.com/background-agent?bcId=bc-94e2b5ec-0599-4df3-9e32-732236362654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94e2b5ec-0599-4df3-9e32-732236362654"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

