### PR TITLE
contracts: Sepolia ENS fork tests, configurable ENS cooldown, and GardenToken ENS refund handling

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -810,3 +810,39 @@ echo $CELO_RPC_URL
 - 📝 [Schema Definitions](./config/schemas.json) — EAS schema configuration
 - 🌐 [Network Configuration](./deployments/networks.json) — Multi-chain settings
 - 🏗️ [Action Definitions](./config/actions.json) — Core garden actions
+
+
+## ENS Cross-Chain (CCIP) Flow
+
+`GreenGoodsENS` runs on L2 (Arbitrum One or Sepolia testnet) and sends registration/release intents to L1 via Chainlink CCIP. `GreenGoodsENSReceiver` runs on Ethereum mainnet and executes ENS writes for `*.greengoods.eth`.
+
+### End-to-End Message Path (Arbitrum → Mainnet)
+
+1. A garden mint (`GardenToken.mintGarden`) or member name claim (`GreenGoodsENS.claimName`) triggers L2 registration logic.
+2. `GreenGoodsENS` validates slug + local collision/cooldown constraints and builds a CCIP `EVM2AnyMessage` payload.
+3. `GreenGoodsENS` estimates fee with `IRouterClient.getFee(...)` and sends message through `IRouterClient.ccipSend(...)` to the L1 chain selector.
+4. Chainlink CCIP DON relays the message to Ethereum mainnet's CCIP router.
+5. Mainnet router calls `GreenGoodsENSReceiver.ccipReceive(...)`.
+6. `GreenGoodsENSReceiver` validates source chain + sender, decodes operation (`register` / `release`), and writes ENS via registry + resolver for `greengoods.eth` subdomains.
+7. L2 keeps a protective cache (`slugOwner`, `ownerToSlug`) to prevent duplicate claims before L1 finalization.
+
+### Deployment Targets
+
+Use the deployment wrapper (`script/deploy.ts`) rather than raw forge commands.
+
+```bash
+# 1) Deploy L2 sender on Sepolia (CCIP test path)
+bun script/deploy.ts core --network sepolia --broadcast
+
+# 2) Deploy L2 sender on Arbitrum One (production L2 sender)
+bun script/deploy.ts core --network arbitrum --broadcast
+
+# 3) Deploy L1 receiver on Ethereum mainnet
+bun script/deploy.ts core --network mainnet --broadcast
+```
+
+After both sides are deployed:
+
+- Set `ENS_L1_RECEIVER` before L2 deploys (or call `setL1Receiver` on `GreenGoodsENS`).
+- Set `ENS_L2_SENDER` before L1 deploys (or call `setL2Sender` on `GreenGoodsENSReceiver`).
+- Verify receiver has ENS operator approval on `greengoods.eth`.

--- a/packages/contracts/src/registries/ENS.sol
+++ b/packages/contracts/src/registries/ENS.sol
@@ -21,6 +21,7 @@ error RefundTransferFailed();
 error NoWithdrawableBalance();
 error WithdrawTransferFailed();
 error OnlySelf();
