### PR TITLE
docs: refresh contracts references, specs, and agent guidance

### DIFF
--- a/.claude/agents/code-reviewer.md
+++ b/.claude/agents/code-reviewer.md
@@ -179,7 +179,7 @@ Create task summary with:
 
 ### Suggested Checks
 ```bash
-bun test
+bun run test
 bun lint
 bun build
 ```
@@ -282,18 +282,24 @@ All user-facing strings must use translation keys.
 
 ### Architectural Rules Quick Check
 
-Check every PR for these 8 rules (from `architectural-rules.md`):
+Check every PR for these 14 rules (from `architectural-rules.md`):
 
 | # | Rule | What to Look For |
 |---|------|-----------------|
 | 1 | **Timer Cleanup** | Raw `setTimeout`/`setInterval` in hooks → should use `useTimeout()` or `useDelayedInvalidation()` |
 | 2 | **Event Listeners** | `addEventListener` without cleanup → should use `useEventListener()` or `{ once: true }` |
 | 3 | **Async Mount Guards** | Async in `useEffect` without `isMounted` → should use `useAsyncEffect()` |
+| 4 | **No Empty Catches** | Empty `catch {}` blocks → should log and handle errors |
+| 5 | **Address Types** | Ethereum addresses typed as `string` → should use `Address` type |
 | 6 | **Zustand Selectors** | `(state) => state` → should select specific fields |
 | 7 | **Query Key Stability** | Object literals in query keys → should serialize or `useMemo` |
+| 8 | **Hook Boundary** | Hooks outside `packages/shared/src/hooks/` → move to shared |
+| 9 | **Contract Addresses** | Hardcoded `0x...` addresses → use deployment artifacts |
 | 10 | **Provider Values** | Inline object in `<Context.Provider value={{...}}>` → should wrap in `useMemo` |
+| 11 | **Barrel Imports** | Deep imports from `@green-goods/shared/...` → use package barrel |
 | 12 | **Console.log** | `console.log/warn/error` in production code → should use `logger` service |
 | 13 | **Provider Order** | Provider nesting differs from hierarchy → must follow Wagmi→Query→AppKit→Auth→App→JobQueue→Work |
+| 14 | **Bun Scripts** | Raw `forge build`/`forge test` usage in contracts → use `bun build`/`bun run test` |
 
 ### Package Structure
 

--- a/.claude/agents/cracked-coder.md
+++ b/.claude/agents/cracked-coder.md
@@ -236,7 +236,7 @@ Use MCP servers and CLI tools for deployment:
 
 | Target | Method | Commands |
 |--------|--------|----------|
-| Contracts | foundry MCP | `forge build`, `forge test`, `bun deploy:testnet` |
+| Contracts | foundry MCP | `bun build`, `bun run test`, `bun deploy:testnet` |
 | Apps | Vercel CLI | `vercel` (manual CLI, not MCP) |
 | Indexer | railway MCP | Deploy via Railway |
 

--- a/.claude/agents/migration.md
+++ b/.claude/agents/migration.md
@@ -135,7 +135,7 @@ bun build
 bun lint
 
 # Full workspace test
-bun test
+bun run test
 
 # Format check
 bun format --check
@@ -217,14 +217,14 @@ client: Test migration from old schema → new schema
 
 ```bash
 # Per-package validation
-bun --filter contracts build && bun --filter contracts test
+bun --filter contracts build && bun --filter contracts run test
 bun --filter indexer build
-bun --filter shared build && bun --filter shared test
-bun --filter client build && bun --filter client test
-bun --filter admin build && bun --filter admin test
+bun --filter shared build && bun --filter shared run test
+bun --filter client build && bun --filter client run test
+bun --filter admin build && bun --filter admin run test
 
 # Cross-package validation
-bun build && bun lint && bun test
+bun build && bun lint && bun run test
 ```
 
 ## Core Rules (from CLAUDE.md)

--- a/.claude/agents/triage.md
+++ b/.claude/agents/triage.md
@@ -165,10 +165,10 @@ packages/
 | Domain | Primary Skill | Secondary |
 |--------|--------------|-----------|
 | React/UI | `react` | `frontend-design`, `radix-ui` |
-| Data fetching | `tanstack-query` | `offline` |
+| Data fetching | `tanstack-query` | `data-layer` |
 | Blockchain | `web3` | `contracts` |
 | Errors | `error-handling-patterns` | `monitoring` |
-| Storage | `storage` | `offline` |
+| Storage | `data-layer` | `monitoring` |
 | State machines | `xstate` | `react` |
 | Testing | `testing` | `storybook` |
 | Build | `vite` | `performance` |

--- a/.claude/context/contracts.md
+++ b/.claude/context/contracts.md
@@ -7,7 +7,7 @@ Loaded when working in `packages/contracts/`. Extends CLAUDE.md.
 | Command | Purpose |
 |---------|---------|
 | `bun run test` | Run unit tests (skips E2E) |
-| `bun test:gas` | Tests with gas report |
+| `bun run test:gas` | Tests with gas report |
 | `bun build` | Adaptive build (~2s cached, skips test/script when unchanged) |
 | `bun build:fast` | Explicit fast (~2s cached, source contracts only) |
 | `bun build:full` | Full compilation including tests (>180s cold) |
