### PR TITLE
metrics: week 2026-17 digest

### DIFF
--- a/docs/metrics/2026-17.md
+++ b/docs/metrics/2026-17.md
@@ -1,0 +1,141 @@
+# Week 2026-17 metrics digest
+
+_April 14 – 20, 2026 · Arbitrum One (42161)_
+
+## Calendar context
+
+No holidays. Heavy sync week: Stewards Sync, Capital Sync, Product Sync, Gardens Core, Regen Coordination Council. Artizen Frontier Fund Showcase (Apr 16). New contributor onboarded (Guilherme Ferreira, Apr 16). LA2050 $75K grant info session attended (Apr 20).
+
+## Growth
+
+| Metric | Total | WoW |
+|---|---|---|
+| Gardens (excl. root + test) | 15 | +1 (Greenpill Nigeria) |
+| Action templates | 23 | +0 |
+| Unique gardeners | 53 | — (no prior baseline) |
+| Unique operators | ~27 | — |
+| Unique evaluators | ~20 | — |
+
+**New garden:** Greenpill Nigeria (tokenID 16, Apr 19) — 1 operator, 2 gardeners, WETH vault created.
+
+**Prior week (W16):** 2 new gardens (Mama Gardens Apr 9, La Ligne Verte Apr 10).
+
+**Domain coverage** (across 15 live gardens): Education in 15, Agroforestry in 13, Waste in 10, Solar in 8.
+
+**Geographic spread:** Nigeria (3), Brazil (2), Venezuela, Côte d'Ivoire, Kenya, Thailand, Spain, Italy, South Africa, Taiwan, Canada, UK.
+
+## Vaults
+
+| Asset | Total deposited | Total withdrawn | Net balance | Funded vaults | Depositors |
+|---|---|---|---|---|---|
+| WETH | 7.46 ETH | 0.010 ETH | ~7.45 ETH | 12 | 28 |
+| DAI | 3,022 DAI | 250 DAI | ~2,772 DAI | 5 | 8 |
+
+**Largest vaults by DAI:** TAS HUB (~1,781 DAI net), GreenSofa (~462 DAI), Muizenberg (~344 DAI).
+
+**Largest vaults by WETH:** Growecosystems (~0.80 ETH), Muizenberg (~0.79 ETH), Rifai Sicilia (~0.75 ETH).
+
+**Week 17 vault events:** 1 (WITHDRAW: 250 DAI from TAS HUB, Apr 17, actor `0x0216…0a73`).
+**Week 16 vault events:** 0.
+
+Harvests: 0 (lifetime). Yield allocations: 0 (lifetime). Hypercerts minted: 0.
+
+## PostHog funnels
+
+**Not available.** The `POSTHOG_API_KEY` has insufficient scopes — it can only read feature flags and actions (both empty). It cannot access events, insights, funnels, dashboards, or person data.
+
+**Required scopes to fix:** `project:read`, `event_definition:read`, `query:read`, `insight:read`, `dashboard:read`. Regenerate the key in PostHog Settings → Personal API Keys.
+
+## On-chain trends
+
+- **Vault activity is slowing.** Most deposits occurred in weeks 8–12 (late Feb – mid Mar). Only 1 vault event this week (a 250 DAI withdrawal) vs. 0 last week. The bulk of deposits were made by 3–4 addresses seeding vaults across multiple gardens.
+- **Garden creation remains steady** at 1–2 per week since early March.
+- **No yield has been harvested** from any vault. The YieldSplitter contract has never been invoked. This may be expected if the Octant integration is not yet live, but worth tracking as the Octant proposal develops.
+- **No hypercerts minted.** The hypercerts module is deployed but unused.
+
+## Funding channel (Discord #funding)
+
+6 messages this week, all triaged 🚧 (in progress):
+
+| Opportunity | Source | Relevance |
+|---|---|---|
+| Artizen Bright Codes Fund for Earth Hackers S6 | Matty (Apr 14) | High — directly aligned with Green Goods mission |
+| AEOE Funding Opportunities | Afo (Apr 13) | Medium — education/outdoors/environment |
+| Burroughs Wellcome Fund — Climate & Health Seeds | Afo (Apr 13) | Medium — climate-health intersection |
+| DWeb Camp: Root Systems | Afo (Apr 16) | Low — event participation, not a grant |
+| 2 ChatGPT research threads | Afo (Apr 17) | Unknown — likely grant research |
+
+**Imminent grant deadlines** (from Drive tracker):
+- **LA2050 Part 1:** Apr 22 (up to $75K, fit 5/5) — info session attended today
+- **EF ESP RFP Hub:** Apr 23 (fit 5/5) — needs schema/API/governance proposal + 2 written data-source commitments
+- **ACTA Living Cultures:** Apr 27 ($10K, fit 5/5)
+- **CAC General Operating Support:** Apr 30 (up to $30K, fit 4/5)
+
+## Strategic context (from Drive)
+
+- **Octant partnership proposal** (6-month, mixed build-and-capital) is the primary strategic vehicle; iterated this week with solar/energy as centerpiece, education as anchor.
+- **Vaults now officially "Octant Vaults"** per Jam Session decision (Apr 15).
+- **Live garden count corrected** to 15 (test garden subtracted from 16).
+- **Website migration needed before Apr 24** (Charmverse shutting down).
+- **Q2 engineering priorities:** WhatsApp/SMS agent, RWA yield strategies, reputation badges (GreenWill).
+- **FTC Story Pack** prepared with current metrics for funder/partner presentations.
+
+## Dune query changes
+
+| Query | Status | Rationale |
+|---|---|---|
+| _none existing_ | — | Dune account has 0 queries; no `[routine]`-tagged queries to maintain |
+
+## Proposals (low-confidence, user decides)
+
+### 1. Create initial Dune `[routine]` queries
+
+The Dune API key is valid but owns zero queries. Proposed starter set for Arbitrum One (42161):
+
+**Query A: `[routine] Green Goods — Weekly Garden Growth`**
+```sql
+SELECT
+  date_trunc('week', block_time) AS week,
+  COUNT(*) AS new_gardens
+FROM arbitrum.logs
+WHERE contract_address = 0xe1Da335110b1ed48e7df63209f5D424d02276593  -- GardenToken
+  AND topic0 = 0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef  -- Transfer
+  AND topic1 = 0x0000000000000000000000000000000000000000000000000000000000000000  -- from zero (mint)
+GROUP BY 1
+ORDER BY 1 DESC
+```
+
+**Query B: `[routine] Green Goods — Weekly Vault Events`**
+```sql
+SELECT
+  date_trunc('week', block_time) AS week,
+  CASE
+    WHEN topic0 = <deposit_sig> THEN 'DEPOSIT'
+    WHEN topic0 = <withdraw_sig> THEN 'WITHDRAW'
+  END AS event_type,
+  COUNT(*) AS event_count
+FROM arbitrum.logs
+WHERE contract_address IN (
+  -- vault addresses from deployment artifacts
+  0x27f347a4c2851424730927526553bae5959ef8be,
+  0xab1b27db2cd372b4416d3cdbe38dd2b4d63ebf7a
+  -- ... (full list from indexer)
+)
+GROUP BY 1, 2
+ORDER BY 1 DESC
+```
+
+**Confidence: ~70%.** The exact event signatures and Dune table schema for Arbitrum need verification. Proposing rather than creating via API.
+
+### 2. Upgrade PostHog API key scopes
+
+The current key blocks all analytics data. Without it, this routine cannot report:
+- Onboarding → first action conversion funnels
+- Feature adoption metrics
+- User retention/cohort analysis
+
+Recommend regenerating the key with read-only scopes: `project:read`, `event_definition:read`, `query:read`, `insight:read`, `dashboard:read`, `person:read`.
+
+### 3. Track yield-split and hypercert activation
+
+Both YieldSplitter and HypercertMinter are deployed but have zero activity. As the Octant integration matures, consider adding a `[routine]` Dune query to monitor first usage and weekly distribution patterns.


