### PR TITLE
fix(shared,scripts): clear CodeQL ReDoS + dev-only TLS findings

### DIFF
--- a/packages/shared/src/modules/data/ipfs/client.ts
+++ b/packages/shared/src/modules/data/ipfs/client.ts
@@ -51,8 +51,18 @@ let pinataUploadSignUrl: string | null = null;
 let ipfsInitializationStatus: IpfsInitStatus = "not_started";
 let ipfsInitializationError: string | null = null;
 
+const SLASH_CODE = 47;
+
 export function trimTrailingSlashes(value: string): string {
-  return value.replace(/\/+$/, "");
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === SLASH_CODE) end--;
+  return end === value.length ? value : value.slice(0, end);
+}
+
+function trimLeadingSlashes(value: string): string {
+  let start = 0;
+  while (start < value.length && value.charCodeAt(start) === SLASH_CODE) start++;
+  return start === 0 ? value : value.slice(start);
 }
 
 // ============================================================================
@@ -105,11 +115,11 @@ export function setIpfsInitializationError(error: string | null): void {
 
 function normalizeOptionalUrl(value?: string | null): string | null {
   const trimmed = value?.trim();
-  return trimmed ? trimmed.replace(/\/+$/, "") : null;
+  return trimmed ? trimTrailingSlashes(trimmed) : null;
 }
 
 function joinUrl(baseUrl: string, path: string): string {
-  return `${baseUrl.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+  return `${trimTrailingSlashes(baseUrl)}/${trimLeadingSlashes(path)}`;
 }
 
 function normalizePinataUploadsApiUrl(value?: string | null): string {

--- a/packages/shared/src/public-contracts/index.ts
+++ b/packages/shared/src/public-contracts/index.ts
@@ -417,12 +417,12 @@ export function derivePublicGardenSlug(name: string | undefined, addressOrId: st
   const fallback = addressOrId.trim().toLowerCase();
   const trimmed = (name ?? "").trim();
   if (!trimmed) return fallback;
-  return (
-    trimmed
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "") || fallback
-  );
+  const slugified = trimmed.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  let start = 0;
+  while (start < slugified.length && slugified.charCodeAt(start) === 45) start++;
+  let end = slugified.length;
+  while (end > start && slugified.charCodeAt(end - 1) === 45) end--;
+  return slugified.slice(start, end) || fallback;
 }
 
 export function resolveFundGardenReference(

--- a/scripts/lib/dev-shared.js
+++ b/scripts/lib/dev-shared.js
@@ -99,8 +99,13 @@ const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
 
 export function requestUrl(url, timeoutMs = 2500) {
   const parsed = new URL(url);
-  const client = parsed.protocol === "https:" ? https : http;
-  const isLoopback = LOOPBACK_HOSTS.has(parsed.hostname);
+  if (parsed.protocol === "https:" && !LOOPBACK_HOSTS.has(parsed.hostname)) {
+    throw new Error(
+      `requestUrl is a dev-only probe and refuses non-loopback HTTPS targets: ${url}`,
+    );
+  }
+  const isHttps = parsed.protocol === "https:";
+  const client = isHttps ? https : http;
 
   return new Promise((resolve) => {
     let settled = false;
@@ -117,18 +122,21 @@ export function requestUrl(url, timeoutMs = 2500) {
       finish({ ok: false, url, error: `Timed out after ${timeoutMs}ms` });
     }, timeoutMs);
 
-    request = client.get(
-      {
-        hostname: parsed.hostname,
-        port: parsed.port,
-        path: parsed.pathname || "/",
-        ...(isLoopback ? { rejectUnauthorized: false } : {}),
-      },
-      (response) => {
-        response.resume();
-        finish({ ok: true, url, statusCode: response.statusCode });
-      },
-    );
+    const requestOptions = {
+      hostname: parsed.hostname,
+      port: parsed.port,
+      path: parsed.pathname || "/",
+    };
+    if (isHttps) {
+      // Loopback-only by the guard above. Dev servers (vite-plugin-mkcert)
+      // ship a per-session self-signed cert, so the smoke probe must accept it.
+      requestOptions.rejectUnauthorized = false;
+    }
+
+    request = client.get(requestOptions, (response) => {
+      response.resume();
+      finish({ ok: true, url, statusCode: response.statusCode });
+    });
     request.setTimeout(timeoutMs, () => {
       finish({ ok: false, url, error: `Timed out after ${timeoutMs}ms` });
     });

--- a/scripts/lib/dev-shared.js
+++ b/scripts/lib/dev-shared.js
@@ -95,9 +95,12 @@ export function majorVersion(version) {
  * `rejectUnauthorized: false` reliably — using the explicit options object
  * guarantees the TLS option is applied.
  */
+const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+
 export function requestUrl(url, timeoutMs = 2500) {
   const parsed = new URL(url);
   const client = parsed.protocol === "https:" ? https : http;
+  const isLoopback = LOOPBACK_HOSTS.has(parsed.hostname);
 
   return new Promise((resolve) => {
     let settled = false;
@@ -119,7 +122,7 @@ export function requestUrl(url, timeoutMs = 2500) {
         hostname: parsed.hostname,
         port: parsed.port,
         path: parsed.pathname || "/",
-        rejectUnauthorized: false,
+        ...(isLoopback ? { rejectUnauthorized: false } : {}),
       },
       (response) => {
         response.resume();


### PR DESCRIPTION
## Summary

Clears 5 of the 7 CodeQL high-severity alerts surfaced on PR #509 (release/1.1.0).

| Alert | Resolution |
|---|---|
| `js/polynomial-redos` × 4 — `ipfs/client.ts:55,108,112` and `public-contracts/index.ts:421` | Replace single-char `+` regex trims with imperative `charCodeAt` loops. Behavior identical, linear-time, no backtracking. |
| `js/disabling-certificate-validation` — `scripts/lib/dev-shared.js:122` | Gate `rejectUnauthorized: false` to loopback hosts (`localhost` / `127.0.0.1` / `::1`). Helper now refuses to skip TLS validation for non-loopback URLs. |

The remaining 2 alerts on PR #509 (`js/xss` in `ImageWithFallback.tsx`, `js/xss-through-dom` in `FileUploadField.tsx`) are pre-existing false positives — `ImageWithFallback` already whitelists `src` via `/^(https?:|data:image\/|\/|blob:)/i` and `FileUploadField` strips HTML meta-chars in `sanitizeFileName` before rendering through React JSX (auto-escaped). They will need a separate review pass to either dismiss or refactor for CodeQL traceability.

## Test plan

- [x] `bun run --cwd packages/shared test src/__tests__/public-contracts` — 9/9 passing
- [x] `bun run --cwd packages/shared test src/__tests__/modules/ipfs` — 11/11 passing
- [ ] CodeQL re-runs on this PR; expect 0 new alerts

## Follow-up

After merge, rebase `release/1.1.0` onto `develop` so PR #509 picks up these fixes and CodeQL re-runs there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)