### PR TITLE
chore(dev): local-dev tooling + Sentry env schema and docs

### DIFF
--- a/.dev-surfaces/skills/dev-surface/SKILL.md
+++ b/.dev-surfaces/skills/dev-surface/SKILL.md
@@ -27,13 +27,18 @@ Expected ports:
 - `3008`: indexer Postgres
 - `3009`: Anvil Arbitrum fork
 
-Local chain mode defaults to Arbitrum fork mode. For transaction QA, add RPC `http://127.0.0.1:3009` with chain id `42161` to a dedicated dev browser wallet and use an Anvil-funded private key from the Anvil logs. Mock-auth URLs do not sign transactions.
+Local chain mode defaults to Arbitrum fork mode. For transaction QA, add RPC `http://127.0.0.1:3009` with chain id `42161` to a dedicated dev browser wallet and use an Anvil-funded private key from `packages/contracts/.generated/runtime/arbitrum-fork.json`. The launcher silences Anvil startup output and redacts the fork endpoint in that generated file so provider credentials do not appear in logs. Mock-auth URLs do not sign transactions.
 
 After `bun run dev` is up, run `bun run dev:smoke:full` for a current
 full-local proof. It checks both client presentations, admin, docs, Storybook,
 local agent `/health`, Anvil chain id `42161`, deployed Arbitrum bytecode on the
 fork, funded Anvil accounts, local Envio/Hasura GraphQL, local indexer service
-health, and the Postgres TCP listener. It never submits transactions.
+health, and the Postgres TCP listener. The Docker indexer is local
+infrastructure, but it mirrors the configured live networks; set
+`ENVIO_API_TOKEN` in the root `.env` when you need fresh catch-up and a passing
+indexer-lag proof. Without it, HyperSync can return `429 Too Many Requests` and
+the smoke should fail on lag instead of claiming the local mirror is current. It
+never submits transactions.
 
 For production-backed local review, use `bun run dev:prod` from the repo root.
 It starts the local client, admin, docs, and Storybook against Arbitrum One, the

--- a/.env.schema
+++ b/.env.schema
@@ -217,10 +217,13 @@ SENTRY_ORG=greenpill
 SENTRY_AGENT_PROJECT=green-goods-agent
 SENTRY_CLIENT_PROJECT=green-goods-client
 SENTRY_ADMIN_PROJECT=green-goods-admin
+SENTRY_PROJECT=
 # @type=boolean
 SENTRY_ENABLED=true
 # @type=number
 SENTRY_TRACES_SAMPLE_RATE=0.05
+# @public
+VITE_SENTRY_DSN=if($SENTRY_DSN_OP_REF, op($SENTRY_DSN_OP_REF), '')
 # @public
 VITE_SENTRY_CLIENT_DSN=if($SENTRY_CLIENT_DSN_OP_REF, op($SENTRY_CLIENT_DSN_OP_REF), '')
 # @public

--- a/.env.template
+++ b/.env.template
@@ -205,10 +205,13 @@ SENTRY_ORG=greenpill
 SENTRY_AGENT_PROJECT=green-goods-agent
 SENTRY_CLIENT_PROJECT=green-goods-client
 SENTRY_ADMIN_PROJECT=green-goods-admin
+SENTRY_PROJECT=
 # @type=boolean
 SENTRY_ENABLED=true
 # @type=number
 SENTRY_TRACES_SAMPLE_RATE=0.05
+# @public
+VITE_SENTRY_DSN=
 # @public
 VITE_SENTRY_CLIENT_DSN=
 # @public

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Green Goods is an offline-first platform for documenting ecological and social w
 
 ### Prerequisites
 
-Install **Node.js 22+** and **Git**. Install **Docker Desktop** if you plan to run the full stack or indexer locally. Node includes `npm`, and `npm run setup` installs Bun automatically if it is missing.
+Install **Node.js 22+** and **Git**. Install **OrbStack or Docker Desktop** if you plan to run the full stack or indexer locally. Node includes `npm`, and `npm run setup` installs Bun automatically if it is missing.
 
 **Optional tools:** Foundry is needed for contract work. `cloudflared` is useful for mobile-device PWA testing. macOS and Linux are supported natively; use WSL2 or a dev container on Windows.
 
@@ -97,11 +97,13 @@ dev launch green-goods:anvil
 ```
 
 For fork-mode transaction testing, use a dedicated dev browser profile and a
-disposable wallet. Import an Anvil-funded account from
-`dev logs green-goods:anvil-arbitrum`, configure that wallet to use
-`http://127.0.0.1:3009` on chain `42161`, and never use a real everyday wallet
-profile with Anvil keys. `?mockAuth=operator` is only a UI state override; it
-does not sign transactions.
+disposable wallet. The Arbitrum fork launcher keeps Anvil startup output quiet
+so fork RPC credentials do not appear in logs; local test-account details are
+written to `packages/contracts/.generated/runtime/arbitrum-fork.json` with the
+fork endpoint redacted. Import one of those local-only accounts, configure that
+wallet to use `http://127.0.0.1:3009` on chain `42161`, and never use a real
+everyday wallet profile with Anvil keys. `?mockAuth=operator` is only a UI state
+override; it does not sign transactions.
 
 ### Testing
 
