### PR TITLE
contracts: add Sepolia GAP fork coverage and avoid partial project state

### DIFF
--- a/packages/contracts/src/modules/Karma.sol
+++ b/packages/contracts/src/modules/Karma.sol
@@ -193,8 +193,6 @@ contract KarmaGAPModule is IKarmaGAPModule, OwnableUpgradeable, UUPSUpgradeable 
             }
         }
 
-        gardenProjects[garden] = projectUID;
-
         // 2. Create MemberOf attestation for operator
         {
             AttestationRequestData memory reqData = AttestationRequestData({
@@ -211,8 +209,8 @@ contract KarmaGAPModule is IKarmaGAPModule, OwnableUpgradeable, UUPSUpgradeable 
             try gap.attest(req) {
                 // Success - continue to details
             } catch {
-                // Non-critical: MemberOf failed but project exists
                 emit GAPOperationFailed(garden, "createProject", "MemberOf attestation failed");
+                return bytes32(0);
             }
         }
 
@@ -232,12 +230,15 @@ contract KarmaGAPModule is IKarmaGAPModule, OwnableUpgradeable, UUPSUpgradeable 
             AttestationRequest memory req = AttestationRequest({ schema: KarmaLib.getDetailsSchemaUID(), data: reqData });
 
             try gap.attest(req) {
-                emit GAPProjectCreated(projectUID, garden, name);
+                // Success - finalize below
             } catch {
-                // Non-critical: Details failed but project exists
                 emit GAPOperationFailed(garden, "createProject", "Details attestation failed");
+                return bytes32(0);
             }
         }
+
+        gardenProjects[garden] = projectUID;
+        emit GAPProjectCreated(projectUID, garden, name);
 
         return projectUID;
     }

--- a/packages/contracts/test/fork/SepoliaKarmaGAP.t.sol
+++ b/packages/contracts/test/fork/SepoliaKarmaGAP.t.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+import { KarmaGAPModule } from "../../src/modules/Karma.sol";
+import { KarmaLib } from "../../src/lib/Karma.sol";
+
+/// @title SepoliaKarmaGAPForkTest
+/// @notice Fork tests against the real Karma GAP contract on Sepolia.
+/// @dev Creates project/impact/milestone attestations through KarmaGAPModule and
+/// validates returned UIDs are non-zero on the real GAP deployment.
+contract SepoliaKarmaGAPForkTest is Test {
+    KarmaGAPModule internal module;
+
+    address internal constant OWNER = address(0xA101);
+    address internal constant GARDEN_TOKEN = address(0xA102);
+    address internal constant WORK_APPROVAL_RESOLVER = address(0xA103);
+    address internal constant ASSESSMENT_RESOLVER = address(0xA104);
+
+    address internal constant GARDEN = address(0xB101);
+    address internal constant OPERATOR = address(0xB102);
+
+    function test_fork_sepolia_createProjectImpactMilestone() public {
+        string memory rpcUrl = _getRpc("SEPOLIA_RPC_URL");
+        if (bytes(rpcUrl).length == 0) {
+            emit log("SKIPPED: No Sepolia RPC URL configured");
+            return;
+        }
+
+        vm.createSelectFork(rpcUrl);
+        assertEq(block.chainid, 11_155_111, "Expected Sepolia fork");
+
+        KarmaGAPModule implementation = new KarmaGAPModule();
+        bytes memory initData = abi.encodeWithSelector(
+            KarmaGAPModule.initialize.selector, OWNER, GARDEN_TOKEN, WORK_APPROVAL_RESOLVER, ASSESSMENT_RESOLVER
+        );
+        module = KarmaGAPModule(address(new ERC1967Proxy(address(implementation), initData)));
+
+        vm.prank(GARDEN_TOKEN);
+        bytes32 projectUID = module.createProject(
+            GARDEN,
+            OPERATOR,
+            "Green Goods Sepolia Fork Garden",
+            "Fork test project created via KarmaGAPModule",
+            "Sepolia Test Location",
+            "QmSepoliaForkBanner"
+        );
+
+        assertTrue(projectUID != bytes32(0), "Project UID should be non-zero");
+        assertEq(module.gardenProjects(GARDEN), projectUID, "Project UID should be persisted for garden");
+
+        vm.prank(WORK_APPROVAL_RESOLVER);
+        bytes32 impactUID = module.createImpact(
+            GARDEN,
+            1,
+            "Fork Impact",
+            "Created impact attestation on real GAP",
+            "QmSepoliaImpactProof",
+            bytes32(uint256(0x123456))
+        );
+
+        assertTrue(impactUID != bytes32(0), "Impact UID should be non-zero");
+
+        vm.prank(ASSESSMENT_RESOLVER);
+        bytes32 milestoneUID = module.createMilestone(
+            GARDEN,
+            "Fork Milestone",
+            "Created milestone attestation on real GAP",
+            block.timestamp,
+            block.timestamp + 7 days,
+            1,
+            "Sepolia Test Location",
+            "QmSepoliaAssessmentConfig"
+        );
+
+        assertTrue(milestoneUID != bytes32(0), "Milestone UID should be non-zero");
+    }
+
+    function test_fork_sepolia_schemaUIDs_matchKnownValues() public {
+        string memory rpcUrl = _getRpc("SEPOLIA_RPC_URL");
+        if (bytes(rpcUrl).length == 0) {
+            emit log("SKIPPED: No Sepolia RPC URL configured");
+            return;
+        }
+
+        vm.createSelectFork(rpcUrl);
+
+        assertEq(KarmaLib.getGapContract(), 0x9E5560f5b084c227Dc40672f48F59DA617eeFA28, "Sepolia GAP contract mismatch");
+        assertEq(
+            KarmaLib.getProjectSchemaUID(),
+            0xec77990a252b54b17673955c774b9712766de5eecb22ca5aa2c440e0e93257fb,
+            "Sepolia project schema mismatch"
+        );
+        assertEq(
+            KarmaLib.getDetailsSchemaUID(),
+            0x2c270e35bfcdc4d611f0e9d3d2ab6924ec6c673505abc22a1dd07e19b67211af,
+            "Sepolia details schema mismatch"
+        );
+        assertEq(
+            KarmaLib.getMemberOfSchemaUID(),
+            0xdd87b3500457931252424f4439365534ba72a367503a8805ff3482353fb90301,
+            "Sepolia memberOf schema mismatch"
+        );
+
+        vm.chainId(42_161);
+        assertEq(KarmaLib.getGapContract(), 0x6dC1D6b864e8BEf815806f9e4677123496e12026, "Arbitrum GAP contract mismatch");
+        assertEq(
+            KarmaLib.getProjectSchemaUID(),
+            0xac2a06e955a7e25e6729efe1a6532237e3435b21ccd3dc827ae3c94e624d25b3,
+            "Arbitrum project schema mismatch"
+        );
+        assertEq(
+            KarmaLib.getDetailsSchemaUID(),
+            0x16bfe4783b7a9c743c401222c56a07ecb77ed42afc84b61ff1f62f5936c0b9d7,
+            "Arbitrum details schema mismatch"
+        );
+        assertEq(
+            KarmaLib.getMemberOfSchemaUID(),
+            0x5f430aec9d04f0dcb3729775c5dfe10752e436469a7607f8c64ae44ef996e477,
+            "Arbitrum memberOf schema mismatch"
+        );
+    }
+
+    function _getRpc(string memory envVar) internal view returns (string memory) {
+        try vm.envString(envVar) returns (string memory rpcUrl) {
+            return rpcUrl;
+        } catch {
+            return "";
+        }
+    }
+}

