### PR TITLE
fix(admin,shared): admin dashboard QA — scrollbar, media uploader, hypercerts query (PRD-559/511/513)

### DIFF
--- a/packages/admin/src/components/Garden/GardenSettingsEditor.stories.tsx
+++ b/packages/admin/src/components/Garden/GardenSettingsEditor.stories.tsx
@@ -1,6 +1,7 @@
 import type { Address } from "@green-goods/shared";
 import type { Meta, StoryObj } from "@storybook/react";
 import { withAdminIdentity } from "../../../../shared/.storybook/decorators";
+import { FIXTURE_IMAGE_BANNER } from "../../../../shared/.storybook/fixtures";
 import { GardenSettingsEditor } from "./GardenSettingsEditor";
 
 const GARDEN_ADDRESS = "0x1234567890123456789012345678901234567890" as Address;
@@ -30,7 +31,7 @@ const meta: Meta<typeof GardenSettingsEditor> = {
     docs: {
       description: {
         component:
-          "Real `GardenSettingsEditor` rendered against the Storybook mock wagmi connector and `DevAuthProvider`. The six underlying update mutations (`useUpdateGardenName`, `useUpdateGarden{Description,Location,BannerImage}`, `useSetOpenJoining`, `useSetMaxGardeners`) are wired but inert — clicking Save triggers the real mutation which fails silently against the mock transport. Render states (view / edit / read-only) reflect the live component.",
+          "Real `GardenSettingsEditor` rendered against the Storybook mock wagmi connector and `DevAuthProvider`. The banner field is an upload-to-IPFS control with a live preview (PRD-513); the other fields use inline `EditableField` save. The underlying update mutations (`useUpdateGardenName`, `useUpdateGarden{Description,Location,BannerImage}`, `useSetOpenJoining`, `useSetMaxGardeners`) are wired but inert — actions trigger the real mutation which fails silently against the mock transport. Render states (view / edit / read-only) reflect the live component.",
       },
     },
   },
@@ -71,5 +72,13 @@ export const EmptyFields: Story = {
       openJoining: false,
       maxGardeners: 0,
     },
+  },
+};
+
+// PRD-513: a saved banner renders as a live preview above the uploader, not as
+// a bare URL link. Read-only operators see the preview without the upload control.
+export const WithBannerImage: Story = {
+  args: {
+    garden: { ...POPULATED_GARDEN, bannerImage: FIXTURE_IMAGE_BANNER },
   },
 };