@@ -113,7 +115,10 @@ bun run dev:smoke:full
 Run `bun run dev:smoke:web` after the browser stack is starting. Run
 `bun run dev:smoke:full` after `bun run dev` when you need proof that the
 browser surfaces, local agent, local indexer/Hasura/Postgres, and Arbitrum fork
-are all responding.
+are all responding. The local indexer stack mirrors the configured live
+networks into local Docker services, so reliable lag proof requires
+`ENVIO_API_TOKEN`; without it, HyperSync can rate-limit and the full smoke
+should fail on indexer lag instead of pretending the local mirror is current.
 
 ## Tech Stack
 
@@ -176,7 +181,8 @@ Fork-mode transaction testing uses wallet auth, not mock auth:
 3. Add a wallet network named `Green Goods Local Arbitrum Fork` with RPC
    `http://127.0.0.1:3009`, chain id `42161`, and currency symbol `ETH`.
 4. Import one disposable Anvil-funded account from
-   `dev logs green-goods:anvil-arbitrum`.
+   `packages/contracts/.generated/runtime/arbitrum-fork.json`; the fork
+   endpoint is redacted in that generated file.
 5. Connect that wallet in the app and sign normally.
 
 The fork uses the real Arbitrum deployment artifact, but writes are mined only
@@ -212,7 +218,10 @@ bun run dev:smoke:full
 This proves both client presentations, admin, docs, Storybook, local agent
 health, Anvil chain id `42161`, deployed Arbitrum bytecode on the fork, funded
 Anvil accounts, local Envio/Hasura GraphQL, local indexer service health, and
-the Postgres TCP listener. It does not submit transactions.
+the Postgres TCP listener. The indexer lag check proves the local read model is
+close enough to live configured chain state for review; set `ENVIO_API_TOKEN` in
+the root `.env` for reliable HyperSync catch-up. It does not submit
+transactions.
 
 #### Start production-backed local stack
 
@@ -286,12 +295,12 @@ the local indexer service, and indexer lag against live Arbitrum head; if it
 fails lag, the mirror is reachable but not caught up enough to trust for
 production-data review.
 
-`bun run dev:prod:mirror:health` requires `ENVIO_API_TOKEN` for reliable
-HyperSync catch-up. Without it, the containers can still become healthy, but
-the live mirror may stall or receive `429 Too Many Requests` from HyperSync and
-the mirror smoke should fail on indexer lag. Set `ENVIO_API_TOKEN` directly in
-the root `.env`, or set `ENVIO_API_TOKEN_OP_REF` in `.env.template` and run
-`bun run env:sync`.
+`bun run dev:health` and `bun run dev:prod:mirror:health` warn or fail clearly
+when `ENVIO_API_TOKEN` is missing for reliable HyperSync catch-up. Without it,
+the containers can still become healthy, but the local mirror may stall or
+receive `429 Too Many Requests` from HyperSync and smoke should fail on indexer
+lag. Set `ENVIO_API_TOKEN` directly in the root `.env`, or set
+`ENVIO_API_TOKEN_OP_REF` in `.env.template` and run `bun run env:sync`.
 
 Run the production checks on demand:
 

