### PR TITLE
refactor(shared,client): dedupe service worker registration

### DIFF
--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -5,6 +5,7 @@ import {
   DEFAULT_CHAIN_ID,
   initGlobalErrorHandlers,
   initTheme,
+  serviceWorkerManager,
   updateToasts,
   useServiceWorkerUpdate,
 } from "@green-goods/shared";
@@ -44,6 +45,11 @@ if (import.meta.env.DEV && import.meta.env.VITE_ENABLE_SW_DEV !== "true") {
         // ignore
       });
   }
+}
+
+// After VitePWA auto-registers the service worker, attach the background-sync shim.
+if (import.meta.env.PROD || import.meta.env.VITE_ENABLE_SW_DEV === "true") {
+  serviceWorkerManager.register();
 }
 
 /**

--- a/packages/shared/src/modules/app/service-worker.ts
+++ b/packages/shared/src/modules/app/service-worker.ts
@@ -30,7 +30,8 @@ class ServiceWorkerManager {
   }
 
   /**
-   * Register the service worker and set up sync capabilities
+   * Attach to the active service worker registration (registered by VitePWA)
+   * and set up message + controllerchange listeners for background sync.
    */
   async register(): Promise<boolean> {
     if (!this.isSupported) {
@@ -39,18 +40,15 @@ class ServiceWorkerManager {
     }
 
     try {
-      this.registration = await navigator.serviceWorker.register("/sw.js", {
-        scope: "/",
-      });
+      // VitePWA owns the actual navigator.serviceWorker.register() call.
+      // Wait for its registration to be active before attaching listeners.
+      this.registration = await navigator.serviceWorker.ready;
 
       // Set up message handler for background sync notifications
       navigator.serviceWorker.removeEventListener("message", this.boundMessageHandler);
       navigator.serviceWorker.removeEventListener("controllerchange", this.handleControllerChange);
       navigator.serviceWorker.addEventListener("message", this.boundMessageHandler);
       navigator.serviceWorker.addEventListener("controllerchange", this.handleControllerChange);
-
-      // Wait for service worker to be ready
-      await navigator.serviceWorker.ready;
 
       track("service_worker_registered", {
         scope: this.registration.scope,
@@ -201,34 +199,3 @@ class ServiceWorkerManager {
 
 // Export singleton instance
 export const serviceWorkerManager = new ServiceWorkerManager();
-
-// Auto-register service worker only in production, or when explicitly enabled for tests
-if (typeof window !== "undefined") {
-  const enableDevServiceWorker = (import.meta as any).env?.VITE_ENABLE_SW_DEV === "true";
-
-  if ((import.meta as any).env?.PROD || enableDevServiceWorker) {
-    serviceWorkerManager.register();
-  }
-
-  // In development (and when not explicitly enabled), ensure no SW interferes with HMR
-  if ((import.meta as any).env?.DEV && !enableDevServiceWorker && "serviceWorker" in navigator) {
-    // Best-effort cleanup: unregister existing SWs and clear caches
-    navigator.serviceWorker
-      .getRegistrations()
-      .then((registrations) => Promise.all(registrations.map((r) => r.unregister())))
-      .catch((error) => {
-        // Log but don't block - this is best-effort cleanup
-        logger.warn("[ServiceWorker] Failed to unregister existing workers", { error });
-      });
-    // Clear caches that could serve stale assets
-    if ("caches" in window) {
-      caches
-        .keys()
-        .then((keys) => Promise.all(keys.map((k) => caches.delete(k))))
-        .catch((error) => {
-          // Log but don't block - this is best-effort cleanup
-          logger.warn("[ServiceWorker] Failed to clear caches", { error });
-        });
-    }
-  }
-}


### PR DESCRIPTION
## Summary
The service worker was registered twice at startup — once by VitePWA (`injectRegister: "auto"` in `vite.config.ts`) and once by `serviceWorkerManager.register()` auto-called at module-import time from `packages/shared/src/modules/app/service-worker.ts`. Browser deduped the actual registration, but the startup path ran feature detection, `register()`, `ready`, listener setup, and PostHog tracking twice, and split PWA lifecycle ownership between two code paths (`useServiceWorkerUpdate` prompt flow vs. `handleControllerChange` hard reload).

**Option A**: keep VitePWA as the canonical registrar; convert `serviceWorkerManager` into a post-registration shim that attaches listeners to the active registration via `navigator.serviceWorker.ready`.

## Changes

### `packages/shared/src/modules/app/service-worker.ts`
- `register()` method now awaits `navigator.serviceWorker.ready` instead of calling `navigator.serviceWorker.register("/sw.js", ...)` itself — VitePWA owns actual registration.
- Docblock updated to describe "attach" semantics.
- Module-level side effects removed (both the PROD auto-registration *and* the DEV cleanup — the latter is already handled in `client/main.tsx`). Module is now pure on import; only side effect is the `serviceWorkerManager` singleton instance export.

### `packages/client/src/main.tsx`
- `serviceWorkerManager` added to existing `@green-goods/shared` import.
- Explicit fire-and-forget call `serviceWorkerManager.register()` gated by `PROD || VITE_ENABLE_SW_DEV`, placed after existing DEV-mode SW cleanup and before `createRoot().render()` — ensures `work-submission.ts` finds an active registration when it calls `requestBackgroundSync()`.

### Not touched
- `vite.config.ts` — `injectRegister: "auto"` unchanged (VitePWA stays canonical).
- `Auth.tsx` — `serviceWorkerManager.clearAllCaches()` unaffected.
- `work-submission.ts` — `requestBackgroundSync()` unaffected.
- `service-worker.test.ts` — only assertion is `getStatus()` shape, unaffected.

## Diff stats
2 files changed, 11 insertions(+), 38 deletions(-) — most of the delta is deletion of the module-level block.

## Validation performed
- `cd packages/client && bunx tsc --noEmit` → **passes**.
- `cd packages/shared && bunx tsc --noEmit` → 2 errors **pre-existing on main** in `src/hooks/yield/useGardenYieldSummary.ts` (`getGardenYieldAllocations` should be `getAllYieldAllocations`, and `queryKeys.gardenSummary` is missing). Confirmed on vanilla `origin/main`. **Unrelated to this PR** — logging as a follow-up.
- `cd packages/shared && bun run test -- service-worker` blocked in sandbox by network-only `node@20` download; not verified here. Run locally before merge.

## Test plan
- [ ] `bun run test -- service-worker` locally → passes
- [ ] Build client (`bun build`) and load the PWA in production mode
- [ ] DevTools → Application → Service Workers: exactly one `/sw.js` registration (same as before, but now via a single code path)
- [ ] Submit work while offline, come back online → `requestBackgroundSync()` fires and queue flushes
- [ ] Deploy a new build → `useServiceWorkerUpdate()` toast appears (not a hard reload)
- [ ] Sign out → `clearAllCaches()` still clears runtime caches and React Query IDB store

## Follow-up (separate PR)
Pre-existing tsc errors in `packages/shared/src/hooks/yield/useGardenYieldSummary.ts`:
- Line 4: `getGardenYieldAllocations` does not exist in `../../modules/data/yield-allocations` (likely renamed to `getAllYieldAllocations`)
- Line 36: `queryKeys.gardenSummary` is not defined

These should be fixed in a dedicated PR to avoid mixing concerns.

Closes #454

---
Surfaced by the \`gg-client-polish\` routine (2026-04-16, Thursday performance audit). Option A chosen by human review; implemented by Codex, committed + pushed from main.