@@ -22,17 +22,21 @@ Loaded when working in `packages/contracts/`. Extends CLAUDE.md.
 
 ```
 packages/contracts/
-├── src/               # Solidity source
-│   ├── GardenToken.sol       # ERC721 for gardens
-│   ├── GardenAccount.sol     # Garden TBA
-│   ├── GreenGoodsResolver.sol  # Central resolver
-│   ├── registries/           # Action, Gardener, Deployment
-│   ├── resolvers/            # Work, WorkApproval, Assessment
-│   └── modules/              # Octant, Unlock, Hats
-├── script/            # Deployment (TypeScript + Solidity)
-├── test/              # Foundry tests
-├── config/            # schemas.json (READ ONLY)
-└── deployments/       # Output artifacts
+├── src/
+│   ├── accounts/          # Garden token-bound account contracts
+│   ├── interfaces/        # Integration + protocol interfaces
+│   ├── lib/               # Shared Solidity libs (Karma, Hats, TBA, JsonBuilder)
+│   ├── markets/           # Marketplace adapters (e.g., Hypercert)
+│   ├── modules/           # Integrations (Hats, Karma, Octant, Gardens, CookieJar, Hypercerts)
+│   ├── registries/        # Deployment, action, ENS, power registries
+│   ├── resolvers/         # Work, approval, assessment, and yield resolvers
+│   ├── strategies/        # Yield and external strategy contracts
+│   ├── tokens/            # Garden + goods token contracts
+│   └── Schemas.sol        # EAS schema constants + helpers
+├── script/                # TypeScript deploy/upgrade orchestration
+├── test/                  # Unit, integration, E2E, fork, fuzz, upgrade tests
+├── config/                # schemas.json (READ ONLY in normal workflow)
+└── deployments/           # chainId-latest artifacts + network config
 ```
 
 ## Critical Patterns

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -319,12 +319,12 @@ test("work submission flow", () => {
 ### Commands
 
 ```bash
-bun test                    # Run all tests
-bun test --watch            # Watch mode
-bun test garden.test.ts     # Run specific file
-bun test --coverage         # With coverage
-bun test --ui               # UI mode
-bun test -t "should validate"  # Filter by name
+bun run test                # Run all tests
+bun run test --watch        # Watch mode
+bun run test -- garden.test.ts # Run specific file
+bun run test --coverage     # With coverage
+bun run test --ui           # UI mode
+bun run test -t "should validate" # Filter by name
 ```
 
 ### Coverage Requirements
@@ -338,7 +338,7 @@ bun test -t "should validate"  # Filter by name
 
 **Measuring coverage:**
 ```bash
-bun test --coverage              # Run with coverage
+bun run test --coverage          # Run with coverage
 open coverage/index.html         # View HTML report
 ```
 
@@ -365,7 +365,7 @@ Before marking work complete:
 - [ ] Edge cases and errors covered
 
 ### Validation Commands
-- [ ] Run `bun format && bun lint && bun test` — no errors/warnings
+- [ ] Run `bun format && bun lint && bun run test` — no errors/warnings
 - [ ] Package-specific: `cd packages/[pkg] && npx tsc --noEmit`
 
 ### Documentation & Communication

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,8 @@ const { user, isPasskeyUser, loginWithPasskey, loginWithWallet } = useAuth();
 
 **Shared Package Structure** (`packages/shared/src/`):
 - `components/` - Reusable UI components
-- `hooks/` - Domain-organized hooks (`app/`, `auth/`, `garden/`, `work/`, `blockchain/`)
-- `modules/` - Business logic modules
+- `hooks/` - Domain-organized hooks (`action/`, `app/`, `assessment/`, `auth/`, `blockchain/`, `conviction/`, `cookie-jar/`, `ens/`, `garden/`, `gardener/`, `hypercerts/`, `roles/`, `translation/`, `utils/`, `vault/`, `work/`, `yield/`)
+- `modules/` - Business logic modules (including `marketplace/` adapters)
 - `providers/` - React context providers
 - `stores/` - Zustand state stores
 - `types/` - TypeScript type definitions
@@ -409,24 +409,34 @@ forge script script/Deploy.s.sol --broadcast --rpc-url $RPC  # Missing env, keys
 
 ### What Gets Deployed
 
-`DeploymentBase._deployCoreContracts()` deploys the **full protocol stack** in order:
+`DeploymentBase._deployCoreContracts()` deploys and wires the **full protocol stack** (18+ addresses plus schema UIDs):
 
-1. **DeploymentRegistry** — Governance + proxy
-2. **Guardian** — Account guardian (CREATE2)
+1. **DeploymentRegistry** — Governance + deployment registry
+2. **Guardian** — Recovery guard + account safety controls
 3. **ActionRegistry** — Domain/action management (UUPS proxy)
 4. **WorkResolver** — EAS work submission resolver (ResolverStub + UUPS)
 5. **WorkApprovalResolver** — EAS work approval resolver (ResolverStub + UUPS)
 6. **AssessmentResolver** — EAS assessment resolver (ResolverStub + UUPS)
-7. **HatsModule** — Role/permission management adapter
-8. **GardenAccount** — Token-bound account (CREATE2)
-9. **AccountProxy** — TBA proxy (CREATE2)
-10. **GardenToken** — NFT + garden factory (CREATE2 + UUPS proxy)
-11. **KarmaGAPModule** — Karma GAP integration
-12. **OctantModule** — Octant vault integration
-13. **GardensModule** — Community, signal pools, power registry
-14. **YieldSplitter** — Yield distribution
+7. **HatsModule** — Role/permission adapter
+8. **GardenAccount implementation** — ERC-6551 account logic
+9. **AccountProxy** — ERC-6551 account proxy factory target
+10. **GardenToken** — Garden NFT + token-bound account mint flow
+11. **GardenerAccount logic** — Gardener smart account implementation
+12. **KarmaGAPModule** — GAP integration module
+13. **OctantFactory** — Octant integration dependency
+14. **OctantModule** — Yield vault integration module
+15. **GardensModule** — Community/signal module integration
+16. **CookieJarModule** — Cookie Jar allowance integration
+17. **YieldSplitter** — Yield distribution and payout routing
+18. **GreenGoodsENS** — ENS integration contract
+19. **UnifiedPowerRegistry** — Cross-module power registry (when enabled)
+20. **HypercertsModule** — Hypercert orchestration module
+21. **MarketplaceAdapter** — Hypercert marketplace adapter
+22. **Hypercert/market contracts** — `hypercertMinter`, `hypercertExchange`, `transferManager`, `strategyHypercertFractionOffer` (chain-dependent)
+23. **Root garden bootstrap** — root garden metadata/address + token ID (chain-dependent)
+24. **Schemas payload** — `workSchemaUID`, `workApprovalSchemaUID`, and `assessmentSchemaUID`
 
-After deployment, all modules are **wired together** (e.g., `gardenToken.setHatsModule()`, `actionRegistry.setGardenToken()`, etc.).
+Some modules may remain zero-address on a given chain until explicitly activated. Deployment artifacts still reserve all keys so downstream packages can detect availability safely.
 
 ### Deployment Artifacts
 

--- a/docs/docs/developer/contracts.md
+++ b/docs/docs/developer/contracts.md
@@ -1,193 +1,117 @@
 # Contracts Package (Solidity)
 
 > **Audience:** Smart contract engineers and protocol contributors working in `packages/contracts`.
-> **Related docs:** [Monorepo Structure](./architecture), [packages/contracts/README.md](https://github.com/greenpill-dev-guild/green-goods/tree/main/packages/contracts#readme)
-> **Networks:** Arbitrum One (42161), Celo (42220), Sepolia (11155111). Deployment data: `packages/contracts/deployments/*.json`. Updated November 2024.
-> **External references:** See [Ethereum Attestation Service docs](https://docs.attest.org/) for resolver expectations and [OpenZeppelin Upgrades guide](https://docs.openzeppelin.com/contracts/4.x/api/proxy#UUPSUpgradeable) for UUPS patterns.
+> **Related docs:** [Contracts Handbook](./contracts-handbook), [packages/contracts/README.md](https://github.com/greenpill-dev-guild/green-goods/tree/main/packages/contracts#readme)
+> **Networks:** Sepolia (11155111), Arbitrum One (42161), Celo (42220).
+> **Source of truth:** `packages/contracts/deployments/*-latest.json`.
 
-Smart contracts powering Green Goods attestations and gardens.
+Green Goods contracts power gardens, attestations, and protocol integrations.
 
 ---
 
 ## Quick Reference
 
-**Path**: `packages/contracts/`
-**Stack**: Solidity 0.8.20 + Foundry
+**Path:** `packages/contracts/`
+**Stack:** Solidity 0.8.30 + Foundry + Bun wrapper scripts
 
-**Commands**:
 ```bash
-bun --filter contracts build          # Compile
-bun --filter contracts test           # Run tests
-bun --filter contracts deploy:testnet # Deploy to Sepolia
-bun --filter contracts deploy:celo    # Deploy to Celo
+bun --filter contracts build            # Adaptive contract build
+bun --filter contracts run test         # Unit + integration tests (scripted)
+bun --filter contracts run test:e2e     # End-to-end workflow suite
+bun --filter contracts deploy:testnet   # Deploy to Sepolia
+bun --filter contracts deploy:celo      # Deploy to Celo
+bun --filter contracts deploy:arbitrum  # Deploy to Arbitrum
 ```
 
 ---
 
-## Core Contracts
+## Core Deployments (Current)
 
-### GardenToken (ERC-721)
+These addresses are taken from deployment artifacts and replace older Nov 2024 values.
 
-Gardens as NFTs with tokenbound accounts.
+| Contract | Sepolia | Arbitrum | Celo |
+|---|---|---|---|
+| `gardenToken` | `0xEcbB6E69BE882d2e4E35CCe0E6637c7e1D64c791` | `0x0a7Ca3203f25c1c028D54C19789e83b401383F92` | `0xDcA639287A392E17cad0deA4E72F5B3cfA429e6B` |
+| `actionRegistry` | `0x547e82BF9c8496f41927583793242f6b91C182A6` | `0x042D2b082Cdd4DCBc0aD9dD7c631BC2e45B05cB1` | `0x0747ED4f1915b8f3A6eA8a9d8216E8F53EE80f92` |
+| `workResolver` | `0x054814d58b3A160ca0243FFC77f2F5d62709f396` | `0x9acf5C0dEc2f8134AC8C68a41bE3eB659e8430b7` | `0x028ff0640262a1847d512B3690266d0B35d5260F` |
+| `workApprovalResolver` | `0x4708E9b199412cc2Cf4d394430BD3DF1f31F2Be5` | `0x0B1Ef706D967820784928c850EFF69E078bcb419` | `0x54b9Dd27d4eD2282D8Cd12CD55ee4B983eC9E3D6` |
+| `assessmentResolver` | `0x0000000000000000000000000000000000000000` | `0xDD3567060cEA024dF9D9950A7Af3D8e1F9dB1216` | `0xC81B11e3d199D60678D5fF962F616ab64df73554` |
 
-```solidity
-contract GardenToken is ERC721, UUPS {
-  function mintGarden(
-    address to,
-    string memory name,
-    string memory metadata,
-    address[] memory gardeners,
-    address[] memory operators
-  ) external returns (uint256 tokenId);
-}
-```
-
-**Deployment**:
-- Arbitrum: `0x3DEc3c42C5872a86Fb0e60A4AaDD7aD51CaF076a`
-- Celo: `0xDcA639287A392E17cad0deA4E72F5B3cfA429e6B`
-- Sepolia: `0x0B0EA0FfB996B0b04335507Ef1523124480f7310`
-
-### ActionRegistry
-
-Register available tasks for gardens.
-
-```solidity
-contract ActionRegistry {
-  function registerAction(
-    uint256 gardenId,
-    string memory title,
-    string memory instructions,
-    uint256 startTime,
-    uint256 endTime,
-    string[] memory capitals,
-    string[] memory media
-  ) external returns (uint256 actionUID);
-}
-```
-
-### WorkResolver
-
-Validates work submissions and creates attestations.
-
-```solidity
-contract WorkResolver is SchemaResolver {
-  function onAttest(
-    Attestation calldata attestation,
-    uint256 /*value*/
-  ) internal override returns (bool) {
-    // Validate gardener membership
-    // Emit WorkSubmitted event
-    // Return true
-  }
-}
-```
-
-### WorkApprovalResolver
-
-Validates approvals and triggers Karma GAP.
-
-```solidity
-contract WorkApprovalResolver is SchemaResolver {
-  function onAttest(
-    Attestation calldata attestation,
-    uint256 /*value*/
-  ) internal override returns (bool) {
-    // Validate operator permission
-    // Trigger Karma GAP attestation
-    // Emit WorkApproved event
-    // Return true
-  }
-}
-```
+> A zero address means “not deployed on this chain yet,” not “invalid artifact.”
 
 ---
 
-## Deployment System
+## What the Core Deployment Writes
 
-**Via `deploy.ts` wrapper**:
-```bash
-bun --filter contracts deploy:testnet    # Sepolia
-bun --filter contracts deploy:celo       # Celo mainnet
-bun --filter contracts deploy:arbitrum   # Arbitrum mainnet
-```
+`deploy.ts core` writes a broad artifact surface (18+ keys), including:
 
-**What Gets Deployed**:
-- Core contracts (deterministic CREATE2)
-- EAS schemas (work, approval, assessment)
-- Root community garden
-- Core actions (3 default)
+- Core protocol contracts: `deploymentRegistry`, `guardian`, `actionRegistry`, resolvers, `gardenToken`, `gardenAccountImpl`, `accountProxy`, `gardenerAccountLogic`
+- Integration modules: `hatsModule`, `karmaGAPModule`, `octantModule`, `gardensModule`, `cookieJarModule`, `yieldSplitter`, `hypercertsModule`, `marketplaceAdapter`
+- Ecosystem integrations: `greenGoodsENS`, `unifiedPowerRegistry`, `hypercertMinter`, `hypercertExchange`, `transferManager`, `strategyHypercertFractionOffer`
+- Bootstrap + metadata: `rootGarden`, `schemas`, `eas`, and network-specific optional addresses
+
+See `packages/contracts/deployments/{chainId}-latest.json` for complete and chain-specific values.
 
 ---
 
-## UUPS Upgrades
+## Contract Areas
 
-All contracts are upgradeable:
+- `tokens/` — Garden NFT and protocol tokens
+- `accounts/` — token-bound account logic
+- `registries/` — deployment, action, ENS, and power registries
+- `resolvers/` — EAS attestation validation (`Work`, `WorkApproval`, `Assessment`, `Yield`)
+- `modules/` — integrations (Hats, Karma, Octant, Gardens, Cookie Jar, Hypercerts)
+- `markets/` + `strategies/` — marketplace and yield strategy adapters
+
+---
+
+## Deployment and Upgrades
+
+Always use the Bun deployment wrappers (never raw `forge script ... --broadcast` for normal deploy flow).
 
 ```bash
+# Dry run (compile + planning)
+bun script/deploy.ts core --network sepolia
+
+# Full deployment
+bun script/deploy.ts core --network sepolia --broadcast
+
+# Deploy + schema metadata refresh
+bun script/deploy.ts core --network sepolia --broadcast --update-schemas
+
+# Upgrade existing contracts
 bun upgrade:testnet
 bun upgrade:celo
+bun upgrade:arbitrum
 ```
-
-**Safety**:
-- Storage gaps prevent collisions
-- Upgrade tests required
-- Multisig-gated (production)
-
-[Upgrade Guide →](./contracts-handbook)
 
 ---
 
 ## Schema Management
 
-**IMMUTABLE**: `config/schemas.json`
+`packages/contracts/config/schemas.json` is production schema config and treated as immutable during normal development.
 
-Never edit directly. Use `--update-schemas` flag for metadata changes only.
-
-**Schemas**:
-- Work Submission
-- Work Approval
-- Garden Assessment
-
----
-
-## Karma GAP Integration
-
-**GardenAccount** creates GAP attestations:
-- Project attestation (garden creation)
-- Impact attestation (work approval)
-
-**Implementation**:
-- `src/lib/Karma.sol`
-- `src/interfaces/IKarmaGap.sol`
-
-[Karma GAP Details →](./karma-gap)
+- Do not hand-edit schema field definitions in place.
+- Use deployment flags (like `--update-schemas`) for metadata refresh flow.
+- Use dedicated test files for experiments.
 
 ---
 
 ## Testing
 
 ```bash
-bun test                    # All tests
-bun test:gap                # Karma GAP tests
-forge test --gas-report     # With gas reporting
+bun --filter contracts run test
+bun --filter contracts run test:e2e
+bun --filter contracts run test:fork
+bun --filter contracts lint
 ```
-
-**Test Categories**:
-- Unit tests (individual contracts)
-- Integration tests (cross-contract)
-- Fork tests (against live networks)
-- Gas optimization tests
 
 ---
 
-## Complete Documentation
+## Related References
 
-**📖 Full details**: [packages/contracts/README.md](https://github.com/greenpill-dev-guild/green-goods/tree/main/packages/contracts#readme)
-
-**Handbooks**:
 - [Contracts Handbook](./contracts-handbook)
-- [Deployment Checklist](https://github.com/greenpill-dev-guild/green-goods/tree/main/docs/DEPLOYMENT_CHECKLIST.md)
-
-**Key Files**:
-- Patterns and conventions: `.claude/context/contracts.md`
-
+- [Karma GAP Integration](./karma-gap)
+- [Architecture diagrams](./architecture/diagrams)
+- `packages/contracts/README.md`
+- `.claude/context/contracts.md`

--- a/docs/docs/specs/cookie-jar/_category_.json
+++ b/docs/docs/specs/cookie-jar/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Cookie Jar",
+  "position": 26,
+  "link": {
+    "type": "doc",
+    "id": "cookie-jar-spec-index"
+  }
+}

--- a/docs/docs/specs/cookie-jar/feature-spec.md
+++ b/docs/docs/specs/cookie-jar/feature-spec.md
@@ -1,0 +1,15 @@
+---
+id: cookie-jar-feature-spec
+title: GG-FEAT-009 Cookie Jar
+sidebar_label: Feature Spec
+---
+
+# GG-FEAT-009 — Cookie Jar
+
+## Goal
+Allow eligible members to claim bounded recurring payouts from garden-managed Cookie Jars.
+
+## Acceptance Criteria
+- Claim eligibility and cooldown windows are enforced.
+- Claim history is visible in UI and indexer data.
+- Failed claims are surfaced with recoverable guidance.

--- a/docs/docs/specs/cookie-jar/index.md
+++ b/docs/docs/specs/cookie-jar/index.md
@@ -1,0 +1,14 @@
+---
+id: cookie-jar-spec-index
+title: Cookie Jar Specification
+sidebar_label: Cookie Jar
+sidebar_position: 1
+---
+
+# Cookie Jar Specification
+
+Allowance-based micro-disbursement integration for garden operators and contributors.
+
+## Documents
+- [Feature Spec](./feature-spec)
+- [Technical Spec](./technical-spec)

--- a/docs/docs/specs/cookie-jar/technical-spec.md
+++ b/docs/docs/specs/cookie-jar/technical-spec.md
@@ -1,0 +1,12 @@
+---
+id: cookie-jar-technical-spec
+title: GG-TECH-009 Cookie Jar
+sidebar_label: Technical Spec
+---
+
+# GG-TECH-009 — Cookie Jar
+
+## Architecture
+- `CookieJarModule` mediates approvals and claims.
+- Indexer persists `CookieJar` + yield transfer entities.
+- Shared `hooks/cookie-jar` provides read/write integration for apps.

--- a/docs/docs/specs/ens/_category_.json
+++ b/docs/docs/specs/ens/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "ENS",
+  "position": 25,
+  "link": {
+    "type": "doc",
+    "id": "ens-spec-index"
+  }
+}

--- a/docs/docs/specs/ens/feature-spec.md
+++ b/docs/docs/specs/ens/feature-spec.md
@@ -1,0 +1,15 @@
+---
+id: ens-feature-spec
+title: GG-FEAT-008 ENS Integration
+sidebar_label: Feature Spec
+---
+
+# GG-FEAT-008 — ENS Integration
+
+## Goal
+Enable stable identity for gardens/gardeners via ENS domains managed by protocol roles.
+
+## Acceptance Criteria
+- Garden and gardener records can reference ENS names.
+- UI shows registration/verification state.
+- Expired/invalid names are surfaced with actionable status.

--- a/docs/docs/specs/ens/index.md
+++ b/docs/docs/specs/ens/index.md
@@ -1,0 +1,18 @@
+---
+id: ens-spec-index
+title: ENS Specification
+sidebar_label: ENS
+sidebar_position: 1
+description: ENS integration specification for Green Goods
+---
+
+# ENS Specification
+
+- Feature scope: ENS name + subdomain lifecycle for gardeners and gardens.
+- Contracts: `registries/ENS.sol`, `registries/ENSReceiver.sol`, `interfaces/IENS.sol`.
+- Shared hooks: `packages/shared/src/hooks/ens/`.
+
+## Documents
+
+- [Feature Spec](./feature-spec)
+- [Technical Spec](./technical-spec)

--- a/docs/docs/specs/ens/technical-spec.md
+++ b/docs/docs/specs/ens/technical-spec.md
@@ -1,0 +1,16 @@
+---
+id: ens-technical-spec
+title: GG-TECH-008 ENS Integration
+sidebar_label: Technical Spec
+---
+
+# GG-TECH-008 — ENS Integration
+
+## Architecture
+- On-chain registration + ownership checks in contracts package.
+- Indexed ENS registration events persisted by indexer.
+- Shared hooks expose status and claim flows.
+
+## Testing
+- Contract unit tests for registration constraints.
+- Shared hook tests for loading/error states.

--- a/docs/docs/specs/index.md
+++ b/docs/docs/specs/index.md
@@ -41,7 +41,55 @@ Enable Garden treasuries to deposit into yield-generating vaults with yield rout
 - Priority: High
 - Estimated Effort: 8 weeks
 
+
 ---
+
+### [ENS Integration](/specs/ens)
+
+**Status:** 📋 Planned
+
+Garden and gardener ENS identity management, including registration status and operator flows.
+
+- Feature Spec: GG-FEAT-008
+- Technical Spec: GG-TECH-008
+- Priority: Medium
+
+---
+
+### [Cookie Jar](/specs/cookie-jar)
+
+**Status:** 📋 Planned
+
+Allowance-based micro-disbursement integration for member claims.
+
+- Feature Spec: GG-FEAT-009
+- Technical Spec: GG-TECH-009
+- Priority: High
+
+---
+
+### [Yield Splitting](/specs/yield-splitting)
+
+**Status:** 📋 Planned
+
+Protocol-level yield distribution routing across treasury and integration targets.
+
+- Feature Spec: GG-FEAT-010
+- Technical Spec: GG-TECH-010
+- Priority: High
+
+---
+
+### [Juicebox Routing](/specs/juicebox)
+
+**Status:** 📋 Planned
+
+Route configured yield slices into Juicebox projects with auditable payment records.
+
+- Feature Spec: GG-FEAT-011
+- Technical Spec: GG-TECH-011
+- Priority: Medium
+
 
 ### Gardens Conviction Voting
 

--- a/docs/docs/specs/juicebox/_category_.json
+++ b/docs/docs/specs/juicebox/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Juicebox",
+  "position": 28,
+  "link": {
+    "type": "doc",
+    "id": "juicebox-spec-index"
+  }
+}

--- a/docs/docs/specs/juicebox/feature-spec.md
+++ b/docs/docs/specs/juicebox/feature-spec.md
@@ -1,0 +1,15 @@
+---
+id: juicebox-feature-spec
+title: GG-FEAT-011 Juicebox Routing
+sidebar_label: Feature Spec
+---
+
+# GG-FEAT-011 — Juicebox Routing
+
+## Goal
+Support treasury/yield routing into Juicebox projects when configured by governance.
+
+## Acceptance Criteria
+- Valid project IDs and payout tokens are enforced.
+- Failed payments are tracked for retry/operations.
+- Operators can view payment status per payout cycle.

--- a/docs/docs/specs/juicebox/index.md
+++ b/docs/docs/specs/juicebox/index.md
@@ -1,0 +1,14 @@
+---
+id: juicebox-spec-index
+title: Juicebox Specification
+sidebar_label: Juicebox
+sidebar_position: 1
+---
+
+# Juicebox Specification
+
+Integration spec for routing yield into Juicebox project payments.
+
+## Documents
+- [Feature Spec](./feature-spec)
+- [Technical Spec](./technical-spec)

--- a/docs/docs/specs/juicebox/technical-spec.md
+++ b/docs/docs/specs/juicebox/technical-spec.md
@@ -1,0 +1,12 @@
+---
+id: juicebox-technical-spec
+title: GG-TECH-011 Juicebox Routing
+sidebar_label: Technical Spec
+---
+
+# GG-TECH-011 — Juicebox Routing
+
+## Architecture
+- Strategy and module contracts call Juicebox payment terminals.
+- Indexer persists `YieldJuiceboxPayment` entities.
+- Shared yield hooks expose payment state in admin/client views.

--- a/docs/docs/specs/yield-splitting/_category_.json
+++ b/docs/docs/specs/yield-splitting/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Yield Splitting",
+  "position": 27,
+  "link": {
+    "type": "doc",
+    "id": "yield-splitting-spec-index"
+  }
+}

--- a/docs/docs/specs/yield-splitting/feature-spec.md
+++ b/docs/docs/specs/yield-splitting/feature-spec.md
@@ -1,0 +1,15 @@
+---
+id: yield-splitting-feature-spec
+title: GG-FEAT-010 Yield Splitting
+sidebar_label: Feature Spec
+---
+
+# GG-FEAT-010 — Yield Splitting
+
+## Goal
+Distribute accrued yield across configured destinations (treasury, cookie jar, juicebox, purchases).
+
+## Acceptance Criteria
+- Split percentages are validated and sum correctly.
+- Distribution decisions are auditable in events/entities.
+- Low-yield accumulation behavior is explicit in UX.

--- a/docs/docs/specs/yield-splitting/index.md
+++ b/docs/docs/specs/yield-splitting/index.md
@@ -1,0 +1,14 @@
+---
+id: yield-splitting-spec-index
+title: Yield Splitting Specification
+sidebar_label: Yield Splitting
+sidebar_position: 1
+---
+
+# Yield Splitting Specification
+
+Rules and payout routing for protocol yield distribution.
+
+## Documents
+- [Feature Spec](./feature-spec)
+- [Technical Spec](./technical-spec)

--- a/docs/docs/specs/yield-splitting/technical-spec.md
+++ b/docs/docs/specs/yield-splitting/technical-spec.md
@@ -1,0 +1,12 @@
+---
+id: yield-splitting-technical-spec
+title: GG-TECH-010 Yield Splitting
+sidebar_label: Technical Spec
+---
+
+# GG-TECH-010 — Yield Splitting
+
+## Architecture
+- `YieldSplitter` calculates destination amounts.
+- `resolvers/Yield.sol` records protocol-level yield attestations.
+- Indexer entities capture allocations, transfers, and stranded yield states.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -104,14 +104,14 @@ Test against real network state without spending gas:
 
 ```bash
 # Run E2E tests against forked networks
-bun test:e2e:celo       # Fork and test Celo mainnet
-bun test:e2e:arbitrum   # Fork and test Arbitrum mainnet
+bun run test:e2e:celo       # Fork and test Celo mainnet
+bun run test:e2e:arbitrum   # Fork and test Arbitrum mainnet
 
 # Or manually fork with Anvil
 anvil --fork-url $CELO_RPC_URL
 
 # Then run tests on fork
-forge test --fork-url http://localhost:8545 -vv
+bun run test:e2e:celo    # or bun run test:e2e:arbitrum / :sepolia
 ```
 
 **Use when:** Testing upgrades, validating against real state, debugging production issues
@@ -170,9 +170,9 @@ bun upgrade:celo        # Upgrade Celo mainnet
 bun upgrade:arbitrum    # Upgrade Arbitrum mainnet
 
 # 🧪 TESTING
-bun test                # Run all tests
-bun test:e2e:celo       # Fork and test Celo mainnet
-bun test:e2e:arbitrum   # Fork and test Arbitrum mainnet
+bun run test                # Run all tests
+bun run test:e2e:celo       # Fork and test Celo mainnet
+bun run test:e2e:arbitrum   # Fork and test Arbitrum mainnet
 
 # 🔧 DEVELOPMENT
 bun build               # Compile contracts
@@ -205,10 +205,10 @@ bun script/deploy.ts core --network sepolia --broadcast --force
 ---
 
 **📖 For detailed documentation, see:**
-- Full Deployment Guide: [docs/DEPLOYMENT.md](./docs/DEPLOYMENT.md)
-- Upgrade Guide: [docs/UPGRADES.md](./docs/UPGRADES.md)
-- Environment Setup: [docs/ENVIRONMENT_SETUP.md](./docs/ENVIRONMENT_SETUP.md)
-- Troubleshooting: [docs/TROUBLESHOOTING.md](./docs/TROUBLESHOOTING.md)
+- Full Deployment Guide: [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook)
+- Upgrade Guide: [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook)
+- Environment Setup: [Developer Quickstart](https://docs.greengoods.app/welcome/quickstart-developer)
+- Troubleshooting: [Developer Quickstart](https://docs.greengoods.app/welcome/quickstart-developer)
 
 ## Deployment System
 
@@ -291,21 +291,21 @@ Green Goods integrates with the **Karma Grantee Accountability Protocol (GAP)** 
 - Identity-first security - all resolvers verify roles before any logic
 
 **Documentation:**
-- User Guide: [docs/KARMA_GAP.md](../../docs/KARMA_GAP.md)
-- Implementation: [docs/KARMA_GAP_IMPLEMENTATION.md](../../docs/KARMA_GAP_IMPLEMENTATION.md)
-- Upgrade Guide: [docs/UPGRADES.md](../../docs/UPGRADES.md)
+- User Guide: [Karma GAP Integration](https://docs.greengoods.app/developer/karma-gap)
+- Implementation: [Karma GAP Integration](https://docs.greengoods.app/developer/karma-gap)
+- Upgrade Guide: [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook)
 - KarmaLib Source: `src/lib/Karma.sol`
 - Interfaces: `src/interfaces/IKarmaGap.sol`
 
 **Testing:**
 ```bash
 # Run E2E tests (includes GAP integration)
-bun test:e2e
+bun run test:e2e
 
 # Test specific networks
-bun test:e2e:arbitrum   # Fork Arbitrum
-bun test:e2e:celo       # Fork Celo
-bun test:e2e:testnet    # Fork Sepolia
+bun run test:e2e:arbitrum   # Fork Arbitrum
+bun run test:e2e:celo       # Fork Celo
+bun run test:e2e:testnet    # Fork Sepolia
 ```
 
 ### Schema Evolution
@@ -326,7 +326,7 @@ bun script/deploy.ts core --network sepolia --broadcast --update-schemas
 bun script/deploy.ts core --network sepolia --broadcast --force
 ```
 
-See `docs/UPGRADES.md` for detailed schema versioning strategy and `docs/DEPLOYMENT.md` for schema deployment troubleshooting.
+See the [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook) for schema versioning strategy and deployment troubleshooting.
 
 ## Configuration
 
@@ -451,7 +451,7 @@ forge script script/Upgrade.s.sol:Upgrade \
   --network arbitrum --broadcast
 ```
 
-See `docs/UPGRADES.md` for complete upgrade guide.
+See the [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook) for the complete upgrade guide.
 
 ### When to Deploy vs Upgrade
 
@@ -467,7 +467,7 @@ See `docs/UPGRADES.md` for complete upgrade guide.
 
 ### Documentation
 
-See [UPGRADES.md](docs/UPGRADES.md) for complete upgrade guide including:
+See the [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook) for the complete upgrade guide including:
 - Deploy vs Upgrade decision matrix
 - Storage gap usage
 - Multisig upgrade process
@@ -507,7 +507,7 @@ bun install
 bun build
 
 # Run comprehensive test suite
-bun test
+bun run test
 
 # Format Solidity code
 bun format
@@ -525,16 +525,16 @@ bun dev
 bun compile
 
 # Run tests with gas reporting
-bun test
+bun run test
 
 # Run specific test contract
-forge test --match-contract YourTestContract -vv
+bun run test:match test/unit/YourTestContract.t.sol
 
 # Run specific test function
-forge test --match-test testYourFunction -vvv
+bun run test:match test/unit/YourTestContract.t.sol
 
 # Watch mode for continuous testing
-forge test --watch
+bun run test --watch
 ```
 
 **Local Development:**
@@ -614,17 +614,17 @@ Networks are configured in `deployments/networks.json`. The system automatically
 **Advanced Testing:**
 ```bash
 # Fork testing against live networks
-bun test:e2e:celo       # Automated fork test
+bun run test:e2e:celo       # Automated fork test
 # Or manually: anvil --fork-url $CELO_RPC_URL
 
 # Gas profiling
-forge test --gas-report
+bun run test:gas
 
 # Coverage analysis
 forge coverage
 
 # Invariant testing
-forge test --match-contract InvariantTest
+bun run test:match test/invariant/InvariantTest.t.sol
 ```
 
 **Test Best Practices:**
@@ -711,7 +711,7 @@ bun envio:cleanup
 - Use events instead of storage for non-critical data
 - Consider CREATE2 for deterministic addresses
 - Batch operations when possible
-- Use `forge test --gas-report` to profile gas usage
+- Use `bun run test:gas` to profile gas usage
 
 ### Troubleshooting
 
@@ -744,10 +744,10 @@ cast balance $DEPLOYER_ADDRESS --rpc-url $CELO_RPC_URL
 **Test Failures:**
 ```bash
 # Run with maximum verbosity
-forge test -vvvv
+bun run test
 
 # Debug specific test
-forge test --match-test testYourFunction --debug
+bun run test:match test/unit/YourTestContract.t.sol
 
 # Check coverage
 forge coverage --report lcov
@@ -759,7 +759,7 @@ forge coverage --report lcov
 forge create src/YourContract.sol:YourContract --estimate
 
 # Profile gas usage
-forge test --gas-report
+bun run test:gas
 
 # Check gas limit
 cast block latest --field gasLimit --rpc-url $CELO_RPC_URL

--- a/packages/indexer/README.md
+++ b/packages/indexer/README.md
@@ -130,9 +130,12 @@ The root `.env` is automatically loaded by the indexer's Docker Compose setup an
 
 ### Entities (from `schema.graphql`)
 
-- Gardens and Actions
-- Work Submissions and Approvals
-- EAS Attestations
+- Gardens and Actions (`Garden`, `Action`, `Gardener`)
+- Garden governance (`GardenCommunity`, `GardenSignalPool`, `GardenHatTree`, `PartialGrantFailure`)
+- Vaults and yield accounting (`GardenVault`, `GardenVaultIndex`, `VaultDeposit`, `VaultEvent`, `VaultAddressIndex`)
+- Yield distribution outputs (`YieldAllocation`, `YieldAccumulation`, `YieldFractionPurchase`, `YieldCookieJarTransfer`, `YieldJuiceboxPayment`, `YieldStranded`)
+- Hypercert ecosystem (`Hypercert`, `HypercertClaim`, `GoodsAirdrop`, `GardenTreasury`)
+- Integrations (`CookieJar`, `ENSRegistration`, `GardenDomains`)
 
 ### Client Configuration
 

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -57,14 +57,19 @@ src/
 │   ├── app/         # App-level hooks (offline, toast, theme)
 │   ├── assessment/  # Assessment workflows
 │   ├── auth/        # Authentication (useAuth, useUser)
-│   ├── blockchain/  # Chain config, ENS, deployment registry
+│   ├── blockchain/  # Chain config, wagmi clients, deployment registry
+│   ├── conviction/  # Conviction voting and signaling hooks
+│   ├── cookie-jar/  # Cookie Jar allowance and claims
+│   ├── ens/         # ENS registration and domain status
 │   ├── garden/      # Garden operations, permissions, invites
 │   ├── gardener/    # Role, profile hooks
+│   ├── hypercerts/  # Hypercert minting, claiming, marketplace data
 │   ├── roles/       # Role management hooks
 │   ├── translation/ # i18n hooks
-│   ├── ui/          # UI utilities
 │   ├── utils/       # Utility hooks (useEventListener, useTimeout, useAsyncEffect)
-│   └── work/        # Work submission, approval, mutations
+│   ├── vault/       # Vault balances, deposits, and yield metrics
+│   ├── work/        # Work submission, approval, mutations
+│   └── yield/       # Yield splitting + payout views
 ├── modules/         # Core business logic
 │   ├── app/         # Analytics (posthog), service worker
 │   ├── auth/        # Passkey session management
@@ -150,10 +155,10 @@ bun format
 bun lint
 
 # Run tests
-bun test
+bun run test
 
 # Run specific test
-bun test job-queue
+bun run test -- job-queue
 ```
 
 ## Storybook


### PR DESCRIPTION
### Motivation

- Replace stale contracts/deployment documentation and Nov‑2024 addresses with current artifacts and the canonical `deployments/*-latest.json` surface.  
- Standardize test/deploy guidance to use the Bun wrapper scripts (`bun run test`, `bun build`, `bun deploy:*`) and remove direct `forge`/`forge test`/`forge build` recommendations.  
- Surface missing feature/technical specs (ENS, Cookie Jar, Yield Splitting, Juicebox) and align agent/skill docs to current package structure and data-layer approach.  
- Harden agent guidance and quick-check rules (code-reviewer, migration, cracked-coder, triage, testing skill) to match repository conventions and avoid outdated commands.

### Description

- Rewrote `docs/docs/developer/contracts.md` to reflect current stack, network addresses, artifact keys, and Bun wrapper commands, and expanded the documented deployment artifact surface (18+ keys + schema UIDs) from the older list.  
- Updated `CLAUDE.md` shared package structure to include `conviction/`, `ens/`, `cookie-jar/`, `hypercerts/`, `vault/`, `yield/` and expanded the “What Gets Deployed” inventory to match `DeploymentBase._deployCoreContracts()` and `packages/contracts/deployments/*-latest.json`.  
- Replaced `bun test` examples with `bun run test` in testing docs and scripts (`.claude/skills/testing/SKILL.md`, `.claude/agents/migration.md`, `packages/*/README.md`) and removed `forge build` from cracked‑coder deployment guidance.  
- Added four new spec modules with feature + technical spec skeletons and sidebar entries: `docs/docs/specs/ens/`, `docs/docs/specs/cookie-jar/`, `docs/docs/specs/yield-splitting/`, `docs/docs/specs/juicebox/`, and linked them from the specs index.  
- Adjusted agent/skill guidance: changed triage mapping from `storage`/`offline` → `data-layer`, broadened the code-reviewer architectural quick-check (added rules 4,5,8,9,11,14), and updated `.claude/context/contracts.md` to the current contracts tree and `bun run test:*` variants.  
- Updated package READMEs: `packages/contracts/README.md`, `packages/shared/README.md`, and `packages/indexer/README.md` to reflect the above changes (commands, hook directories, indexer entity list).

### Testing

- Ran automated textual/structural checks to validate replacements and new content: `rg` searches for command and keyword replacements (verified `bun run test`, `data-layer`, new spec IDs, and code-reviewer rule additions) and `jq` to inspect `packages/contracts/deployments/*-latest.json` keys. These pattern checks succeeded.  
- Performed whitespace/format checks (`git diff --check`) and repo formatting hooks (biome) as part of the commit pipeline; formatting hooks ran and returned clean results.  
- Attempted a doc build with `bun --filter docs run build` which failed because no `docs` package exists in the workspace (expected for docs-only edits); this had no impact on the repo changes.  
- No runtime or unit code was modified; no package unit test suites were run as part of this docs-only PR beyond the textual validations above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69940caac5688331890f956b2094e6ca)