### PR TITLE
Refactor HypercertWizard beforeunload handling and extract hypercert distribution hooks

### DIFF
--- a/packages/admin/src/components/hypercerts/HypercertWizard.tsx
+++ b/packages/admin/src/components/hypercerts/HypercertWizard.tsx
@@ -5,8 +5,6 @@ import {
   ErrorBoundary,
   logger,
   TOTAL_UNITS,
-  buildContributorWeights,
-  calculateDistribution,
   formatHypercertMetadata,
   getSDGLabel,
   prefillMetadataFromAssessment,
@@ -15,9 +13,12 @@ import {
   useHypercertAttestations,
   useAuth,
   useCreateHypercertWorkflow,
+  useHypercertAllowlist,
   useHypercertDraft,
   useHypercerts,
+  useHypercertContributorWeights,
   useMintHypercert,
+  useWindowEvent,
   useGardenAssessments,
   useHypercertWizardStore,
   type HypercertAttestation,
@@ -151,18 +152,12 @@ export function HypercertWizard({
   );
 
   // Handle browser refresh/close with beforeunload
-  useEffect(() => {
+  useWindowEvent("beforeunload", (event) => {
     if (!hasUnsavedChanges) return;
-
-    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
-      event.preventDefault();
-      // Modern browsers ignore custom messages, but this triggers the dialog
-      event.returnValue = "";
-    };
-
-    window.addEventListener("beforeunload", handleBeforeUnload);
-    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
-  }, [hasUnsavedChanges]);
+    event.preventDefault();
+    // Modern browsers ignore custom messages, but this triggers the dialog
+    event.returnValue = "";
+  });
 
   // Handle blocker state - show confirmation dialog
   useEffect(() => {
@@ -241,29 +236,15 @@ export function HypercertWizard({
     }
   }, [bundledAttestations, selectedAttestationIds, setSelectedAttestations]);
 
-  const contributorWeights = useMemo(
-    () => buildContributorWeights(selectedAttestations),
-    [selectedAttestations]
-  );
+  const contributorWeights = useHypercertContributorWeights(selectedAttestations);
 
-  useEffect(() => {
-    if (!selectedAttestations.length) return;
-    if (distributionMode === "custom" && allowlist.length > 0) return;
-
-    const mode = distributionMode === "proportional" ? "count" : distributionMode;
-    const nextAllowlist = calculateDistribution(contributorWeights, mode, allowlist);
-
-    // Deep compare to avoid infinite loop - only update if contents differ
-    const isDifferent =
-      nextAllowlist.length !== allowlist.length ||
-      nextAllowlist.some(
-        (entry, i) => entry.address !== allowlist[i]?.address || entry.units !== allowlist[i]?.units
-      );
-
-    if (isDifferent) {
-      setAllowlist(nextAllowlist);
-    }
-  }, [allowlist, contributorWeights, distributionMode, selectedAttestations, setAllowlist]);
+  useHypercertAllowlist({
+    allowlist,
+    contributorWeights,
+    distributionMode,
+    hasSelectedAttestations: selectedAttestations.length > 0,
+    onAllowlistChange: setAllowlist,
+  });
 
   const suggestedScopes = useMemo(() => {
     const scopes = selectedAttestations.flatMap((attestation) => attestation.workScope ?? []);

--- a/packages/shared/src/hooks/hypercerts/useHypercertAllowlist.ts
+++ b/packages/shared/src/hooks/hypercerts/useHypercertAllowlist.ts
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import {
+  calculateDistribution,
+  type ContributorWeight,
+  type DistributionMode,
+} from "../../lib/hypercerts";
+import type { AllowlistEntry } from "../../types/hypercerts";
+
+interface UseHypercertAllowlistParams {
+  allowlist: AllowlistEntry[];
+  contributorWeights: ContributorWeight[];
+  distributionMode: DistributionMode;
+  hasSelectedAttestations: boolean;
+  onAllowlistChange: (allowlist: AllowlistEntry[]) => void;
+}
+
+/**
+ * Keeps allowlist distribution in sync with selected contributors and distribution mode.
+ */
+export function useHypercertAllowlist({
+  allowlist,
+  contributorWeights,
+  distributionMode,
+  hasSelectedAttestations,
+  onAllowlistChange,
+}: UseHypercertAllowlistParams): void {
+  useEffect(() => {
+    if (!hasSelectedAttestations) return;
+    if (distributionMode === "custom" && allowlist.length > 0) return;
+
+    const mode = distributionMode === "proportional" ? "count" : distributionMode;
+    const nextAllowlist = calculateDistribution(contributorWeights, mode, allowlist);
+
+    // Deep compare to avoid infinite loops - only update if contents differ
+    const isDifferent =
+      nextAllowlist.length !== allowlist.length ||
+      nextAllowlist.some(
+        (entry, index) =>
+          entry.address !== allowlist[index]?.address || entry.units !== allowlist[index]?.units
+      );
+
+    if (isDifferent) {
+      onAllowlistChange(nextAllowlist);
+    }
+  }, [allowlist, contributorWeights, distributionMode, hasSelectedAttestations, onAllowlistChange]);
+}

--- a/packages/shared/src/hooks/hypercerts/useHypercertContributorWeights.ts
+++ b/packages/shared/src/hooks/hypercerts/useHypercertContributorWeights.ts
@@ -1,0 +1,12 @@
+import { useMemo } from "react";
+import { buildContributorWeights, type ContributorWeight } from "../../lib/hypercerts";
+import type { HypercertAttestation } from "../../types/hypercerts";
+
+/**
+ * Derives contributor weights from selected attestations for distribution calculations.
+ */
+export function useHypercertContributorWeights(
+  selectedAttestations: HypercertAttestation[]
+): ContributorWeight[] {
+  return useMemo(() => buildContributorWeights(selectedAttestations), [selectedAttestations]);
+}

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -227,6 +227,8 @@ export type {
 // Re-export with consistent naming (useHypercertAttestations instead of useAttestations)
 export { useAttestations as useHypercertAttestations } from "./hypercerts/useAttestations";
 export { useCreateHypercertWorkflow } from "./hypercerts/useCreateHypercertWorkflow";
+export { useHypercertAllowlist } from "./hypercerts/useHypercertAllowlist";
+export { useHypercertContributorWeights } from "./hypercerts/useHypercertContributorWeights";
 export type { UseHypercertDraftResult } from "./hypercerts/useHypercertDraft";
 export { useHypercertDraft } from "./hypercerts/useHypercertDraft";
 export type {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -241,6 +241,8 @@ export {
   useHasRole,
   // Hypercert hooks (grouped together, prefixed with useHypercert*)
   useHypercertAttestations,
+  useHypercertAllowlist,
+  useHypercertContributorWeights,
   useHypercertDraft,
   useHypercerts,
   type OptimisticHypercertData,


### PR DESCRIPTION
### Motivation
- Replace a raw `window.addEventListener("beforeunload")` usage with the shared `useWindowEvent` utility to follow the project rule for window event handling. 
- Reduce complexity in a large `HypercertWizard` component by moving distribution/weight logic into focused hooks for reuse and testability. 
- Centralize hypercert distribution logic in `@green-goods/shared` so other packages can reuse it consistently.

### Description
- Replaced the manual `beforeunload` listener in `packages/admin/src/components/hypercerts/HypercertWizard.tsx` with `useWindowEvent("beforeunload", ...)` from `@green-goods/shared` to handle unsaved-change protection. 
- Extracted contributor weight derivation into `useHypercertContributorWeights` in `packages/shared/src/hooks/hypercerts/useHypercertContributorWeights.ts` which wraps `buildContributorWeights`. 
- Extracted allowlist synchronization and distribution update logic into `useHypercertAllowlist` in `packages/shared/src/hooks/hypercerts/useHypercertAllowlist.ts` which encapsulates `calculateDistribution` and the deep-compare guard before calling `onAllowlistChange`. 
- Exported the new hooks from the shared barrels by updating `packages/shared/src/hooks/index.ts` and `packages/shared/src/index.ts` and wired the `HypercertWizard` to use the new hooks instead of in-component logic.

### Testing
- Ran code formatting with `bunx @biomejs/biome format --write` on changed files and it completed successfully. 
- Ran unit tests in `packages/admin` with `bun run test`, which failed due to the test environment being unable to resolve external packages (errors resolving `react-router-dom`, `@tanstack/react-query`, `xstate`), so no test assertions were executed. 
- Attempted builds with `bun build` and `bun run build` in `packages/admin`, both of which failed in this environment (missing explicit `bun build` entrypoints and a missing `@tailwindcss/vite` plugin), so package build could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69940c8631508331af0e3518b5ec4682)