### PR TITLE
fix(client): use homepage hero for social preview

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -12,11 +12,11 @@
     />
     <meta name="author" content="Green Goods" />
 
-    <meta property="og:image" content="%BASE_URL%social-image-v1-1.webp" />
-    <meta property="og:image:alt" content="Green Goods social preview with community garden imagery" />
+    <meta property="og:image" content="%BASE_URL%images/hero-home.webp" />
+    <meta property="og:image:alt" content="Green Goods homepage hero" />
     <meta property="og:image:type" content="image/webp" />
-    <meta property="og:image:width" content="1280" />
-    <meta property="og:image:height" content="675" />
+    <meta property="og:image:width" content="1672" />
+    <meta property="og:image:height" content="941" />
 
     <meta property="og:title" content="Green Goods" />
     <meta property="og:site_name" content="Green Goods" />
@@ -29,8 +29,8 @@
     <meta name="twitter:title" content="Green Goods" />
     <meta name="twitter:site" content="greengoodsapp" />
     <meta name="twitter:creator" content="time_is_oba" />
-    <meta name="twitter:image" content="%BASE_URL%social-image-v1-1.webp" />
-    <meta name="twitter:image:alt" content="Green Goods social preview with community garden imagery" />
+    <meta name="twitter:image" content="%BASE_URL%images/hero-home.webp" />
+    <meta name="twitter:image:alt" content="Green Goods homepage hero" />
     <link
       rel="apple-touch-icon"
       sizes="57x57"


### PR DESCRIPTION
## Summary
- Point Open Graph and Twitter social preview metadata at the homepage editorial hero image.
- Update recorded WebP dimensions and alt text to match the homepage hero asset.

## Validation
- [x] `bun run build` passes from `packages/client`
- [x] Branch pre-push checks passed with existing warnings only