--- a/packages/admin/src/components/Garden/GardenSettingsEditor.tsx
+++ b/packages/admin/src/components/Garden/GardenSettingsEditor.tsx
@@ -3,10 +3,18 @@ import {
   Button,
   Card,
   cn,
+  FileUploadField,
   GARDEN_NAME_MAX_LENGTH,
+  GardenBannerFallback,
+  ImageWithFallback,
+  imageCompressor,
+  logger,
+  resolveIPFSUrl,
   Switch,
   Textarea,
   TextInput,
+  toastService,
+  uploadFileToIPFS,
   useSetMaxGardeners,
   useSetOpenJoining,
   useUpdateGardenBannerImage,
@@ -14,7 +22,7 @@ import {
   useUpdateGardenLocation,
   useUpdateGardenName,
 } from "@green-goods/shared";
-import { RiEditLine, RiLoader4Line, RiSaveLine } from "@remixicon/react";
+import { RiCloseLine, RiEditLine, RiLoader4Line, RiSaveLine } from "@remixicon/react";
 import { useState } from "react";
 import { useIntl } from "react-intl";
 
@@ -158,6 +166,142 @@ function EditableField({
   );
 }
 
+/**
+ * Banner image field with upload-to-IPFS + live preview (PRD-513).
+ *
+ * Replaces the prior text-only URL field, which rendered the saved value as a
+ * bare link with no preview, leaving operators unable to see the image they
+ * uploaded. Mirrors the create-flow uploader (`DetailsStep.handleBannerUpload`)
+ * and routes the on-chain write through `useUpdateGardenBannerImage`, which owns
+ * the loading/success toast and cache invalidation.
+ */
+function BannerImageField({
+  gardenAddress,
+  bannerImage,
+  gardenName,
+  canEdit,
+}: {
+  gardenAddress: Address;
+  bannerImage: string;
+  gardenName: string;
+  canEdit: boolean;
+}) {
+  const { formatMessage } = useIntl();
+  const updateBannerImage = useUpdateGardenBannerImage();
+  const [isUploading, setIsUploading] = useState(false);
+  // Optimistic preview: resolved URL of the image we just uploaded, shown
+  // immediately while the on-chain update confirms and re-indexes.
+  const [pendingPreview, setPendingPreview] = useState<string | null>(null);
+
+  const resolvedCurrent = bannerImage ? resolveIPFSUrl(bannerImage) : "";
+  const previewSrc = pendingPreview ?? resolvedCurrent;
+  const isPending = isUploading || updateBannerImage.isPending;
+
+  const handleUpload = async (files: File[]) => {
+    let file = files[0];
+    if (!file) return;
+
+    setIsUploading(true);
+    try {
+      if (imageCompressor.shouldCompress(file, 1024)) {
+        const result = await imageCompressor.compressImage(file, {
+          maxSizeMB: 0.8,
+          maxWidthOrHeight: 2048,
+        });
+        file = result.file;
+      }
+
+      const uploadResult = await uploadFileToIPFS(file);
+      const ipfsUrl = resolveIPFSUrl(uploadResult.cid);
+
+      setPendingPreview(ipfsUrl);
+      // Roll the optimistic preview back if the on-chain write fails, so the UI
+      // never contradicts the mutation's own error toast (sensitive write surface).
+      updateBannerImage.mutate(
+        { gardenAddress, value: ipfsUrl },
+        { onError: () => setPendingPreview(null) }
+      );
+    } catch (error) {
+      logger.error("Banner upload failed", { error, source: "GardenSettingsEditor" });
+      toastService.error({
+        title: formatMessage({
+          id: "app.garden.create.uploadFailed",
+          defaultMessage: "Upload failed",
+        }),
+        message: formatMessage({
+          id: "app.garden.create.uploadFailedMessage",
+          defaultMessage: "Could not upload banner image. Please try again.",
+        }),
+        context: "banner upload",
+        error,
+      });
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleRemove = () => {
+    setPendingPreview(null);
+    updateBannerImage.mutate({ gardenAddress, value: "" });
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <p className="label-xs text-text-soft">
+          {formatMessage({
+            id: "app.garden.create.bannerImageLabel",
+            defaultMessage: "Banner image",
+          })}
+        </p>
+        {canEdit && previewSrc ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={handleRemove}
+            disabled={isPending}
+            className="h-auto min-w-0 shrink-0 rounded-md px-1.5 py-1 text-text-soft hover:bg-bg-weak hover:text-text-strong"
+          >
+            {isPending ? (
+              <RiLoader4Line className="mr-1 h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RiCloseLine className="mr-1 h-3.5 w-3.5" />
+            )}
+            {formatMessage({ id: "app.common.remove", defaultMessage: "Remove" })}
+          </Button>
+        ) : null}
+      </div>
+
+      <div className="h-28 w-full overflow-hidden rounded-lg">
+        {previewSrc ? (
+          <ImageWithFallback
+            src={previewSrc}
+            alt={formatMessage({ id: "app.garden.detail.bannerAlt" }, { name: gardenName })}
+            className="h-28 w-full object-cover"
+            backgroundFallback={<GardenBannerFallback name={gardenName} />}
+          />
+        ) : (
+          <GardenBannerFallback name={gardenName} />
+        )}
+      </div>
+
+      {canEdit ? (
+        <FileUploadField
+          accept="image/*"
+          showPreview={false}
+          disabled={isPending}
+          helpText={formatMessage({
+            id: "app.garden.create.bannerImageHelp",
+            defaultMessage: "Upload a hero image showcasing the garden (optional)",
+          })}
+          onFilesChange={handleUpload}
+        />
+      ) : null}
+    </div>
+  );
+}
+
 export function GardenSettingsEditor({
   gardenAddress,
   garden,
@@ -169,7 +313,6 @@ export function GardenSettingsEditor({
   const updateName = useUpdateGardenName();
   const updateDescription = useUpdateGardenDescription();
   const updateLocation = useUpdateGardenLocation();
-  const updateBannerImage = useUpdateGardenBannerImage();
   const setOpenJoining = useSetOpenJoining();
   const setMaxGardeners = useSetMaxGardeners();
 
@@ -227,14 +370,10 @@ export function GardenSettingsEditor({
 
         <div className="border-t border-stroke-soft" />
 
-        <EditableField
-          label={formatMessage({
-            id: "app.garden.settings.bannerImage",
-            defaultMessage: "Banner Image URL",
-          })}
-          value={garden.bannerImage}
-          onSave={(v) => updateBannerImage.mutate({ gardenAddress, value: v })}
-          isPending={updateBannerImage.isPending}
+        <BannerImageField
+          gardenAddress={gardenAddress}
+          bannerImage={garden.bannerImage}
+          gardenName={garden.name}
           canEdit={canManage}
         />
 

--- a/packages/admin/src/index.css
+++ b/packages/admin/src/index.css
@@ -1522,6 +1522,34 @@
 .main-scroll-area {
   overflow-x: hidden;
   min-block-size: min(100%, var(--admin-main-content-min-height));
+  /* PRD-511: the primary content scroller must expose a draggable scrollbar.
+     The global `* { scrollbar-width: none }` + `*::-webkit-scrollbar { display: none }`
+     in @layer base intentionally strips scrollbar chrome from rails and sheets;
+     these unlayered rules win over @layer base and re-enable a thin, styled bar
+     here — including on webkit/Brave, where `scrollbar-width` has no effect. */
+  scrollbar-width: thin;
+  scrollbar-color: rgb(var(--neutral-400) / 0.6) transparent;
+}
+
+.main-scroll-area::-webkit-scrollbar {
+  width: 0.625rem;
+  height: 0.625rem;
+  display: block;
+}
+
+.main-scroll-area::-webkit-scrollbar-thumb {
+  background-color: rgb(var(--neutral-400) / 0.55);
+  background-clip: padding-box;
+  border: 2px solid transparent;
+  border-radius: 9999px;
+}
+
+.main-scroll-area::-webkit-scrollbar-thumb:hover {
+  background-color: rgb(var(--neutral-400) / 0.8);
+}
+
+.main-scroll-area::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 @media (max-width: 599px) {

--- a/packages/shared/src/__tests__/modules/data/hypercerts-fetch.test.ts
+++ b/packages/shared/src/__tests__/modules/data/hypercerts-fetch.test.ts
@@ -1,0 +1,52 @@
+/**
+ * getGardenHypercerts query-contract tests
+ *
+ * PRD-559 regression: the `GardenHypercerts` query must declare
+ * `$gardenId: String!` to match the indexer's `Hypercert.garden: String!`
+ * column. A prior `$gardenId: ID!` declaration was rejected by Hasura
+ * ("variable 'gardenId' is declared as 'ID!', but used where 'String' is
+ * expected") and broke garden hypercert loading on every garden the operator
+ * switched to. Mocked-client unit tests don't exercise the real GraphQL
+ * validator, so this test guards the query document string directly.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { queryMock } = vi.hoisted(() => ({ queryMock: vi.fn() }));
+
+vi.mock("../../../modules/data/graphql-client", () => ({
+  greenGoodsIndexer: { query: queryMock },
+  GQLClient: class GQLClient {
+    query = vi.fn();
+  },
+}));
+
+vi.mock("../../../modules/app/logger", () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { getGardenHypercerts } from "../../../modules/data/hypercerts-fetch";
+
+describe("getGardenHypercerts query contract (PRD-559 regression)", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    queryMock.mockResolvedValue({ data: { Hypercert: [] }, error: null });
+  });
+
+  it("declares $gardenId as String! to match the indexer's Hypercert.garden column", async () => {
+    await getGardenHypercerts("0xGardenAddress", 42161);
+
+    expect(queryMock).toHaveBeenCalledTimes(1);
+    const [query, variables, source] = queryMock.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+      string,
+    ];
+
+    // schema.graphql types Hypercert.garden as String!; ID! is rejected by Hasura.
+    expect(query).toMatch(/\$gardenId:\s*String!/);
+    expect(query).not.toMatch(/\$gardenId:\s*ID!/);
+    expect(variables).toMatchObject({ gardenId: "0xGardenAddress", chainId: 42161 });
+    expect(source).toBe("getGardenHypercerts");
+  });
+});

--- a/packages/shared/src/modules/data/hypercerts-fetch.ts
+++ b/packages/shared/src/modules/data/hypercerts-fetch.ts
@@ -160,7 +160,7 @@ export async function getHypercertFromSdkApi(
 // =============================================================================
 
 const GARDEN_HYPERCERTS_QUERY = /* GraphQL */ `
-  query GardenHypercerts($gardenId: ID!, $chainId: Int!, $limit: Int!) {
+  query GardenHypercerts($gardenId: String!, $chainId: Int!, $limit: Int!) {
     Hypercert(
       where: { garden: { _eq: $gardenId }, chainId: { _eq: $chainId } }
       order_by: { mintedAt: desc }


### PR DESCRIPTION
## Summary
Resolves three Admin Dashboard QA issues. Scoped to `packages/shared` and `packages/admin`.

- **PRD-559** (`shared`): the `GardenHypercerts` query declared `$gardenId: ID!` while the indexer types `Hypercert.garden: String!`, so Hasura rejected every garden's hypercerts load. Changed to `String!` and added a regression test that asserts the query document declares `String!` (mocked-client unit tests bypass the validator — which is how it shipped). Sweep confirmed isolated.
- **PRD-511** (`admin`): the dashboard content scroller had no visible scrollbar. A global `* { scrollbar-width: none }` + `*::-webkit-scrollbar { display: none }` in `@layer base` hid it. Added **unlayered** `.main-scroll-area` rules (`scrollbar-width: thin` + a `::-webkit-scrollbar` re-enable) that win over the layered global hide while keeping rails/sheets intentionally barless.
- **PRD-513** (`admin`): garden Settings rendered the banner image as a bare URL with no preview or upload. Replaced the text field with `BannerImageField` — live `ImageWithFallback` preview + `FileUploadField` (compress → IPFS → `useUpdateGardenBannerImage`, which owns the toast + cache), with optimistic-preview rollback on mutation error. Added a `WithBannerImage` story.

## Investigated — no code change
- **PRD-514**: verified in the Storybook canvas harness that the "Edit domains" control already opens the modal on `/garden/settings` — not a bug. The originally-proposed guard removal would have added a duplicate action (admin.mdx contract), so it was not applied. Recommend closing as not-reproducible.
- **PRD-508 / 510 / 512**: verify-only (see Linear) — 508 needs a live ≥2-garden switch; 510 is render-stable; 512 fills the screen at 1440px. **PRD-516** moved to Done.
- Deliberately did **not** wire the orphaned `GardenHeroBanner` into `/garden` (it restates the garden name the AppBar already owns — frontend-design Rule 17); surfacing the image on the overview is a separate IA decision.

## Validation
- `@green-goods/admin` tests: **437 passed** / 3 skipped
- `@green-goods/shared` tests: **3076 passed** / 1 skipped (incl. the new 559 regression test)
- admin build (tsc --noEmit + vite) ✓ · `check:stories` ✓ · `check:design-tokens` ✓ · `lint:vocab` ✓ · oxlint 0/0
- PRD-511 cascade proven in Brave/Chromium (layered global hide → 0px scrollbar; unlayered re-enable → 11px visible)
- PRD-513 verified rendering a preview + uploader in the real `CanvasLayout` harness

Linear: PRD-559, PRD-511, PRD-513 (508/509/510/512/514/516 also triaged with findings comments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)