--- a/packages/contracts/test/unit/KarmaModule.t.sol
+++ b/packages/contracts/test/unit/KarmaModule.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import { Test } from "forge-std/Test.sol";
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { AttestationRequest, AttestationRequestData } from "@eas/IEAS.sol";
 
 import { KarmaGAPModule } from "../../src/modules/Karma.sol";
 import { IKarmaGAPModule } from "../../src/interfaces/IKarmaGAPModule.sol";
@@ -28,6 +29,12 @@ contract KarmaModuleTest is Test {
 
     /// @dev KarmaLib.getGapContract() returns this for chainId 11155111 (Sepolia)
     address internal constant GAP_ADDRESS = 0x9E5560f5b084c227Dc40672f48F59DA617eeFA28;
+    bytes32 internal constant GAP_PROJECT_SCHEMA_SEPOLIA =
+        0xec77990a252b54b17673955c774b9712766de5eecb22ca5aa2c440e0e93257fb;
+    bytes32 internal constant GAP_DETAILS_SCHEMA_SEPOLIA =
+        0x2c270e35bfcdc4d611f0e9d3d2ab6924ec6c673505abc22a1dd07e19b67211af;
+    bytes32 internal constant GAP_MEMBEROF_SCHEMA_SEPOLIA =
+        0xdd87b3500457931252424f4439365534ba72a367503a8805ff3482353fb90301;
 
     // Events from IKarmaGAPModule
     event GAPProjectCreated(bytes32 indexed projectUID, address indexed garden, string projectName);
@@ -302,6 +309,68 @@ contract KarmaModuleTest is Test {
         vm.prank(GARDEN_TOKEN);
         bytes32 uid = module.createProject(GARDEN, OPERATOR, "Garden", "Desc", "Loc", "Banner");
         assertEq(uid, bytes32(0), "Should return zero UID when GAP fails");
+    }
+
+    function test_createProject_memberOfFailure_doesNotPersistProject() public {
+        _setupSupportedChain();
+
+        bytes32 expectedProjectUID =
+            keccak256(abi.encodePacked(block.timestamp, address(module), uint256(1), GAP_PROJECT_SCHEMA_SEPOLIA));
+
+        AttestationRequest memory memberRequest = AttestationRequest({
+            schema: GAP_MEMBEROF_SCHEMA_SEPOLIA,
+            data: AttestationRequestData({
+                recipient: OPERATOR,
+                expirationTime: 0,
+                revocable: true,
+                refUID: expectedProjectUID,
+                data: abi.encode(true),
+                value: 0
+            })
+        });
+
+        vm.mockCallRevert(GAP_ADDRESS, abi.encodeWithSelector(MockGAP.attest.selector, memberRequest), "member failed");
+
+        vm.expectEmit(true, false, false, true);
+        emit GAPOperationFailed(GARDEN, "createProject", "MemberOf attestation failed");
+
+        vm.prank(GARDEN_TOKEN);
+        bytes32 uid = module.createProject(GARDEN, OPERATOR, "Garden", "Desc", "Loc", "Banner");
+
+        assertEq(uid, bytes32(0), "Should return zero when MemberOf attestation fails");
+        assertEq(module.gardenProjects(GARDEN), bytes32(0), "Mapping must stay unset on partial failure");
+    }
+
+    function test_createProject_detailsFailure_doesNotPersistProject() public {
+        _setupSupportedChain();
+
+        bytes32 expectedProjectUID =
+            keccak256(abi.encodePacked(block.timestamp, address(module), uint256(1), GAP_PROJECT_SCHEMA_SEPOLIA));
+        string memory detailsJson =
+            '{"title":"Garden","description":"Desc","locationOfImpact":"Loc","imageURL":"ipfs://Banner","slug":"garden","type":"project-details"}';
+
+        AttestationRequest memory detailsRequest = AttestationRequest({
+            schema: GAP_DETAILS_SCHEMA_SEPOLIA,
+            data: AttestationRequestData({
+                recipient: GARDEN,
+                expirationTime: 0,
+                revocable: true,
+                refUID: expectedProjectUID,
+                data: abi.encode(detailsJson),
+                value: 0
+            })
+        });
+
+        vm.mockCallRevert(GAP_ADDRESS, abi.encodeWithSelector(MockGAP.attest.selector, detailsRequest), "details failed");
+
+        vm.expectEmit(true, false, false, true);
+        emit GAPOperationFailed(GARDEN, "createProject", "Details attestation failed");
+
+        vm.prank(GARDEN_TOKEN);
+        bytes32 uid = module.createProject(GARDEN, OPERATOR, "Garden", "Desc", "Loc", "Banner");
+
+        assertEq(uid, bytes32(0), "Should return zero when Details attestation fails");
+        assertEq(module.gardenProjects(GARDEN), bytes32(0), "Mapping must stay unset on partial failure");
     }
 
     function test_addProjectAdmin_callsGAP_onSupportedChain() public {


### PR DESCRIPTION
### Motivation

- Add a real-fork test exercising Karma GAP on Sepolia because there was no coverage against the real GAP contract. 
- Prevent partial on-chain state where `gardenProjects[garden]` could be set even when follow-up attestations (`MemberOf` / `Details`) failed.  
- Ensure deployed schema UIDs and GAP addresses match expected constants to avoid deployment/compatibility drift.

### Description

- Harden `KarmaGAPModule.createProject()` (in `src/modules/Karma.sol`) so the `gardenProjects[garden]` mapping is only written and `GAPProjectCreated` emitted after the project attestation and the subsequent `MemberOf` and `Details` attestations all succeed, and return `bytes32(0)` on intermediate failures.  
- Add a Sepolia fork test `test/fork/SepoliaKarmaGAP.t.sol` that forks Sepolia and exercises `createProject`, `createImpact`, and `createMilestone` against the real GAP contract and also asserts known Sepolia+Arbitrum schema and contract constants via `KarmaLib`.  
- Add unit tests in `test/unit/KarmaModule.t.sol` to cover the partial-state cases: simulated `MemberOf` and `Details` attestation failures (via `vm.mockCallRevert`) assert the function returns `bytes32(0)` and that `gardenProjects[garden]` remains unset, plus small test-support constants and imports needed for those tests.  

### Testing

- Attempted to run unit tests with `cd packages/contracts && bun run test`, but automated runs failed because `forge` is not installed in this environment (`command not found`).  
- Attempted fork tests with `cd packages/contracts && bun run test:fork`, but the command failed for the same reason (`spawn forge ENOENT`).  
- Attempted to deploy with `cd packages/contracts && bun run deploy:sepolia` and `bun run deploy:arbitrum`, but the Sepolia broadcast failed due to the missing `forge` executable and Arbitrum deploy was blocked by the Sepolia checkpoint gate; therefore no deployment / fork execution was possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69940b67a06c8331a23070ceb6cbb844)