+error InvalidCooldown();
 
 interface IHats {
     function isWearerOfHat(address account, uint256 hatId) external view returns (bool);
@@ -51,7 +52,8 @@ contract GreenGoodsENS is Ownable {
 
     uint256 public constant MIN_SLUG_LENGTH = 3;
     uint256 public constant MAX_SLUG_LENGTH = 50;
-    uint256 public constant NAME_CHANGE_COOLDOWN = 30 days;
+    uint256 public constant DEFAULT_NAME_CHANGE_COOLDOWN = 30 days;
+    uint256 public nameChangeCooldown;
 
     /// @notice Authorized callers (GardenToken contract, owner)
     mapping(address => bool) public authorizedCallers;
@@ -70,6 +72,7 @@ contract GreenGoodsENS is Ownable {
     event L1ReceiverUpdated(address indexed oldReceiver, address indexed newReceiver);
     event AuthorizedCallerUpdated(address indexed caller, bool authorized);
     event ProtocolHatIdUpdated(uint256 oldHatId, uint256 newHatId);
+    event NameChangeCooldownUpdated(uint256 oldCooldown, uint256 newCooldown);
     event RefundFailed(address indexed recipient, uint256 amount);
     event RefundClaimed(address indexed recipient, uint256 amount);
 
@@ -86,6 +89,7 @@ contract GreenGoodsENS is Ownable {
         l1Receiver = _l1Receiver;
         HATS = IHats(_hats);
         protocolHatId = _protocolHatId;
+        nameChangeCooldown = DEFAULT_NAME_CHANGE_COOLDOWN;
         _transferOwnership(_owner);
     }
 
@@ -127,7 +131,7 @@ contract GreenGoodsENS is Ownable {
         _sendSponsoredRegistrationMessage(slug, msg.sender, NameType.Gardener);
     }
 
-    /// @notice Release current name (gardener names only, 30-day cooldown)
+    /// @notice Release current name (gardener names only, owner-configurable cooldown)
     /// @dev Garden names (NameType.Garden) are immutable and cannot be released.
     function releaseName() external payable {
         string memory currentSlug = ownerToSlug[msg.sender];
@@ -155,7 +159,7 @@ contract GreenGoodsENS is Ownable {
         bytes32 slugHash = keccak256(bytes(slug));
         if (slugOwner[slugHash] != address(0)) return false;
         uint256 releasedAt = slugReleasedAt[slug];
-        if (releasedAt > 0 && block.timestamp < releasedAt + NAME_CHANGE_COOLDOWN) return false;
+        if (releasedAt > 0 && block.timestamp < releasedAt + nameChangeCooldown) return false;
         return true;
     }
 
@@ -255,7 +259,7 @@ contract GreenGoodsENS is Ownable {
         if (slugOwner[slugHash] != address(0)) revert NameTaken();
 
         uint256 releasedAt = slugReleasedAt[slug];
-        if (releasedAt > 0 && block.timestamp < releasedAt + NAME_CHANGE_COOLDOWN) {
+        if (releasedAt > 0 && block.timestamp < releasedAt + nameChangeCooldown) {
             revert NameInCooldown();
         }
 
@@ -327,6 +331,14 @@ contract GreenGoodsENS is Ownable {
         uint256 old = protocolHatId;
         protocolHatId = _protocolHatId;
         emit ProtocolHatIdUpdated(old, _protocolHatId);
+    }
+
+    /// @notice Update the cooldown enforced after releasing a slug.
+    function setNameChangeCooldown(uint256 _cooldown) external onlyOwner {
+        if (_cooldown == 0) revert InvalidCooldown();
+        uint256 old = nameChangeCooldown;
+        nameChangeCooldown = _cooldown;
+        emit NameChangeCooldownUpdated(old, _cooldown);
     }
 
     /// @notice Withdraw stuck ETH (excess CCIP fees, etc.)

--- a/packages/contracts/src/tokens/Garden.sol
+++ b/packages/contracts/src/tokens/Garden.sol
@@ -32,6 +32,12 @@ contract GardenToken is ERC721Upgradeable, OwnableUpgradeable, UUPSUpgradeable {
     ICookieJarModule public cookieJarModule;
     IGreenGoodsENS public ensModule;
 
+    /// @notice Refund credits for failed ENS registrations, claimable by minter
+    mapping(address minter => uint256 amount) public failedENSRefunds;
+
+    /// @notice Total ETH reserved for pending ENS refund claims
+    uint256 public totalPendingENSRefunds;
+
     /// @notice Transfer restriction mode for garden NFTs
     enum TransferRestriction {
         Unrestricted,
@@ -44,12 +50,12 @@ contract GardenToken is ERC721Upgradeable, OwnableUpgradeable, UUPSUpgradeable {
 
     /**
      * @dev Storage gap for future upgrades
-     * Reserves 40 slots (50 total - 10 used: _nextTokenId, deploymentRegistry, hatsModule, karmaGAPModule,
-     * octantModule, gardensModule, actionRegistry, cookieJarModule, ensModule, transferRestriction)
-     * Note: _GARDEN_ACCOUNT_IMPLEMENTATION is immutable (not in storage)
+     * Reserves 38 slots (50 total - 12 used: _nextTokenId, deploymentRegistry, hatsModule, karmaGAPModule,
+     * octantModule, gardensModule, actionRegistry, cookieJarModule, ensModule, failedENSRefunds,
+     * totalPendingENSRefunds, transferRestriction)
      * Allows adding new state variables without breaking storage layout in upgrades
      */
-    uint256[40] private __gap;
+    uint256[38] private __gap;
 
     /// @notice Emitted when a new Garden is minted.
     /// @param tokenId The unique identifier of the minted Garden token.
@@ -84,6 +90,12 @@ contract GardenToken is ERC721Upgradeable, OwnableUpgradeable, UUPSUpgradeable {
 
     /// @notice Emitted when the ENS module address is updated.
     event ENSModuleUpdated(address indexed oldModule, address indexed newModule);
+
+    /// @notice Emitted when an ENS registration refund is queued for manual claim
+    event ENSRegistrationRefundQueued(address indexed minter, uint256 amount);
+
+    /// @notice Emitted when a minter claims previously queued ENS registration refunds
+    event ENSRegistrationRefundClaimed(address indexed minter, uint256 amount);
 
     /// @notice Configuration for batch garden minting (Gas Optimized)
     struct GardenConfig {
@@ -123,6 +135,10 @@ contract GardenToken is ERC721Upgradeable, OwnableUpgradeable, UUPSUpgradeable {
     error TransfersLocked();
     /// @notice Error thrown when transfers are restricted to owner only
     error TransfersRestricted();
+    /// @notice Error thrown when ENS refund claim is requested without a balance
+    error NoENSRefundAvailable();
+    /// @notice Error thrown when ENS refund transfer fails
+    error ENSRefundTransferFailed();
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     /// @param gardenAccountImplementation The address of the Garden account implementation.
@@ -377,6 +393,12 @@ contract GardenToken is ERC721Upgradeable, OwnableUpgradeable, UUPSUpgradeable {
                 // Success handled by ENS module events
             } catch {
                 // Non-blocking — garden mint MUST NOT revert
+                // Keep user funds recoverable if ENS registration failed.
+                if (msg.value > 0) {
+                    failedENSRefunds[_msgSender()] += msg.value;
+                    totalPendingENSRefunds += msg.value;
+                    emit ENSRegistrationRefundQueued(_msgSender(), msg.value);
+                }
             }
         }
 
@@ -393,6 +415,20 @@ contract GardenToken is ERC721Upgradeable, OwnableUpgradeable, UUPSUpgradeable {
         });
 
         IGardenAccount(gardenAccount).initialize(params);
+    }
+
+    /// @notice Claim queued refund from failed ENS registration attempts
+    function claimENSRefund() external {
+        uint256 amount = failedENSRefunds[_msgSender()];
+        if (amount == 0) revert NoENSRefundAvailable();
+
+        failedENSRefunds[_msgSender()] = 0;
+        totalPendingENSRefunds -= amount;
+
+        (bool ok,) = _msgSender().call{ value: amount }("");
+        if (!ok) revert ENSRefundTransferFailed();
+
+        emit ENSRegistrationRefundClaimed(_msgSender(), amount);
     }
 
     /// @notice Validates that the provided address is a valid ERC-20 token contract

--- a/packages/contracts/test/fork/SepoliaENS.t.sol
+++ b/packages/contracts/test/fork/SepoliaENS.t.sol
@@ -1,0 +1,268 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+
+import {
+    GreenGoodsENS,
+    InvalidSlug,
+    NameTaken,
+    AlreadyHasName,
+    NotAuthorizedCaller,
+    NotProtocolMember
+} from "../../src/registries/ENS.sol";
+import { IRouterClient } from "@chainlink/contracts-ccip/contracts/interfaces/IRouterClient.sol";
+
+/// @title SepoliaENSForkTest
+/// @notice Fork tests for GreenGoodsENS against real CCIP Router and Hats Protocol on Sepolia.
+contract SepoliaENSForkTest is Test {
+    address internal constant HATS_PROTOCOL = 0x3bc1A0Ad72417f2d411118085256fC53CBdDd137;
+    address internal constant CCIP_ROUTER = 0x0BF3dE8c5D3e8A2B34D2BEeB17ABfCeBaf363A59;
+    uint64 internal constant SEPOLIA_CHAIN_SELECTOR = 16_015_286_601_757_825_753;
+
+    GreenGoodsENS public ens;
+
+    address public owner;
+    address public l1Receiver;
+    address public gardenToken;
+    address public member;
+    address public nonMember;
+
+    uint256 public protocolHatId;
+
+    function _tryFork() internal returns (bool) {
+        string memory rpc;
+        try vm.envString("SEPOLIA_RPC_URL") returns (string memory value) {
+            rpc = value;
+        } catch {
+            try vm.envString("SEPOLIA_RPC") returns (string memory fallback_) {
+                rpc = fallback_;
+            } catch {
+                return false;
+            }
+        }
+        if (bytes(rpc).length == 0) return false;
+
+        vm.createSelectFork(rpc);
+        return true;
+    }
+
+    function _deployENSOnFork() internal {
+        owner = address(this);
+        l1Receiver = makeAddr("l1Receiver");
+        gardenToken = makeAddr("gardenToken");
+        member = makeAddr("member");
+        nonMember = makeAddr("nonMember");
+
+        (bool ok, bytes memory data) =
+            HATS_PROTOCOL.call(abi.encodeWithSignature("mintTopHat(address,string,string)", owner, "ENS Test", ""));
+        require(ok, "mintTopHat failed");
+        uint256 topHat = abi.decode(data, (uint256));
+
+        (ok, data) = HATS_PROTOCOL.call(
+            abi.encodeWithSignature(
+                "createHat(uint256,string,uint32,address,address,bool,string)",
+                topHat,
+                "Protocol Members",
+                uint32(100),
+                address(0xdead),
+                address(0xdead),
+                true,
+                ""
+            )
+        );
+        require(ok, "createHat failed");
+        protocolHatId = abi.decode(data, (uint256));
+
+        (ok,) = HATS_PROTOCOL.call(abi.encodeWithSignature("mintHat(uint256,address)", protocolHatId, member));
+        require(ok, "mintHat failed");
+
+        ens = new GreenGoodsENS(CCIP_ROUTER, SEPOLIA_CHAIN_SELECTOR, l1Receiver, HATS_PROTOCOL, protocolHatId, owner);
+        ens.setAuthorizedCaller(gardenToken, true);
+    }
+
+    function _mockCcipSend() internal {
+        vm.mockCall(
+            CCIP_ROUTER, abi.encodeWithSelector(IRouterClient.ccipSend.selector), abi.encode(bytes32("mock-message-id"))
+        );
+    }
+
+    function test_forkDeploy_ccipRouterIsDeployed() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+        assertGt(CCIP_ROUTER.code.length, 0, "CCIP Router should be deployed on Sepolia");
+    }
+
+    function test_forkDeploy_hatsProtocolIsDeployed() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+        assertGt(HATS_PROTOCOL.code.length, 0, "Hats Protocol should be deployed on Sepolia");
+    }
+
+    function test_forkDeploy_ensInitializesWithRealInfra() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+
+        _deployENSOnFork();
+
+        assertEq(address(ens.CCIP_ROUTER()), CCIP_ROUTER);
+        assertEq(ens.ETHEREUM_CHAIN_SELECTOR(), SEPOLIA_CHAIN_SELECTOR);
+        assertEq(address(ens.HATS()), HATS_PROTOCOL);
+        assertEq(ens.protocolHatId(), protocolHatId);
+        assertEq(ens.l1Receiver(), l1Receiver);
+        assertEq(ens.owner(), owner);
+        assertTrue(ens.authorizedCallers(gardenToken));
+    }
+
+    function test_forkDeploy_feeEstimationReturnsNonZero() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+
+        _deployENSOnFork();
+
+        uint256 fee = ens.getRegistrationFee("test-garden", member, GreenGoodsENS.NameType.Gardener);
+        assertGt(fee, 0, "CCIP fee should be non-zero from real router");
+    }
+
+    function test_forkSlug_validSlugCachesCorrectly() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+
+        _deployENSOnFork();
+        _mockCcipSend();
+
+        string memory slug = "sepolia-garden";
+        address gardenAccount = makeAddr("gardenAccount");
+        uint256 fee = ens.getRegistrationFee(slug, gardenAccount, GreenGoodsENS.NameType.Garden);
+
+        vm.prank(gardenToken);
+        ens.registerGarden{ value: fee }(slug, gardenAccount);
+
+        bytes32 slugHash = keccak256(bytes(slug));
+        assertEq(ens.slugOwner(slugHash), gardenAccount);
+        assertEq(keccak256(bytes(ens.ownerToSlug(gardenAccount))), keccak256(bytes(slug)));
+        assertFalse(ens.available(slug));
+    }
+
+    function test_forkSlug_invalidSlugReverts() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+
+        _deployENSOnFork();
+        _mockCcipSend();
+
+        uint256 fee = 0.1 ether;
+
+        vm.prank(gardenToken);
+        vm.expectRevert(InvalidSlug.selector);
+        ens.registerGarden{ value: fee }("ab", makeAddr("g1"));
+
+        vm.prank(gardenToken);
+        vm.expectRevert(InvalidSlug.selector);
+        ens.registerGarden{ value: fee }("MyGarden", makeAddr("g2"));
+
+        vm.prank(gardenToken);
+        vm.expectRevert(InvalidSlug.selector);
+        ens.registerGarden{ value: fee }("my--garden", makeAddr("g3"));
+    }
+
+    function test_forkSlug_duplicateSlugReverts() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+
+        _deployENSOnFork();
+        _mockCcipSend();
+
+        string memory slug = "unique-garden";
+        uint256 fee = ens.getRegistrationFee(slug, makeAddr("g1"), GreenGoodsENS.NameType.Garden);
+
+        vm.prank(gardenToken);
+        ens.registerGarden{ value: fee }(slug, makeAddr("g1"));
+
+        vm.prank(gardenToken);
+        vm.expectRevert(NameTaken.selector);
+        ens.registerGarden{ value: fee }(slug, makeAddr("g2"));
+    }
+
+    function test_forkSlug_ownerAlreadyHasNameReverts() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+
+        _deployENSOnFork();
+        _mockCcipSend();
+
+        address sameOwner = makeAddr("sameOwner");
+        string memory slug1 = "first-name";
+        uint256 fee1 = ens.getRegistrationFee(slug1, sameOwner, GreenGoodsENS.NameType.Garden);
+
+        vm.prank(gardenToken);
+        ens.registerGarden{ value: fee1 }(slug1, sameOwner);
+
+        string memory slug2 = "second-name";
+        uint256 fee2 = ens.getRegistrationFee(slug2, sameOwner, GreenGoodsENS.NameType.Garden);
+
+        vm.prank(gardenToken);
+        vm.expectRevert(AlreadyHasName.selector);
+        ens.registerGarden{ value: fee2 }(slug2, sameOwner);
+    }
+
+    function test_forkAccess_nonAuthorizedCallerReverts() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+
+        _deployENSOnFork();
+        _mockCcipSend();
+
+        address unauthorized = makeAddr("unauthorized");
+        vm.deal(unauthorized, 1 ether);
+
+        vm.prank(unauthorized);
+        vm.expectRevert(NotAuthorizedCaller.selector);
+        ens.registerGarden{ value: 0.1 ether }("my-garden", makeAddr("garden"));
+    }
+
+    function test_forkAccess_nonMemberClaimNameReverts() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+
+        _deployENSOnFork();
+        _mockCcipSend();
+
+        vm.deal(nonMember, 1 ether);
+        vm.prank(nonMember);
+        vm.expectRevert(NotProtocolMember.selector);
+        ens.claimName{ value: 0.1 ether }("my-name");
+    }
+
+    function test_forkSlug_releaseFeeEstimationWorks() public {
+        if (!_tryFork()) {
+            emit log("SKIPPED: SEPOLIA_RPC_URL not set");
+            return;
+        }
+
+        _deployENSOnFork();
+
+        uint256 fee = ens.getReleaseFee("test-slug");
+        assertGt(fee, 0, "CCIP release fee should be non-zero from real router");
+    }
+}

