### PR TITLE
Garden: surface offline queue status in Review, replace setTimeout with useTimeout, stabilize setGardenAddress

### DIFF
--- a/packages/client/src/views/Garden/index.tsx
+++ b/packages/client/src/views/Garden/index.tsx
@@ -6,6 +6,8 @@ import {
   useDraftAutoSave,
   useDraftResume,
   useGardenTranslation,
+  useOffline,
+  useTimeout,
   useWork,
   useWorkFlowStore,
   useWorkSelection,
@@ -91,8 +93,11 @@ const Work: React.FC = () => {
 
   const canBypassMediaRequirement = import.meta.env.VITE_DEBUG_MODE === "true";
   const submissionCompleted = useWorkFlowStore((s) => s.submissionCompleted);
+  const setGardenAddressStable = useWorkFlowStore((s) => s.setGardenAddress);
   const audioNotes = useWorkFlowStore((s) => s.audioNotes);
   const setAudioNotes = useWorkFlowStore((s) => s.setAudioNotes);
+  const { isOnline, pendingCount, syncStatus } = useOffline();
+  const { set: scheduleNavigation } = useTimeout();
 
   // Media upload click handlers (exposed by WorkMedia for PostHog tracking)
   const galleryClickRef = useRef<(() => void) | null>(null);
@@ -149,9 +154,9 @@ const Work: React.FC = () => {
   useEffect(() => {
     const navigationState = location.state as { gardenId?: string } | null;
     if (navigationState?.gardenId && gardens.length > 0) {
-      setGardenAddress(navigationState.gardenId);
+      setGardenAddressStable(navigationState.gardenId);
     }
-  }, [location.state, gardens.length, setGardenAddress]);
+  }, [location.state, gardens.length, setGardenAddressStable]);
 
   const handleStartFresh = async () => {
     await clearDraft();
@@ -168,7 +173,7 @@ const Work: React.FC = () => {
       logger.error("Failed to clear draft after submission", { error, source: "Garden" });
     });
 
-    const timer = setTimeout(() => {
+    const cancelNavigation = scheduleNavigation(() => {
       navigate("/home", { replace: true, viewTransition: true });
       requestAnimationFrame(() => {
         useWorkFlowStore.getState().reset();
@@ -176,8 +181,41 @@ const Work: React.FC = () => {
       });
     }, 800);
 
-    return () => clearTimeout(timer);
-  }, [submissionCompleted, navigate, form, clearActiveDraft]);
+    return cancelNavigation;
+  }, [submissionCompleted, navigate, form, clearActiveDraft, scheduleNavigation]);
+
+  const queueStatusMessage = useMemo(() => {
+    if (activeTab !== WorkTab.Review) return null;
+
+    if (!isOnline) {
+      return intl.formatMessage({
+        id: "app.offline.status.went.offline",
+        defaultMessage: "You're offline. Your work will sync when you're back online.",
+      });
+    }
+
+    if (syncStatus === "syncing" || workMutation.isPending) {
+      return intl.formatMessage(
+        {
+          id: "app.syncBar.syncing",
+          defaultMessage: "Syncing {count} items...",
+        },
+        { count: Math.max(pendingCount, 1) }
+      );
+    }
+
+    if (pendingCount > 0) {
+      return intl.formatMessage(
+        {
+          id: "app.syncBar.pendingOnline",
+          defaultMessage: "{count} items waiting to sync",
+        },
+        { count: pendingCount }
+      );
+    }
+
+    return null;
+  }, [activeTab, isOnline, intl, pendingCount, syncStatus, workMutation.isPending]);
 
   // Selected action and garden with translations
   const selectedAction = useMemo(() => {
@@ -508,20 +546,27 @@ const Work: React.FC = () => {
       >
         <div className="padded relative flex flex-col gap-4 flex-1">{renderTabContent()}</div>
         <div className="flex fixed left-0 bottom-0 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] w-full z-[10000] bg-bg-white-0 border-t border-stroke-soft-200">
-          <div className="flex flex-row gap-4 w-full padded">
-            {currentTab.customSecondary}
-            <Button
-              onClick={currentTab.primary}
-              label={currentTab.primaryLabel}
-              disabled={currentTab.primaryDisabled}
-              className="w-full"
-              variant="primary"
-              mode="filled"
-              size="medium"
-              type="button"
-              shape="pilled"
-              trailingIcon={<RiArrowRightSLine className="w-5 h-5" />}
-            />
+          <div className="flex flex-col gap-2 w-full padded">
+            {queueStatusMessage && (
+              <p className="text-xs text-text-sub-600 px-1" role="status" aria-live="polite">
+                {queueStatusMessage}
+              </p>
+            )}
+            <div className="flex flex-row gap-4 w-full">
+              {currentTab.customSecondary}
+              <Button
+                onClick={currentTab.primary}
+                label={currentTab.primaryLabel}
+                disabled={currentTab.primaryDisabled}
+                className="w-full"
+                variant="primary"
+                mode="filled"
+                size="medium"
+                type="button"
+                shape="pilled"
+                trailingIcon={<RiArrowRightSLine className="w-5 h-5" />}
+              />
+            </div>
           </div>
         </div>
       </form>


### PR DESCRIPTION
### Motivation
- Improve UX by making offline/job-queue status visible at the view level during the Review step so users know when submissions are queued or syncing. 
- Replace raw `setTimeout` usage with the shared `useTimeout()` helper for safe cleanup and to follow the hook rule. 
- Avoid unnecessary re-runs of a navigation-state effect by stabilizing the `setGardenAddress` dependency to the store selector identity.

### Description
- Added `useOffline()` + `useTimeout()` usage and a small accessible status line above the submit button in `packages/client/src/views/Garden/index.tsx` to surface queue/sync messages (uses i18n keys `app.offline.status.went.offline`, `app.syncBar.syncing`, `app.syncBar.pendingOnline`).
- Replaced the raw `setTimeout` navigation delay after successful submission with the `useTimeout()` managed `set`/cancel pattern to ensure automatic cleanup.
- Switched the pre-selection effect to depend on the store selector `setGardenAddress` (renamed locally to `setGardenAddressStable`) to avoid function-identity churn in the dependency array.
- Verified the offline submission path already exists in shared code: `useWorkMutation` calls `submitWorkToQueue` for queued submissions and `submitWorkToQueue` adds a `

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69940c6874e483318cf1a6745c9e3e83)