### PR TITLE
fix(client): correct notification icon paths in sw-custom.js

### DIFF
--- a/packages/client/public/sw-custom.js
+++ b/packages/client/public/sw-custom.js
@@ -60,8 +60,8 @@ self.addEventListener("message", (event) => {
     event.waitUntil(
       self.registration.showNotification("ENS Name Active", {
         body: `Your name ${slug}.greengoods.eth is now active!`,
-        icon: "/icons/icon-192x192.png",
-        badge: "/icons/icon-72x72.png",
+        icon: "/icon-192.png",
+        badge: "/images/android-icon-72x72.png",
         tag: `ens-complete-${slug}`,
         data: { url: "/profile", slug },
       })


### PR DESCRIPTION
## Summary
- The custom service worker referenced `/icons/icon-192x192.png` and `/icons/icon-72x72.png`, but the `/icons/` directory does not exist in `packages/client/public/`. ENS registration completion notifications rendered with broken icons.
- Fix: point `icon` at `/icon-192.png` (root) and `badge` at `/images/android-icon-72x72.png` (images subdirectory) — both verified present.

## Changes
`packages/client/public/sw-custom.js` — 2 lines changed.

## Test plan
- [ ] Build the client locally and trigger ENS registration
- [ ] Confirm the completion notification displays the Green Goods icon
- [ ] Verify Android badge renders (not a blank square)

Closes #449

---
Surfaced by the `gg-client-polish` routine (2026-04-16, Thursday performance audit). Implemented by Codex, committed + cherry-picked onto `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated notification icon and badge assets for ENS registration completion notifications to reference correct image paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->