### PR TITLE
contracts: harden Juicebox fork checks and document YieldResolver split defaults

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -676,7 +676,21 @@ bun deploy:dry:testnet
 # Advanced options via deploy.ts
 bun script/deploy.ts core --network sepolia --broadcast --update-schemas
 bun script/deploy.ts core --network sepolia --broadcast --force
+
+# Deploy Juicebox GOODS project (deployer-managed pipeline)
+bun script/deploy.ts goods --network arbitrum --broadcast
+# Alias: bun script/deploy.ts juicebox --network arbitrum --broadcast
 ```
+
+### Yield Split Defaults (YieldResolver)
+
+The default split ratio is **48.65% / 48.65% / 2.7%**:
+
+- `4865` bps → Cookie Jar (garden operations)
+- `4865` bps → Hypercert fractions (impact allocation; escrowed if routing is unavailable)
+- `270` bps → Juicebox (GOODS treasury backing)
+
+Rationale: keep operational + impact allocations balanced, while retaining a smaller treasury-growth leg. This is configurable per garden via `setSplitRatio(garden, cookieJarBps, fractionsBps, juiceboxBps)` as long as the basis points sum to `10_000`.
 
 **Adding New Networks:**
 1. Update `deployments/networks.json` with network configuration

--- a/packages/contracts/script/deploy/cli.ts
+++ b/packages/contracts/script/deploy/cli.ts
@@ -60,6 +60,7 @@ Usage: bun deploy.ts <command> [options]
 Commands:
   core                     Deploy core contracts
   goods                    Deploy GOODS Juicebox project (requires env vars)
+  juicebox                 Alias for `goods` deployment
   octant-factory           Deploy Octant vault factory (auto-updates deployment JSON)
   garden <config.json>     Deploy garden from config file
   actions <config.json>    Deploy actions from config file
@@ -178,6 +179,7 @@ For UUPS upgrades, use: bun upgrade.ts <contract> --network <network> --broadcas
           break;
 
         case "goods":
+        case "juicebox":
           await this.goodsDeployer.deployGoods(options);
           break;
 

--- a/packages/contracts/src/resolvers/Yield.sol
+++ b/packages/contracts/src/resolvers/Yield.sol
@@ -96,8 +96,16 @@ contract YieldResolver is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUp
     // ═══════════════════════════════════════════════════════════════════════════
 
     uint256 public constant BPS_DENOMINATOR = 10_000;
+    /// @notice Default split allocates 48.65% to gardener operations (Cookie Jar)
+    /// @dev 4865 bps = 48.65%. Kept symmetric with fractions to balance near-term ops and long-term impact.
     uint256 public constant DEFAULT_COOKIE_JAR_BPS = 4865;
+
+    /// @notice Default split allocates 48.65% to conviction-routed hypercert fractions
+    /// @dev 4865 bps = 48.65%. If fractions routing is unavailable this portion is escrowed for later withdrawal.
     uint256 public constant DEFAULT_FRACTIONS_BPS = 4865;
+
+    /// @notice Default split allocates 2.7% to Juicebox GOODS backing
+    /// @dev 270 bps = 2.7%. Using the remainder keeps rounding deterministic (sum always equals 10_000 bps).
     uint256 public constant DEFAULT_JUICEBOX_BPS = 270;
 
     // ═══════════════════════════════════════════════════════════════════════════
@@ -302,6 +310,9 @@ contract YieldResolver is OwnableUpgradeable, ReentrancyGuardUpgradeable, UUPSUp
     ///      HatsModule state. This is an intentional emergency escalation path — if a
     ///      garden's operator misconfigures the split (e.g., 100% to Cookie Jar), the
     ///      protocol owner can correct it without requiring garden-level cooperation.
+    ///
+    ///      Configurability: callers can set any valid basis-point tuple that sums to 10_000,
+    ///      including disabling a destination entirely (e.g., 5000/5000/0 or 0/0/10000).
     /// @param garden The garden address
     /// @param cookieJarBps Cookie Jar portion in basis points
     /// @param fractionsBps Fractions portion in basis points

--- a/packages/contracts/test/fork/ArbitrumYieldSplitter.t.sol
+++ b/packages/contracts/test/fork/ArbitrumYieldSplitter.t.sol
@@ -102,8 +102,17 @@ contract ArbitrumYieldResolverForkTest is Test {
     /// @notice Real WETH on Arbitrum
     address internal constant WETH = 0x82aF49447D8a07e3bd95BD0d56f35241523fBab1;
 
-    /// @notice Juicebox Multi-Terminal on Arbitrum
+    /// @notice Juicebox Controller on Arbitrum (mainnet)
+    /// @dev Source: https://docs.juicebox.money/dev/v5/addresses
+    address internal constant JB_CONTROLLER = 0x84E1D0102A722b3f3c00EC4E2b7ca2B97edF4eB2;
+
+    /// @notice Juicebox Multi-Terminal on Arbitrum (mainnet)
+    /// @dev Source: https://docs.juicebox.money/dev/v5/addresses
     address internal constant JB_MULTI_TERMINAL = 0x82129d4109625F94582bDdF6101a8Cd1a27919f5;
+
+    /// @notice Juicebox terminal used for project launches in fork tests
+    /// @dev Some forks expose a dedicated terminal that routes via the multi-terminal.
+    address internal constant JB_TERMINAL = 0x14785612bd5C27D8CbAd1d9A9E33BEBfF5F4C3b6;
 
     YieldResolver public yieldSplitter;
     MockVaultForFork public vault;
@@ -369,21 +378,25 @@ contract ArbitrumYieldResolverForkTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════════════════════
-    // Test: JB Multi-Terminal exists on Arbitrum
+    // Test: JB addresses exist on Arbitrum
     // ═══════════════════════════════════════════════════════════════════════════
 
-    function test_forkDeploy_jbMultiTerminalIsDeployed() public {
+    function test_forkDeploy_jbAddressesAreDeployed() public {
         if (!_tryFork()) {
             emit log("SKIPPED: ARBITRUM_RPC_URL not set");
             return;
         }
 
-        if (JB_MULTI_TERMINAL.code.length == 0) {
-            emit log("WARNING: JBMultiTerminal not deployed at expected address on Arbitrum");
-            emit log("  Expected: 0x82129d4109625F94582bDdF6101a8Cd1a27919f5");
-            emit log("  Action required: verify correct JB Multi-Terminal address for Arbitrum");
+        if (JB_CONTROLLER.code.length == 0 || JB_MULTI_TERMINAL.code.length == 0 || JB_TERMINAL.code.length == 0) {
+            emit log("WARNING: Juicebox contracts not deployed at expected Arbitrum addresses");
+            emit log("  Expected controller: 0x84E1D0102A722b3f3c00EC4E2b7ca2B97edF4eB2");
+            emit log("  Expected multi-terminal: 0x82129d4109625F94582bDdF6101a8Cd1a27919f5");
+            emit log("  Expected terminal: 0x14785612bd5C27D8CbAd1d9A9E33BEBfF5F4C3b6");
+            emit log("  Action required: verify current Juicebox v5 Arbitrum addresses");
         } else {
+            assertGt(JB_CONTROLLER.code.length, 0, "JBController should be deployed on Arbitrum");
             assertGt(JB_MULTI_TERMINAL.code.length, 0, "JBMultiTerminal should be deployed on Arbitrum");
+            assertGt(JB_TERMINAL.code.length, 0, "JBTerminal should be deployed on Arbitrum");
         }
     }
 
@@ -527,9 +540,7 @@ contract ArbitrumYieldResolverForkTest is Test {
             return;
         }
 
-        // Arbitrum Juicebox v5 addresses (from script/DeployJuicebox.s.sol)
-        address JB_CONTROLLER = 0x84E1D0102A722b3f3c00EC4E2b7ca2B97edF4eB2;
-        address JB_TERMINAL = 0x14785612bd5C27D8CbAd1d9A9E33BEBfF5F4C3b6;
+        // Arbitrum Juicebox v5 addresses (shared constants above)
 
         // Skip if JB contracts not deployed on this fork block
         if (JB_CONTROLLER.code.length == 0 || JB_TERMINAL.code.length == 0) {
@@ -577,7 +588,7 @@ contract ArbitrumYieldResolverForkTest is Test {
     }
 
     /// @notice Helper: Launch a JB project on Arbitrum fork that accepts WETH
-    /// @dev Mirrors the production DeployJuicebox.s.sol but for WETH instead of native ETH
+    /// @dev Mirrors the production DeployGoodsProject.s.sol launch flow but for WETH instead of native ETH
     function _launchTestJBProject(address controller, address terminal) internal returns (uint256 projectId) {
         // Ruleset metadata — pausePay must be false for pay() to work
         JBRulesetMetadata memory metadata = JBRulesetMetadata({
@@ -637,9 +648,6 @@ contract ArbitrumYieldResolverForkTest is Test {
             emit log("SKIPPED: ARBITRUM_RPC_URL not set");
             return;
         }
-
-        address JB_CONTROLLER = 0x84E1D0102A722b3f3c00EC4E2b7ca2B97edF4eB2;
-        address JB_TERMINAL = 0x14785612bd5C27D8CbAd1d9A9E33BEBfF5F4C3b6;
 
         if (JB_CONTROLLER.code.length == 0 || JB_TERMINAL.code.length == 0) {
             emit log("SKIPPED: Juicebox v5 contracts not deployed at expected addresses");


### PR DESCRIPTION
### Motivation

- Make Juicebox fork tests more reliable by centralizing the expected Arbitrum JB addresses and adding an explicit presence check for controller, multi-terminal and terminal contracts. 
- Make the Yield split defaults and rationale explicit in code and documentation so operators understand the 48.65/48.65/2.7 split and know it is configurable per garden.
- Surface a deployer-managed Juicebox/GOODS deployment path in the TypeScript deployment CLI so teams can run the Juicebox project deployment via the normal pipeline.

### Description

- Update `YieldResolver` defaults and NatSpec: add explanatory comments for `DEFAULT_COOKIE_JAR_BPS`, `DEFAULT_FRACTIONS_BPS`, and `DEFAULT_JUICEBOX_BPS` (4865/4865/270) and clarify `setSplitRatio` configurability; file: `packages/contracts/src/resolvers/Yield.sol`.
- Harden Arbitrum fork tests: centralize JB addresses (`JB_CONTROLLER`, `JB_MULTI_TERMINAL`, `JB_TERMINAL`), reuse them in fork tests, and add `test_forkDeploy_jbAddressesAreDeployed()` which warns if the expected JB contracts are not present; file: `packages/contracts/test/fork/ArbitrumYieldSplitter.t.sol`.
- Document the default split rationale and how to change it in the contracts README under deployment instructions and a new "Yield Split Defaults (YieldResolver)" section; file: `packages/contracts/README.md`.
- Add an explicit CLI alias so the Juicebox GOODS deploy flow can be invoked as `juicebox` (alias to existing `goods` deployer) via `bun script/deploy.ts`; file: `packages/contracts/script/deploy/cli.ts`.

### Testing

- Ran the fork test runner via `cd packages/contracts && bun run test:fork`, which invokes `forge test` for fork tests; the run could not execute in this environment because `forge` is not installed and the process failed with `spawn forge ENOENT` (test run aborted).
- Performed local code inspection and static validation (grep/sed/reading updated tests and scripts) to verify new constants, NatSpec, README additions, and CLI alias wiring; no unit/integration tests were executed here because Foundry/forge was unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69940be8fffc83318c0a483540e2aa2f)