### PR DESCRIPTION
## Summary

- First automated weekly metrics digest (`docs/metrics/2026-17.md`)
- Covers April 14–20, 2026 on Arbitrum One (42161)
- Data sourced from Envio indexer, Google Calendar, Google Drive, and Discord #funding

## Key findings

- **Gardens:** 15 live (+1 WoW — Greenpill Nigeria joined Apr 19)
- **Gardeners:** 53 unique, ~27 operators, ~20 evaluators
- **Vaults:** ~7.45 ETH + ~2,772 DAI net across 17 funded vaults; 1 event this week (250 DAI withdrawal from TAS HUB)
- **Yield/Hypercerts:** Both deployed but unused (0 harvests, 0 mints)
- **PostHog:** API key lacks scopes — funnel data unavailable
- **Dune:** Account has 0 queries — initial `[routine]` set proposed in digest

## Proposals (need human decision)

1. Create initial Dune `[routine]` queries (garden growth + vault activity)
2. Upgrade PostHog API key with read-only analytics scopes
3. Add yield-split / hypercert activation tracking once Octant integration goes live

## Anomalies

None meeting threshold criteria (no >40% action drop, no >50% vault swing, no Dune errors).

## Test plan

- [x] Digest file renders correctly as Markdown
- [ ] Verify vault balance figures against Arbiscan
- [ ] Confirm garden count matches admin dashboard

https://claude.ai/code/session_01QpFdewo3CrjbKHrptp3cMT