### PR TITLE
contracts: handle vault maxWithdraw limits in YieldResolver and document permissionless splitYield

### DIFF
--- a/packages/contracts/src/mocks/YieldDeps.sol
+++ b/packages/contracts/src/mocks/YieldDeps.sol
@@ -200,6 +200,7 @@ contract MockOctantVaultForYield {
     /// @notice Exchange rate: assets = shares * rateNumerator / rateDenominator
     uint256 public rateNumerator = 1;
     uint256 public rateDenominator = 1;
+    uint256 public maxWithdrawOverride = type(uint256).max;
 
     constructor(address _asset) {
         UNDERLYING = ERC20(_asset);
@@ -212,6 +213,11 @@ contract MockOctantVaultForYield {
         rateDenominator = _denominator;
     }
 
+    /// @notice Set maxWithdraw override (in assets) to simulate vault liquidity limits
+    function setMaxWithdrawOverride(uint256 _maxWithdrawOverride) external {
+        maxWithdrawOverride = _maxWithdrawOverride;
+    }
+
     function asset() external view returns (address) {
         return address(UNDERLYING);
     }
@@ -222,6 +228,22 @@ contract MockOctantVaultForYield {
 
     function totalSupply() external view returns (uint256) {
         return _totalSupply;
+    }
+
+    function convertToAssets(uint256 shares) external view returns (uint256 assets) {
+        return (shares * rateNumerator) / rateDenominator;
+    }
+
+    function convertToShares(uint256 assets) external view returns (uint256 shares) {
+        return (assets * rateDenominator) / rateNumerator;
+    }
+
+    function maxWithdraw(address account) external view returns (uint256 assets) {
+        uint256 accountAssets = (_balances[account] * rateNumerator) / rateDenominator;
+        if (maxWithdrawOverride < accountAssets) {
+            return maxWithdrawOverride;
+        }
+        return accountAssets;
     }
 
     /// @notice Mint shares to an account (test helper)

--- a/packages/contracts/src/resolvers/Yield.sol
+++ b/packages/contracts/src/resolvers/Yield.sol
@@ -215,6 +215,11 @@ contract YieldResolver is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUp
 
     /// @notice Split yield from a garden's vault for a given asset
     /// @dev Permissionless — anyone can trigger. Redeems vault shares, applies three-way split.
+    ///      Timing risk is intentional: callers can trigger immediately after harvest and before
+    ///      additional yield accrues. This cannot redirect funds (fixed split ratios + fixed
+    ///      destinations), but can make distributions occur earlier than garden operators prefer.
+    ///      Mitigations: minYieldThreshold batching, operator-controlled split config, and owner
+    ///      emergency override of split config/destinations.
     /// @param garden The garden address
     /// @param asset The underlying asset (WETH/DAI)
     /// @param vault The ERC-4626 vault holding shares for this garden+asset
@@ -257,14 +262,24 @@ contract YieldResolver is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUp
 
         uint256 redeemed = 0;
         if (shares > 0) {
+            uint256 redeemableShares = shares;
+            uint256 maxWithdrawAssets = IOctantVault(vault).maxWithdraw(address(this));
+
+            // Some ERC-4626 implementations cap withdrawals during strategy illiquidity.
+            // Redeem only the currently withdrawable portion to avoid full-call reverts.
+            uint256 sharesFromMaxWithdraw = IOctantVault(vault).convertToShares(maxWithdrawAssets);
+            if (sharesFromMaxWithdraw < redeemableShares) {
+                redeemableShares = sharesFromMaxWithdraw;
+            }
+
             // maxLoss=1 (1 bps) allows up to 0.01% rounding loss during redemption.
             // ERC-4626 vaults may return slightly fewer assets than expected due to
             // integer division in share→asset conversion. The vault reverts if loss
             // exceeds this threshold, preventing material share drain.
-            redeemed = IOctantVault(vault).redeem(shares, address(this), address(this), 1, new address[](0));
+            redeemed = IOctantVault(vault).redeem(redeemableShares, address(this), address(this), 1, new address[](0));
             if (redeemed > 0) {
-                gardenShares[garden][vault] = 0;
-                totalRegisteredShares[vault] -= shares;
+                gardenShares[garden][vault] = shares - redeemableShares;
+                totalRegisteredShares[vault] -= redeemableShares;
             }
         }
         return redeemed + pendingYield[garden][asset];

--- a/packages/contracts/test/unit/YieldSplitter.t.sol
+++ b/packages/contracts/test/unit/YieldSplitter.t.sol
@@ -933,6 +933,50 @@ contract YieldResolverTest is Test {
         );
     }
 
+    /// @notice Verify splitYield redeems only currently-withdrawable shares when vault liquidity is capped
+    function test_splitYield_respectsMaxWithdraw_partialRedemption() public {
+        uint256 shares = 100e18;
+        uint256 maxWithdrawAssets = 40e18;
+
+        weth.mint(address(vault), shares);
+        vault.mintShares(address(yieldSplitter), shares);
+
+        vm.prank(octantModule);
+        yieldSplitter.registerShares(garden, address(vault), shares);
+
+        vault.setMaxWithdrawOverride(maxWithdrawAssets);
+
+        vm.prank(owner);
+        yieldSplitter.setMinYieldThreshold(0);
+
+        yieldSplitter.splitYield(garden, address(weth), address(vault));
+
+        assertEq(
+            yieldSplitter.gardenShares(garden, address(vault)),
+            shares - maxWithdrawAssets,
+            "Unredeemable shares should remain registered"
+        );
+        assertEq(
+            yieldSplitter.totalRegisteredShares(address(vault)),
+            shares - maxWithdrawAssets,
+            "Aggregate registered shares should decrement by redeemed amount"
+        );
+
+        uint256 expectedCookieJar = (maxWithdrawAssets * 4865) / 10_000;
+        uint256 expectedFractions = (maxWithdrawAssets * 4865) / 10_000;
+        uint256 expectedJuicebox = maxWithdrawAssets - expectedCookieJar - expectedFractions;
+
+        assertEq(weth.balanceOf(address(cookieJar)), expectedCookieJar, "Cookie Jar should only receive split of redeemed assets");
+        assertEq(
+            yieldSplitter.getEscrowedFractions(garden, address(weth)),
+            expectedFractions,
+            "Fractions escrow should only receive split of redeemed assets"
+        );
+
+        (,, uint256 payAmount,) = jbTerminal.payCalls(0);
+        assertEq(payAmount, expectedJuicebox, "Juicebox should receive remainder of redeemed assets");
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Cross-Garden Share Validation (Aggregate Tracking)
     // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation

- Prevent full-redemption reverts when underlying ERC-4626 vaults impose withdrawal caps and document the permissionless `splitYield()` timing tradeoff and mitigations.

### Description

- Documented the intentional permissionless timing risk in `YieldResolver::splitYield` NatSpec and listed mitigations (`minYieldThreshold`, operator split config, owner emergency override).
- Changed `_redeemAndAccumulate` to query `IOctantVault.maxWithdraw(address(this))`, convert that to redeemable shares, redeem only the withdrawable portion, and keep any unredeemed shares in `gardenShares` / `totalRegisteredShares` instead of zeroing them out.
- Extended the mock `MockOctantVaultForYield` with `maxWithdrawOverride`, `setMaxWithdrawOverride`, `convertToAssets`, `convertToShares`, and `maxWithdraw` to simulate liquidity caps in tests.
- Added a unit test `test_splitYield_respectsMaxWithdraw_partialRedemption` to `test/unit/YieldSplitter.t.sol` that asserts partial redemption behavior, residual share accounting, and correct split distribution for the redeemed assets.

### Testing

- Added a unit test in `packages/contracts/test/unit/YieldSplitter.t.sol` but `forge`/Foundry is not available here so tests were not executed in this environment.
- Ran formatting via package script `bun --filter @green-goods/contracts format` which failed because `forge` is not installed in the container (format task invokes `forge`).
- Attempted schema/deployment commands `bun script/deploy.ts core --network sepolia --broadcast --update-schemas` and `bun script/deploy.ts core --network arbitrum --broadcast --update-schemas` but both failed: the environment lacks `forge`, and the Arbitrum run is gated by a Sepolia checkpoint that requires a prior Sepolia broadcast.
- Ran `bun run verify:contracts` which failed for the same reason (`forge` not found).

Notes: The code changes and tests are present locally; please run `forge test` (or `bun run test` per CI) and the deployment commands in an environment with Foundry (`forge`) and deployer credentials to validate and broadcast schema registrations and core contract deployments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69940c1550e4833187b04eed7f49d712)