--- a/packages/contracts/test/unit/GardenToken.t.sol
+++ b/packages/contracts/test/unit/GardenToken.t.sol
@@ -35,6 +35,29 @@ contract RevertingENSModule is IGreenGoodsENS {
     }
 }
 
+
+/// @title AcceptingENSModule
+/// @notice Mock ENS module that accepts registration and records the forwarded ETH
+contract AcceptingENSModule is IGreenGoodsENS {
+    uint256 public totalValueReceived;
+
+    function registerGarden(string calldata, address) external payable override {
+        totalValueReceived += msg.value;
+    }
+
+    function claimName(string calldata) external payable override { }
+    function claimNameSponsored(string calldata) external override { }
+    function releaseName() external payable override { }
+
+    function available(string calldata) external pure override returns (bool) {
+        return true;
+    }
+
+    function getRegistrationFee(string calldata, address, NameType) external pure override returns (uint256) {
+        return 0;
+    }
+}
+
 contract GardenTokenTest is Test, ERC6551Helper {
     GardenToken private gardenToken;
     address private multisig = address(0x123);
@@ -56,6 +79,8 @@ contract GardenTokenTest is Test, ERC6551Helper {
     event HatsModuleUpdated(address indexed oldModule, address indexed newModule);
     event KarmaGAPModuleUpdated(address indexed oldModule, address indexed newModule);
     event OctantModuleUpdated(address indexed oldModule, address indexed newModule);
+    event ENSRegistrationRefundQueued(address indexed minter, uint256 amount);
+    event ENSRegistrationRefundClaimed(address indexed minter, uint256 amount);
     event GardenMinted(
         uint256 indexed tokenId,
         address indexed account,
@@ -618,4 +643,63 @@ contract GardenTokenTest is Test, ERC6551Helper {
         // Verify ENS module is wired (confirms the code path was exercised)
         assertEq(address(gardenToken.ensModule()), address(revertingENS), "ENS module should be set");
     }
+
+    function test_mintGarden_ensFailureQueuesRefundAndClaimSucceeds() public {
+        _setHatsModule();
+
+        RevertingENSModule revertingENS = new RevertingENSModule();
+        vm.prank(multisig);
+        gardenToken.setENSModule(address(revertingENS));
+
+        GardenToken.GardenConfig memory config = _defaultConfig(address(mockToken));
+        config.slug = "refund-garden";
+
+        uint256 refundAmount = 0.05 ether;
+        vm.deal(multisig, 1 ether);
+
+        vm.prank(multisig);
+        vm.expectEmit(true, false, false, true);
+        emit ENSRegistrationRefundQueued(multisig, refundAmount);
+        gardenToken.mintGarden{ value: refundAmount }(config);
+
+        assertEq(gardenToken.failedENSRefunds(multisig), refundAmount, "refund should be queued");
+        assertEq(gardenToken.totalPendingENSRefunds(), refundAmount, "pending total should increase");
+
+        uint256 before = multisig.balance;
+        vm.prank(multisig);
+        vm.expectEmit(true, false, false, true);
+        emit ENSRegistrationRefundClaimed(multisig, refundAmount);
+        gardenToken.claimENSRefund();
+
+        assertEq(multisig.balance, before + refundAmount, "refund should be paid out");
+        assertEq(gardenToken.failedENSRefunds(multisig), 0, "refund credit should clear");
+        assertEq(gardenToken.totalPendingENSRefunds(), 0, "pending total should clear");
+    }
+
+    function test_mintGarden_ensSuccessDoesNotQueueRefund() public {
+        _setHatsModule();
+
+        AcceptingENSModule ens = new AcceptingENSModule();
+        vm.prank(multisig);
+        gardenToken.setENSModule(address(ens));
+
+        GardenToken.GardenConfig memory config = _defaultConfig(address(mockToken));
+        config.slug = "success-garden";
+
+        uint256 forwardedValue = 0.03 ether;
+        vm.deal(multisig, 1 ether);
+
+        vm.prank(multisig);
+        gardenToken.mintGarden{ value: forwardedValue }(config);
+
+        assertEq(ens.totalValueReceived(), forwardedValue, "value should be forwarded to ENS module");
+        assertEq(gardenToken.failedENSRefunds(multisig), 0, "no refund should be queued");
+    }
+
+    function test_claimENSRefund_revertsWithoutBalance() public {
+        vm.prank(multisig);
+        vm.expectRevert(GardenToken.NoENSRefundAvailable.selector);
+        gardenToken.claimENSRefund();
+    }
+
 }

--- a/packages/contracts/test/unit/GreenGoodsENS.t.sol
+++ b/packages/contracts/test/unit/GreenGoodsENS.t.sol
@@ -2,7 +2,7 @@
 pragma solidity >=0.8.25;
 
 import { Test } from "forge-std/Test.sol";
-import { GreenGoodsENS, NoWithdrawableBalance } from "../../src/registries/ENS.sol";
+import { GreenGoodsENS, NoWithdrawableBalance, InvalidCooldown } from "../../src/registries/ENS.sol";
 import { Client } from "@chainlink/contracts-ccip/contracts/libraries/Client.sol";
 
 /// @dev Mock CCIP Router that tracks sent messages
@@ -83,12 +83,15 @@ contract GreenGoodsENSTest is Test {
     event NameReleaseSent(bytes32 indexed messageId, string slug, address indexed previousOwner);
     event AuthorizedCallerUpdated(address indexed caller, bool authorized);
     event RefundFailed(address indexed recipient, uint256 amount);
+    event NameChangeCooldownUpdated(uint256 oldCooldown, uint256 newCooldown);
 
     function setUp() public {
         router = new MockCCIPRouter(MOCK_FEE);
         hats = new MockHats();
 
         ens = new GreenGoodsENS(address(router), ETH_CHAIN_SELECTOR, l1Receiver, address(hats), PROTOCOL_HAT_ID, owner);
+
+        assertEq(ens.nameChangeCooldown(), 30 days, "default cooldown should be 30 days");
 
         // Set gardenToken as authorized caller
         vm.prank(owner);
@@ -345,7 +348,7 @@ contract GreenGoodsENSTest is Test {
         assertEq(ens.available("alice"), false);
 
         // After cooldown, slug is available
-        vm.warp(block.timestamp + 30 days + 1);
+        vm.warp(block.timestamp + ens.nameChangeCooldown() + 1);
         assertEq(ens.available("alice"), true);
     }
 
@@ -363,6 +366,42 @@ contract GreenGoodsENSTest is Test {
         vm.prank(user2);
         vm.expectRevert(abi.encodeWithSignature("NameInCooldown()"));
         ens.claimName{ value: MOCK_FEE }("alice");
+    }
+
+    function test_SetNameChangeCooldown_OnlyOwner() public {
+        vm.prank(user1);
+        vm.expectRevert("Ownable: caller is not the owner");
+        ens.setNameChangeCooldown(7 days);
+    }
+
+    function test_SetNameChangeCooldown_ZeroReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(InvalidCooldown.selector);
+        ens.setNameChangeCooldown(0);
+    }
+
+    function test_SetNameChangeCooldown_UpdatesValueAndEmits() public {
+        vm.prank(owner);
+        vm.expectEmit(false, false, false, true);
+        emit NameChangeCooldownUpdated(30 days, 7 days);
+        ens.setNameChangeCooldown(7 days);
+
+        assertEq(ens.nameChangeCooldown(), 7 days);
+    }
+
+    function test_ReleaseName_UsesUpdatedCooldown() public {
+        vm.prank(owner);
+        ens.setNameChangeCooldown(1 days);
+
+        vm.deal(user1, 2 ether);
+        vm.prank(user1);
+        ens.claimName{ value: MOCK_FEE }("alice");
+
+        vm.prank(user1);
+        ens.releaseName{ value: MOCK_FEE }();
+
+        vm.warp(block.timestamp + 1 days + 1);
+        assertTrue(ens.available("alice"), "name should be available after updated cooldown");
     }
 
     // ═══════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation
- Add Sepolia fork coverage for the ENS/CCIP flows because only Arbitrum fork tests existed and Sepolia testnet coverage was missing. 
- Make the hardcoded 30-day name-change cooldown configurable to avoid needing a contract upgrade for policy adjustments. 
- Ensure ETH forwarded during garden ENS registration is recoverable when the L2→L1 ENS call fails so minters are not permanently out-of-pocket. 
- Document the L2→L1 CCIP ENS message flow and deployment sequencing for clarity during multi-chain deployments. 

### Description
- Added a Sepolia fork test suite at `test/fork/SepoliaENS.t.sol` which exercises router/hat presence, fee estimation, registration caching, and key revert paths while mocking `ccipSend` but using real `getFee` from the router. 
- Reworked `GreenGoodsENS` to replace the hardcoded cooldown with `nameChangeCooldown` (default `DEFAULT_NAME_CHANGE_COOLDOWN = 30 days`) and owner setter `setNameChangeCooldown(uint256)`, plus `NameChangeCooldownUpdated` event and unit tests in `test/unit/GreenGoodsENS.t.sol`. 
- Implemented a GardenToken refund mechanism by adding `failedENSRefunds` and `totalPendingENSRefunds`, queuing forwarded ETH when ENS registration reverts, adding `claimENSRefund()` to recover queued refunds, emitting `ENSRegistrationRefundQueued`/`ENSRegistrationRefundClaimed`, and updating storage gap accounting in `src/tokens/Garden.sol` with corresponding unit tests in `test/unit/GardenToken.t.sol`. 
- Documented the CCIP cross-chain ENS flow and deployment steps in `packages/contracts/README.md` and wired L2/L1 deployment guidance to the `script/deploy.ts` pattern. 

### Testing
- New unit and fork tests were added: `test/fork/SepoliaENS.t.sol`, updated `test/unit/GreenGoodsENS.t.sol` (cooldown tests), and updated `test/unit/GardenToken.t.sol` (ENS refund queue/claim and success-path); these were added but not executed in this environment. 
- Attempts to run the package test commands `bun run test` and `bun run test:fork` in `packages/contracts` failed in this environment because the `forge` binary (Foundry) is not installed, so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69940bfd7b008331817b90cbd421c803)