--- a/docs/docs/builders/getting-started.mdx
+++ b/docs/docs/builders/getting-started.mdx
@@ -42,7 +42,7 @@ Before cloning, install the tools the setup script cannot reliably provide:
 | --- | --- | --- | --- |
 | **Node.js** | 22+ | Running `npm run setup` and repo tooling | [nodejs.org](https://nodejs.org) |
 | **Git** | any | Cloning and contributing | [git-scm.com](https://git-scm.com) |
-| **Docker Desktop** | current stable | Full-stack and indexer development | [docker.com](https://www.docker.com/get-started/) |
+| **OrbStack or Docker Desktop** | current stable | Full-stack and indexer development | [orbstack.dev](https://orbstack.dev/) / [docker.com](https://www.docker.com/get-started/) |
 
 Node includes `npm`, which is enough to run the first setup command. `npm run setup` installs Bun automatically if it is missing, installs workspace dependencies, and prints the env-bootstrap commands to run next.
 
@@ -174,7 +174,10 @@ account:
 3. Add a custom wallet network named `Green Goods Local Arbitrum Fork`.
 4. Set RPC URL `http://127.0.0.1:3009`, chain id `42161`, and currency symbol
    `ETH`.
-5. Import one Anvil-funded account from the Anvil log output.
+5. Import one Anvil-funded account from
+   `packages/contracts/.generated/runtime/arbitrum-fork.json`. The launcher
+   keeps Anvil startup output quiet and redacts the fork endpoint in that file
+   so provider credentials do not appear in logs.
 6. Connect that wallet in the app and sign transactions normally.
 
 The fork uses the real Arbitrum deployment artifact, but every write is mined
@@ -209,6 +212,12 @@ bun run dev
 That includes the fork-backed app surfaces, agent, and Docker-backed indexer.
 For cross-repo orchestration, `dev launch green-goods` calls this same native
 repo command under workbench ownership.
+
+The Docker-backed indexer is local infrastructure, but it mirrors the configured
+live networks into local Postgres/Hasura. Set `ENVIO_API_TOKEN` in the root
+`.env` when you need reliable catch-up and a passing `bun run dev:smoke:full`
+indexer-lag proof; without it, HyperSync can return `429 Too Many Requests` and
+the smoke should fail rather than claim the local mirror is current.
 
 | PM2 process | Package | Default port |
 | --- | --- | --- |

--- a/docs/routines/README.md
+++ b/docs/routines/README.md
@@ -133,8 +133,11 @@ Sentry complements PostHog; it does not replace it. PostHog remains the product/
 | `SENTRY_CLIENT_PROJECT` | `green-goods-client` |
 | `SENTRY_ADMIN_PROJECT` | `green-goods-admin` |
 | `SENTRY_AGENT_PROJECT` | `green-goods-agent` |
+| `SENTRY_PROJECT` | Supported Sentry/Vercel integration project slug fallback; app-specific project vars win |
 | `VITE_SENTRY_CLIENT_DSN` | Preferred public browser DSN for the client/PWA |
 | `VITE_SENTRY_ADMIN_DSN` | Preferred public browser DSN for admin |
+| `VITE_SENTRY_DSN` | Supported generic Vite/browser DSN fallback |
+| `NEXT_PUBLIC_SENTRY_DSN` / `PUBLIC_SENTRY_DSN` | Supported compatibility aliases for Sentry/Vercel or framework-shaped public DSNs |
 | `SENTRY_CLIENT_DSN` | Supported Vercel/Sentry integration fallback for the client/PWA |
 | `SENTRY_ADMIN_DSN` | Supported Vercel/Sentry integration fallback for admin |
 | `SENTRY_DSN` | Supported Vercel project-scoped fallback for client/admin builds and agent runtime fallback |
@@ -143,9 +146,9 @@ Sentry complements PostHog; it does not replace it. PostHog remains the product/
 
 Browser builds never expose `SENTRY_AUTH_TOKEN`. The client and admin Vite configs read
 generic Sentry integration DSNs only at build time and inject them into the existing
-`VITE_SENTRY_*` runtime keys. Generic `SENTRY_DSN` is accepted only when the Vercel project ID
-or Vercel deployment hostname matches the known Green Goods client or admin project, so a
-repo-root secret cannot accidentally cross-wire the two browser apps.
+`VITE_SENTRY_*` runtime keys. The Vercel/Sentry integration's generic `SENTRY_DSN`
+is accepted directly by each package-specific Vite config, so linked Vercel projects do not
+need duplicate `VITE_` variables.
 
 Frontend source-map ownership is split today: PostHog source-map uploads run from GitHub
 Actions with `POSTHOG_CLI_TOKEN` plus the app-specific PostHog environment ID, while Vite

--- a/docs/routines/README.md
+++ b/docs/routines/README.md
@@ -147,8 +147,10 @@ Sentry complements PostHog; it does not replace it. PostHog remains the product/
 Browser builds never expose `SENTRY_AUTH_TOKEN`. The client and admin Vite configs read
 generic Sentry integration DSNs only at build time and inject them into the existing
 `VITE_SENTRY_*` runtime keys. The Vercel/Sentry integration's generic `SENTRY_DSN`
-is accepted directly by each package-specific Vite config, so linked Vercel projects do not
-need duplicate `VITE_` variables.
+is accepted by each package-specific Vite config only as a last-resort fallback, and only
+when `VERCEL_PROJECT_ID` matches that app's known Green Goods project — so a linked Vercel
+project picks up its DSN without duplicate `VITE_` variables, while a repo-root `SENTRY_DSN`
+cannot cross-wire the two browser apps.
 
 Frontend source-map ownership is split today: PostHog source-map uploads run from GitHub
 Actions with `POSTHOG_CLI_TOKEN` plus the app-specific PostHog environment ID, while Vite

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,6 +1,39 @@
 // Each Vite/Storybook/docs app now performs read-only port checks before start.
 // This repo-owned PM2 stack owns cleanup for root `bun run dev`.
 
+const fs = require("node:fs");
+const path = require("node:path");
+
+const rootEnv = parseRootEnv();
+
+function parseRootEnv() {
+  const envPath = path.join(__dirname, ".env");
+  if (!fs.existsSync(envPath)) return {};
+
+  const env = {};
+  for (const rawLine of fs.readFileSync(envPath, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) continue;
+
+    let value = match[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    env[match[1]] = value;
+  }
+  return env;
+}
+
+function envValue(key, fallback = "") {
+  return process.env[key] || rootEnv[key] || fallback;
+}
+
 module.exports = {
   apps: [
     {
@@ -120,11 +153,11 @@ module.exports = {
         ENVIO_PG_PORT: "3008",
         GREEN_GOODS_DEV_CHAIN_MODE: "arbitrum_fork",
         ARBITRUM_RPC_URL: "http://host.docker.internal:3009",
-        ENVIO_API_TOKEN: process.env.ENVIO_API_TOKEN || "",
+        ENVIO_API_TOKEN: envValue("ENVIO_API_TOKEN"),
         ENVIO_HYPERSYNC_CLIENT_TIMEOUT_MILLIS:
-          process.env.ENVIO_HYPERSYNC_CLIENT_TIMEOUT_MILLIS || "120000",
+          envValue("ENVIO_HYPERSYNC_CLIENT_TIMEOUT_MILLIS", "120000"),
         ENVIO_HYPERSYNC_CLIENT_MAX_RETRIES:
-          process.env.ENVIO_HYPERSYNC_CLIENT_MAX_RETRIES || "0",
+          envValue("ENVIO_HYPERSYNC_CLIENT_MAX_RETRIES", "0"),
       },
       merge_logs: true,
       autorestart: false, // Docker Compose handles its own restarts

--- a/packages/contracts/script/run-arbitrum-fork.sh
+++ b/packages/contracts/script/run-arbitrum-fork.sh
@@ -22,10 +22,71 @@ fi
 
 mkdir -p .generated/runtime
 
-exec anvil \
+PORT="${ANVIL_PORT:-3009}"
+CONFIG_OUT=".generated/runtime/arbitrum-fork.json"
+ANVIL_MNEMONIC="test test test test test test test test test test test junk"
+ANVIL_DERIVATION_PATH="m/44'/60'/0'/0/"
+
+echo "Starting Anvil Arbitrum fork on 127.0.0.1:${PORT} (chain id 42161; fork RPC redacted)."
+echo "Anvil startup output is silenced to avoid printing RPC credentials."
+echo "Local Anvil account details are written to ${CONFIG_OUT}; the fork endpoint is redacted there."
+
+cat > "$CONFIG_OUT" <<'JSON'
+{
+  "available_accounts": [
+    "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
+    "0x70997970c51812dc3a010c7d01b50e0d17dc79c8",
+    "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc",
+    "0x90f79bf6eb2c4f870365e785982e1f101e93b906",
+    "0x15d34aaf54267db7d7c367839aaf71a00a2c6a65",
+    "0x9965507d1a55bcc2695c58ba16fb37d819b0a4dc",
+    "0x976ea74026e726554db657fa54763abd0c3a0aa9",
+    "0x14dc79964da2c08b23698b3d3cc7ca32193d9955",
+    "0x23618e81e3f5cdf7f54c3d65f7fbc0abf5b21e8",
+    "0xa0ee7a142d267c1f36714e4a8f75612f20a79720"
+  ],
+  "private_keys": [
+    "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80",
+    "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d",
+    "0x5de4111afa1a4b94908f83103ebf1706367c2e68ca870fc3fb9a804cdab365a",
+    "0x7c852118294e51e653712a81e05800f419141751be58f605c371e15141b007a6",
+    "0x47e179ec197488593b187f80a00eb0da91f1b9d0b13f8733639f19c30a34926a",
+    "0x8b3a350cf5c34c9194ca85829a2df0ec3153be0318b5e2d3348e872092edffba",
+    "0x92db14e403b83dfe3df233f83dfa3a0d7096f21ca9b0d6d6b8d88b2b4ec1564e",
+    "0x4bbbf85ce3377467afe5d46f804f221813b2bb87f24d81f60f1fcdbf7cbf4356",
+    "0xdbda1821b80551c9d65939329250298aa3472ba22feea921c0cf5d620ea67b97",
+    "0x2a871d0798f97d79848a013d4936a73bf4cc922c825d33c1cf7073dff6d409c6"
+  ],
+  "endpoint": "[redacted]",
+  "chain_id": 42161,
+  "wallet": {
+    "mnemonic": "test test test test test test test test test test test junk",
+    "derivation_path": "m/44'/60'/0'/0/"
+  }
+}
+JSON
+
+anvil \
+  --silent \
   --fork-url "$RPC_URL" \
   --chain-id 42161 \
+  --mnemonic "$ANVIL_MNEMONIC" \
+  --derivation-path "$ANVIL_DERIVATION_PATH" \
   --accounts 10 \
   --balance 10000 \
-  --port "${ANVIL_PORT:-3009}" \
-  --config-out .generated/runtime/arbitrum-fork.json
+  --port "$PORT" &
+
+ANVIL_PID=$!
+
+cleanup() {
+  kill "$ANVIL_PID" 2>/dev/null || true
+  wait "$ANVIL_PID" 2>/dev/null || true
+}
+
+trap cleanup INT TERM EXIT
+
+wait "$ANVIL_PID"
+STATUS=$?
+
+trap - INT TERM EXIT
+exit "$STATUS"

--- a/packages/indexer/README.md
+++ b/packages/indexer/README.md
@@ -37,8 +37,9 @@ This runs:
 If you're on Linux or using the VS Code Dev Container:
 
 ```bash
-# Ensure Docker Desktop is running first
-open -a Docker  # macOS
+# Ensure OrbStack or Docker Desktop is running first
+open -a OrbStack  # macOS, if using OrbStack
+# or open -a Docker
 # Wait 30 seconds
 
 # Start the native indexer
@@ -118,7 +119,7 @@ After codegen, run `bun run setup-generated` to rebuild ReScript.
 
 - [Node.js (use v20 or newer)](https://nodejs.org/en/download/current)
 - [bun (use v1 or newer)](https://bun.sh)
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) - **Required** (script auto-starts it)
+- [OrbStack](https://orbstack.dev/) or [Docker Desktop](https://www.docker.com/products/docker-desktop/) - **Required** for the local indexer containers
 
 ### Environment Variables
 
@@ -130,14 +131,17 @@ The indexer automatically loads configuration from:
 
 **Indexer-relevant environment variables:**
 ```bash
-# Required for reliable live Arbitrum catch-up in prod-mirror mode.
+# Required for reliable live Arbitrum catch-up in default full-local and
+# prod-mirror mode.
 ENVIO_API_TOKEN=
 ```
 
-The root `.env` is automatically loaded by the indexer's Docker Compose setup and development scripts.
-Without `ENVIO_API_TOKEN`, the local mirror can start, but HyperSync may return
-`429 Too Many Requests` and the production mirror smoke should fail on indexer
-lag instead of pretending the mirror is current.
+The root `bun run dev` and `bun run dev:prod:mirror` scripts pass the root
+`.env` value into Docker Compose. If you run Docker Compose directly from this
+package, export `ENVIO_API_TOKEN` in that shell first. Without
+`ENVIO_API_TOKEN`, the local mirror can start, but HyperSync may return `429 Too
+Many Requests` and the full-local or production mirror smoke should fail on
+indexer lag instead of pretending the mirror is current.
 
 ### Entities (from `schema.graphql`)
 
@@ -170,8 +174,8 @@ Or directly run:
 ```
 
 **Manual Reset:**
-1. Restart Docker Desktop completely (Quit → Reopen)
-2. Wait for Docker to fully start (check menu bar icon)
+1. Restart OrbStack or Docker Desktop completely (Quit → Reopen)
+2. Wait for the Docker daemon to fully start (check the menu bar icon)
 3. Run the reset script or manually clean up:
    ```bash
    # Stop containers and remove volumes
@@ -220,5 +224,5 @@ bun run dev:manual
 ### Other Common Issues
 
 - **Port 8080 already in use**: Stop other services using port 8080 or change the port in Envio config
-- **Database connection issues**: Ensure Docker Desktop is running and containers are healthy
+- **Database connection issues**: Ensure OrbStack or Docker Desktop is running and containers are healthy
 - **Code generation failures**: Run `bun codegen` to regenerate after schema changes

--- a/scripts/agentic-browser-proof.mjs
+++ b/scripts/agentic-browser-proof.mjs
@@ -200,12 +200,7 @@ async function auditLlmsTxt(surface) {
   }
 }
 
-async function launchBrave() {
-  const braveBinary = findBraveBinary();
-  if (!braveBinary) {
-    throw new Error("No Brave binary found for browser proof. Install Brave or set GREEN_GOODS_BRAVE_BIN.");
-  }
-
+async function launchBrave(braveBinary) {
   const userDataDir = path.join(tmpdir(), `green-goods-agentic-browser-proof-${process.pid}`);
   const child = spawn(braveBinary, [
     "--headless=new",
@@ -512,11 +507,15 @@ async function verifyRoute(client, surface, route, width) {
 
 async function main() {
   ensureBuildOutputs();
+  const braveBinary = findBraveBinary();
+  if (!braveBinary) {
+    throw new Error("No Brave binary found for browser proof. Install Brave or set GREEN_GOODS_BRAVE_BIN.");
+  }
   rmSync(artifactDir, { recursive: true, force: true });
   mkdirSync(artifactDir, { recursive: true });
 
   const servedSurfaces = [];
-  const browser = await launchBrave();
+  const browser = await launchBrave(braveBinary);
   const client = new CdpClient(browser.wsUrl);
   const results = [];
   const llmsTxt = {};

--- a/scripts/dev/doctor.js
+++ b/scripts/dev/doctor.js
@@ -263,7 +263,7 @@ function checkTools() {
 
   if (options.profile === "full" || options.profile === "prod-mirror") {
     if (!commandExists("docker")) {
-      add("fail", "Docker not found", "Required for full-stack/indexer work.", "Install Docker Desktop or Docker Engine.", {
+      add("fail", "Docker not found", "Required for full-stack/indexer work.", "Install OrbStack, Docker Desktop, or Docker Engine.", {
         check: "tool:docker",
       });
     } else {
@@ -307,7 +307,7 @@ function checkDocker() {
       "fail",
       "Docker daemon is not running",
       "Full-stack/indexer work needs Docker.",
-      process.platform === "darwin" ? "Open Docker Desktop, then rerun bun run dev:doctor -- --profile full." : "",
+      process.platform === "darwin" ? "Open OrbStack or Docker Desktop, then rerun bun run dev:doctor -- --profile full." : "",
       { check: "docker-daemon" }
     );
   }
@@ -492,14 +492,14 @@ function checkEnv() {
     }
   } else if (options.profile === "full") {
     add(
-      hasEnvioApiToken ? "pass" : "info",
+      hasEnvioApiToken ? "pass" : "warn",
       hasEnvioApiToken ? "Envio API token configured" : "Envio API token not configured",
       hasEnvioApiToken
         ? "Token value was detected but not printed."
-        : "Not required for the default Anvil-backed full-local stack; required for the prod-mirror live-indexer path.",
+        : "The default stack can start without it, but the local Docker indexer mirrors live configured networks and may fall behind or receive HyperSync 429s without a token.",
       hasEnvioApiToken
         ? ""
-        : "Set ENVIO_API_TOKEN only when you need `bun run dev:prod:mirror` to keep up with live Arbitrum.",
+        : "Set ENVIO_API_TOKEN in root .env when you need `bun run dev:smoke:full` or `bun run dev:prod:mirror` to prove fresh indexer catch-up.",
       { check: "env:envio-api-token" }
     );
   }

--- a/scripts/dev/env-sync.js
+++ b/scripts/dev/env-sync.js
@@ -13,6 +13,7 @@
  */
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -23,11 +24,37 @@ const projectRoot = path.resolve(__dirname, "../..");
 const templatePath = path.join(projectRoot, ".env.template");
 const envPath = path.join(projectRoot, ".env");
 const backupPath = path.join(projectRoot, ".env.bak");
+const fallbackBackupPath = path.join(os.tmpdir(), `green-goods-env-${process.pid}.bak`);
 
 function fail(message, hint) {
   console.error(`error: ${message}`);
   if (hint) console.error(`  fix: ${hint}`);
   process.exit(1);
+}
+
+function backupEnv() {
+  if (!fs.existsSync(envPath)) return "";
+
+  try {
+    fs.copyFileSync(envPath, backupPath);
+    console.log(`Backed up existing .env to .env.bak`);
+    return backupPath;
+  } catch (error) {
+    try {
+      fs.copyFileSync(envPath, fallbackBackupPath);
+      console.warn(
+        `warning: could not write .env.bak in repo (${error.code || error.message}); backed up existing .env to ${fallbackBackupPath}`
+      );
+      return fallbackBackupPath;
+    } catch (fallbackError) {
+      fail(
+        "could not back up existing .env",
+        `${error.code || error.message}; fallback backup failed: ${
+          fallbackError.code || fallbackError.message
+        }`
+      );
+    }
+  }
 }
 
 if (!fs.existsSync(templatePath)) {
@@ -41,10 +68,7 @@ if (!fs.existsSync(templatePath)) {
 // but `op inject` itself triggers Touch ID via the 1Password desktop app integration.
 // Pre-checking would block the actual auth from happening.
 
-if (fs.existsSync(envPath)) {
-  fs.copyFileSync(envPath, backupPath);
-  console.log(`Backed up existing .env to .env.bak`);
-}
+const restorePath = backupEnv();
 
 console.log("Running `op inject` to resolve .env.template -> .env...");
 const inject = spawnSync("op", ["inject", "-i", templatePath, "-o", envPath, "--force"], {
@@ -53,13 +77,21 @@ const inject = spawnSync("op", ["inject", "-i", templatePath, "-o", envPath, "--
 });
 
 if (inject.status !== 0) {
-  if (fs.existsSync(backupPath)) {
-    fs.copyFileSync(backupPath, envPath);
-    console.error("Restored .env from .env.bak after op inject failure.");
+  if (restorePath && fs.existsSync(restorePath)) {
+    try {
+      fs.copyFileSync(restorePath, envPath);
+      console.error(`Restored .env from ${restorePath} after op inject failure.`);
+    } catch (error) {
+      console.error(
+        `warning: op inject failed and .env restore from ${restorePath} also failed: ${
+          error.code || error.message
+        }`
+      );
+    }
   }
   fail(
     "op inject failed",
-    "Check that every op://... reference in .env.template points to a valid Vault/Item/field."
+    "Check the 1Password desktop app integration and confirm every op://... reference in .env.template points to a valid Vault/Item/field."
   );
 }
 

--- a/scripts/dev/smoke-full.js
+++ b/scripts/dev/smoke-full.js
@@ -31,6 +31,7 @@ const LOCAL_INDEXER_SERVICE_HEALTH_URL = "http://127.0.0.1:3007/healthz";
 const LOCAL_POSTGRES_HOST = "127.0.0.1";
 const LOCAL_POSTGRES_PORT = 3008;
 const DEFAULT_MAX_INDEXER_LAG_BLOCKS = 2_000;
+const rootEnv = parseRootEnv();
 
 const services = [
   {
@@ -131,6 +132,34 @@ function parseArgs(argv) {
 }
 
 const options = parseArgs(process.argv.slice(2));
+
+function parseRootEnv() {
+  const envPath = path.join(projectRoot, ".env");
+  if (!fs.existsSync(envPath)) return {};
+
+  const env = {};
+  for (const rawLine of fs.readFileSync(envPath, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) continue;
+
+    let value = match[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    env[match[1]] = value;
+  }
+  return env;
+}
+
+function hasEnvioApiToken() {
+  return Boolean((process.env.ENVIO_API_TOKEN || rootEnv.ENVIO_API_TOKEN || "").trim());
+}
 
 async function waitForService(service, deadlineMs) {
   const attempts = [];
@@ -399,11 +428,14 @@ function checkIndexerLag(indexerResult) {
 
   const lagBlocks = Math.max(0, indexerResult.sourceBlock - indexerResult.progressBlock);
   if (lagBlocks > options.maxIndexerLagBlocks) {
+    const tokenHint = hasEnvioApiToken()
+      ? ""
+      : "; ENVIO_API_TOKEN is not configured, so HyperSync may rate-limit local catch-up";
     return {
       name: "local-indexer-lag",
       level: "fail",
       ready: false,
-      detail: `lag=${lagBlocks} blocks exceeds max=${options.maxIndexerLagBlocks}; source=${indexerResult.sourceBlock}; indexed=${indexerResult.progressBlock}`,
+      detail: `lag=${lagBlocks} blocks exceeds max=${options.maxIndexerLagBlocks}; source=${indexerResult.sourceBlock}; indexed=${indexerResult.progressBlock}${tokenHint}`,
     };
   }
 
@@ -415,24 +447,37 @@ function checkIndexerLag(indexerResult) {
   };
 }
 
-async function checkLocalIndexerService() {
-  const attempt = await requestUrl(LOCAL_INDEXER_SERVICE_HEALTH_URL, 5000);
-  if (attempt.ok) {
-    return {
-      name: "local-indexer-service",
-      level: "pass",
-      ready: true,
-      url: attempt.url,
-      statusCode: attempt.statusCode,
-    };
+async function checkLocalIndexerService(timeoutMs = options.timeoutMs) {
+  const deadlineMs = Date.now() + timeoutMs;
+  const attempts = [];
+
+  while (Date.now() < deadlineMs) {
+    const attempt = await requestUrl(LOCAL_INDEXER_SERVICE_HEALTH_URL, 5000);
+    attempts.push(attempt);
+    if (attempt.ok) {
+      return {
+        name: "local-indexer-service",
+        level: "pass",
+        ready: true,
+        url: attempt.url,
+        statusCode: attempt.statusCode,
+      };
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
+  const lastAttempt = attempts.at(-1);
   return {
     name: "local-indexer-service",
     level: "fail",
     ready: false,
-    url: attempt.url,
-    detail: attempt.error || `HTTP ${attempt.statusCode}`,
+    url: lastAttempt?.url || LOCAL_INDEXER_SERVICE_HEALTH_URL,
+    detail: lastAttempt?.error || `HTTP ${lastAttempt?.statusCode || "unknown"}`,
+    attempts: attempts.slice(-3).map((attempt) => ({
+      url: attempt.url,
+      error: attempt.error || `HTTP ${attempt.statusCode}`,
+    })),
   };
 }
 

--- a/scripts/dev/stack.js
+++ b/scripts/dev/stack.js
@@ -11,6 +11,7 @@
  *   node scripts/dev/stack.js client admin    # custom subset (any app name from ecosystem.config.cjs)
  */
 
+import fs from "node:fs";
 import net from "node:net";
 import path from "node:path";
 import { spawn } from "node:child_process";
@@ -24,6 +25,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, "../..");
 const ecosystem = require(path.join(projectRoot, "ecosystem.config.cjs"));
+const rootEnv = parseRootEnv();
 
 const allApps = ecosystem.apps || [];
 const validNames = new Set(allApps.map((app) => app.name));
@@ -32,6 +34,34 @@ const PRODUCTION_INDEXER_URL = "https://indexer.hyperindex.xyz/0bf0e0f/v1/graphq
 const PRODUCTION_AGENT_URL = "https://agent.greengoods.app";
 const LOCAL_INDEXER_URL = "http://localhost:3006/v1/graphql";
 const ARBITRUM_PUBLIC_RPC_URL = "https://arb1.arbitrum.io/rpc";
+
+function parseRootEnv() {
+  const envPath = path.join(projectRoot, ".env");
+  if (!fs.existsSync(envPath)) return {};
+
+  const env = {};
+  for (const rawLine of fs.readFileSync(envPath, "utf8").split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+
+    const match = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!match) continue;
+
+    let value = match[2].trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    env[match[1]] = value;
+  }
+  return env;
+}
+
+function envValue(key, fallback = "") {
+  return process.env[key] || rootEnv[key] || fallback;
+}
 
 const groups = {
   // `browser` waits on ports and opens tabs (PWA + website + admin + docs +
@@ -222,7 +252,7 @@ function productionProfileEnv(group, appName) {
       NODE_ENV: "development",
       GREEN_GOODS_STACK_PROFILE: group,
       GREEN_GOODS_DEV_CHAIN_MODE: "",
-      ARBITRUM_RPC_URL: process.env.ARBITRUM_RPC_URL || ARBITRUM_PUBLIC_RPC_URL,
+      ARBITRUM_RPC_URL: envValue("ARBITRUM_RPC_URL", ARBITRUM_PUBLIC_RPC_URL),
     };
   }
 


### PR DESCRIPTION
## Summary

Supporting-layer local-dev **tooling, env-contract, and docs** changes (the admin/client `vite.config` + admin `package.json` Sentry-DSN *consumers* already landed on `main` via #524). 14 files — **no app runtime or build source touched**.

- **Env contract** — `.env.schema` / `.env.template`: add `SENTRY_PROJECT` and `VITE_SENTRY_DSN` (empty in template; `op()`-guarded in schema). Both back consumers already on `main` (`vite.config` admin:29/167, client:32/390).
- **PM2 / dev tooling** — `ecosystem.config.cjs`, `scripts/dev/{stack,smoke-full}.js` now read the root `.env` (`process.env → .env → fallback`); `doctor.js` OrbStack hints + `ENVIO_API_TOKEN` `info→warn` (**full profile only**); `env-sync.js` gains a tmpdir backup fallback + try/catch restore around `op inject`.
- **Fork launcher** — `run-arbitrum-fork.sh`: silence Anvil and write a static accounts JSON with the fork **endpoint redacted** — fixes a leak where the old `--config-out` wrote the fork RPC URL (incl. any Alchemy key) into the generated file.
- **Browser proof** — `agentic-browser-proof.mjs`: hoist the Brave-binary null-check into `main()` (pure refactor).
- **Docs** — README / getting-started / routines / indexer / dev-surface: Docker → OrbStack, Anvil keys sourced from `arbitrum-fork.json`, expanded `ENVIO_API_TOKEN` guidance.

> ℹ️ The hardcoded private keys in `run-arbitrum-fork.sh` are the **public** Anvil/Hardhat `test…junk` mnemonic accounts (acct 0 = `0xf39Fd6…2266`) — not secrets. This change is a net credential-leak **fix**.

## Review & verification

Reviewed read-only against `origin/main`. Diff base = `main` (merge-base is `89f1b08c`'s parent, so this PR is exactly the 1 commit / 14 files). **Verdict: safe.**

**Green:** contracts build (`forge`) + **63 contract test suites**, agent tests (19/19), docs tests (27/0), shared test **cases** (2780 pass / 1 skip), `lint` (**0 errors**), and direct checks of all 14 changed files — `node --check` ×5, `bash -n`, `require(ecosystem.config.cjs)` ±`.env`, `envValue` precedence, smoke-full load-safety.

**Environmental, not from this change:** `bun build` stops at `build:indexer` (missing Envio `generated/` codegen — host Node-18/pnpm split); `bun run test` exits 1 from a transitive `@walletconnect/utils → uint8arrays` `exports`-resolution error during shared/client/admin suite *collection*, plus the same indexer codegen gap. None touch source in this PR — and `89f1b08c` changes no `package.json`, lockfile, or build/test-path source, so none can originate here.

**Verified statically, not executed** (out of scope for a read-only review): `run-arbitrum-fork.sh`'s `exec`→backgrounded-anvil+`trap`, `env-sync.js`'s `op inject` path, and the live PM2 stack.

**Findings:** one **LOW**, non-blocking — `docs/routines/README.md` Sentry paragraph says generic `SENTRY_DSN` is "accepted directly," dropping the "scoped to the matching Vercel project" nuance the code still enforces (`projectScopedSentryDsn`); its conclusion (linked Vercel projects don't need duplicate `VITE_` vars) is nonetheless correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
