### PR TITLE
enable install app button if app is uninstalled from mobile

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -34,6 +34,8 @@ function envValue(key, fallback = "") {
   return process.env[key] || rootEnv[key] || fallback;
 }
 
+const viteEnableSwDev = envValue("VITE_ENABLE_SW_DEV", "false");
+
 module.exports = {
   apps: [
     {
@@ -99,7 +101,7 @@ module.exports = {
       cwd: ".",
       env: {
         NODE_ENV: "development",
-        VITE_ENABLE_SW_DEV: "false",
+        VITE_ENABLE_SW_DEV: viteEnableSwDev,
         VITE_DEV_CHAIN_MODE: "arbitrum_fork",
         VITE_CHAIN_ID: "42161",
         VITE_LOCAL_FORK_RPC_URL: "http://127.0.0.1:3009",

--- a/packages/client/src/__tests__/components/SiteHeader.test.tsx
+++ b/packages/client/src/__tests__/components/SiteHeader.test.tsx
@@ -135,6 +135,39 @@ describe("SiteHeader", () => {
     expect(screen.getAllByText("Open App").length).toBeGreaterThanOrEqual(1);
   });
 
+  it("renders Install App when mobile history says installed but the PWA is gone", () => {
+    mockUseApp.mockReturnValue({
+      isMobile: true,
+      isInstalled: false,
+      wasInstalled: true,
+      platform: "unknown",
+      deferredPrompt: null,
+      promptInstall: vi.fn(),
+    });
+    mockUseInstallGuidance.mockReturnValue({
+      scenario: "manual-install-available",
+      primaryAction: { type: "show-manual-steps", label: "Install App" },
+      secondaryAction: { type: "continue-in-browser", label: "Continue in Browser" },
+      browserInfo: { browser: "unknown" },
+      showBrowserOption: true,
+      manualInstructions: [
+        {
+          stepNumber: 1,
+          icon: "menu",
+          title: "Step 1",
+          description: "Open the browser menu.",
+        },
+      ],
+      browserSwitchReason: null,
+      openInBrowserUrl: null,
+    });
+
+    renderHeader();
+
+    expect(screen.getAllByText("Install App").length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText("Open App")).not.toBeInTheDocument();
+  });
+
   it("desktop install CTA opens the QR handoff dialog", () => {
     renderHeader();
     const desktopCta = screen.getByRole("button", { name: "Install App" });

--- a/packages/client/src/components/Public/PublicInstallAction.tsx
+++ b/packages/client/src/components/Public/PublicInstallAction.tsx
@@ -48,8 +48,7 @@ export function PublicInstallAction({ children, forceOpenApp = false }: PublicIn
   // the installed PWA from a desktop browser even if `getInstalledRelatedApps`
   // reports it as installed. Always show "Install App" + QR dialog on desktop.
   const isOpenApp =
-    forceOpenApp ||
-    (isMobile && (isInstalled || wasInstalled || guidance.primaryAction.type === "open-app"));
+    forceOpenApp || (isMobile && (isInstalled || guidance.primaryAction.type === "open-app"));
   const dataInstallAction = isOpenApp ? "open-app" : guidance.primaryAction.type;
   const label = formatMessage({
     id: isOpenApp ? "public.nav.openApp" : "public.nav.installApp",

--- a/packages/shared/src/__tests__/hooks/app/useInstallGuidance.test.ts
+++ b/packages/shared/src/__tests__/hooks/app/useInstallGuidance.test.ts
@@ -190,16 +190,17 @@ describe("hooks/app/useInstallGuidance", () => {
       expect(result.current.manualInstructions![0].icon).toBe("share");
     });
 
-    it("shows open-app as primary when wasInstalled is true", () => {
+    it("keeps reinstall guidance primary when wasInstalled is true but not currently installed", () => {
       mockDetect.mockReturnValue(safariBrowser);
       mockCanTrigger.mockReturnValue(false);
 
       const { result } = renderHook(() => useInstallGuidance("ios", false, true, null, true));
 
       expect(result.current.scenario).toBe("manual-install-available");
-      expect(result.current.primaryAction.type).toBe("open-app");
-      expect(result.current.secondaryAction?.type).toBe("show-manual-steps");
-      expect(result.current.secondaryAction?.label).toBe("Reinstall");
+      expect(result.current.primaryAction.type).toBe("show-manual-steps");
+      expect(result.current.primaryAction.label).toBe("Install App");
+      expect(result.current.secondaryAction?.type).toBe("continue-in-browser");
+      expect(result.current.secondaryAction?.label).toBe("Continue in Browser");
     });
 
     it("provides Android Chrome manual steps", () => {

--- a/packages/shared/src/hooks/app/useInstallGuidance.ts
+++ b/packages/shared/src/hooks/app/useInstallGuidance.ts
@@ -236,18 +236,20 @@ export function useInstallGuidance(
     // Manual installation available (Safari on iOS, or Android without prompt)
     const manualInstructions = getManualInstallSteps(platform, browserInfo.browser);
 
-    // User has already installed the PWA — primary CTA is "Open App", not "Install".
+    // A remembered install is not proof the PWA is still installed. Mobile browsers
+    // can keep local install history after the app is removed, so keep reinstall
+    // guidance available unless the current installed check confirms it is present.
     if (wasInstalled) {
       return {
         browserInfo,
         scenario: "manual-install-available",
         primaryAction: {
-          type: "open-app",
-          label: "Open App",
+          type: "show-manual-steps",
+          label: "Install App",
         },
         secondaryAction: {
-          type: "show-manual-steps",
-          label: "Reinstall",
+          type: "continue-in-browser",
+          label: "Continue in Browser",
         },
         showBrowserOption: true,
         manualInstructions,
@@ -365,18 +367,4 @@ function getManualInstallSteps(platform: Platform, browser: MobileBrowser): Manu
       description: 'Look for "Add to Home Screen" or "Install".',
     },
   ];
-}
-
-/**
- * Declaration for BeforeInstallPromptEvent (not in standard TS types)
- */
-declare global {
-  interface BeforeInstallPromptEvent extends Event {
-    readonly platforms: string[];
-    readonly userChoice: Promise<{
-      outcome: "accepted" | "dismissed";
-      platform: string;
-    }>;
-    prompt(): Promise<void>;
-  }
 }

--- a/packages/shared/src/providers/App.tsx
+++ b/packages/shared/src/providers/App.tsx
@@ -49,11 +49,6 @@ export interface AppDataProps {
   switchLanguage: (lang: Locale) => void;
 }
 
-interface BeforeInstallPromptEvent extends Event {
-  prompt: () => Promise<void>;
-  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
-}
-
 function getBrowserLocale(available: readonly string[], fallback: string): string {
   if (typeof navigator === "undefined") return fallback;
 

--- a/packages/shared/src/types/global.d.ts
+++ b/packages/shared/src/types/global.d.ts
@@ -22,6 +22,19 @@ declare global {
       "appkit-button": AppKitButtonElement;
     }
   }
+
+  /**
+   * Chromium PWA install prompt (not in standard DOM lib types).
+   * @see https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeinstallprompt_event
+   */
+  interface BeforeInstallPromptEvent extends Event {
+    readonly platforms: string[];
+    readonly userChoice: Promise<{
+      outcome: "accepted" | "dismissed";
+      platform: string;
+    }>;
+    prompt(): Promise<void>;
+  }
 }
 
 // Ensures file is treated as a module


### PR DESCRIPTION
## Summary

Fixes install app button not showing after user have uninstalled app from androib mobile


## Why

<!-- The motivation. Link to the issue, RFC, Linear reference, or funded-work scope. -->

Closes https://linear.app/greenpill-dev-guild/issue/PRD-502/after-uninstall-chrome-refuses-to-re-install-pwa-only-shows-open-the

## What changed

<!-- Bullet list of notable changes. Group by package or area if helpful. -->

- Removed wasInstalled check from showing install app button on PublicInstallActions
- Prefer .env over ecosystem.config.cjs to be able to enable serviceworkers in development mode
- Removed duplicated type declaration and created a global type for BeforeInstallPromptEvent
- ran format and linting

## Test plan

<!-- How did you verify this works? -->

- [ ] Install PWA app through browser landing page
- [ ] Uninstall it from your phone
- [ ] Refresh Browser page and check if app shows install app

## Risk and rollout

- **Risk level**: <!-- low / medium / high — touches deploy/contracts/auth/CI? -->
- **Rollout**: <!-- merge as-is / behind feature flag / staged rollout / requires migration -->
- **Backwards compatibility**: <!-- breaking? deprecation needed? -->

## Checklist

- [ ] CI is green (format, lint, tests, build)
- [ ] Conventional Commit message
- [ ] Tests added or updated for new behavior
- [ ] Docs updated if behavior changed
- [ ] Open-source-only dependencies
- [ ] No secrets, credentials, or `.env*` files committed
- [ ] If touching a high-risk path (deploy, contracts, auth, CI, security), I have requested a steward review

## Notes for reviewer

<!-- Anything else worth flagging — known limitations, follow-ups, design tradeoffs. -->
