### PR TITLE
chore: June Phase 0 foundation — contributor docs, staging flow, restore client E2E auth

### DIFF
--- a/.plans/reviews/2026-05-month-in-review.md
+++ b/.plans/reviews/2026-05-month-in-review.md
@@ -1,0 +1,117 @@
+# Green Goods — May 2026 Month in Review
+
+_Written 2026-05-30. Scope: code quality, tech debt, agentic development flow, software architecture. Lens: what May tells us about going from solo to team in June._
+
+## Thesis
+
+**Agentic velocity let one person ship roughly a quarter's worth of work in a month. Every structure that velocity outran is now the bottleneck to going from solo to team.** The code quality is genuinely good and the agentic foundation is a rare, durable asset. The gaps are not "broken code" — they are scaffolding the output outpaced: a review surface that exists but is bypassed, an E2E safety net that's switched off, env-thrash that lands in main history, plan sprawl, and an onboarding doc that already points at the wrong tracker. June's job is to **convert the agentic foundation into contributor leverage.**
+
+---
+
+## 1. The shape of May
+
+| Metric | Value |
+|---|---|
+| Commits (May 1–30) | **330** |
+| Net change | **+107,500 / −27,178** across **1,336 files** |
+| Authors | `contact@afolabi.info` ×322, `afo@greenpill.builders` ×8 — **~98%+ solo** |
+| PRs opened/merged | **~14** (#509–#528); most substantive work went **direct-to-branch** |
+
+**Per-package code churn (vs. 30 Apr baseline):**
+
+| Package | Files | +/− | Read |
+|---|---|---|---|
+| shared | 279 | +19,055 / −4,180 | The critical hook/logic layer — biggest churn, highest risk |
+| client | 188 | +16,230 / −4,228 | PWA + public editorial site rebuild |
+| admin | 180 | +11,981 / −3,426 | Design revamp Tier 1–6 |
+| agent | 55 | +6,003 / −1,322 | Idempotency, rate-limit, Sentry, Telegram, PostHog |
+| contracts | 56 | +3,435 / −1,343 | **Least churned — stable (good)** |
+| indexer | 14 | +418 / −76 | Light, bounded |
+
+**Headlines shipped:** v1.1.0 "Season One" launch (admin design revamp, PWA pre-release hardening, agent idempotency); conviction-voting + HypercertSignal pools + yield routing across contracts/shared/admin; public editorial website (SiteHeader, personas, glossary, eight-capitals, funding bridge); public endowment management; campaign cookie jars; Sentry observability across all surfaces; supply-chain guardrails + release-age gates; and a large investment in agentic dev infrastructure.
+
+---
+
+## 2. What we did genuinely well
+
+1. **The agentic foundation is the asset that makes scaling feasible.** 25 project skills, a `plan-hub.mjs` harness (with tests), 6 cron'd routines (bug-intake, health-watch, growth-pulse, qa-triage-pulse, pr-review), `drift-check`, `/qa-triage`, and the `ai-native-dev-workflow` framework (agent-run ledger, workflow scorecard, adversarial review, closeout gate, rule-feedback loop, pre-agent-max checklist, data-contract map, route/access matrix). Claude+Codex worktree orchestration is real and working. **Most solo projects never build this** — it's what makes a contributor handoff even thinkable.
+
+2. **Code quality is strong where it counts.** Honest, corrected numbers (raw greps were inflated by test/story files):
+   - `any` in **app** code: client **0**, admin **1**, agent **1**. Concentrated debt is **39 in `shared/src`** — mostly low-level event/EAS payload boundaries, not laziness.
+   - `console.*`: ~**10 real violations** in `shared/src` (the raw 26 includes READMEs and the `logger.ts` implementation itself). The "use `logger`, not console" rule is ~90% followed.
+   - **15** TODO/FIXME/HACK/XXX markers in 12 files across the whole tree. **6** `@ts-ignore`/`@ts-expect-error`. This is a clean codebase.
+
+3. **Test density in the critical layers is high.** contracts 507 test files, indexer 354, shared 259 unit + 79 stories, admin 117 stories. The contract and shared invariants are well-covered.
+
+4. **Design-system maturity.** Strict M3 anatomy, token-drift lint, vocab lint, DesignMD gates, Storybook story-quality checks — design is governed, not vibes.
+
+5. **Security/ops posture improved _within_ the month.** Sentry observability, supply-chain guardrails, release-age gates, CodeQL ReDoS/TLS cleanup, env via `op inject` (Varlock retired). The protocol is mostly deployed and stable on Arbitrum.
+
+---
+
+## 3. Where the velocity outran the scaffolding
+
+Each of these is the _same story_: output moved faster than the structure around it.
+
+1. **The review surface exists but is bypassed.** CI is comprehensive — 9 workflows on `push`/`pull_request` to `[main, develop]`, plus supply-chain guardrails — and Vercel is wired to all three browser surfaces (per-PR previews are its default). But **~14 PRs against 330 commits** means the dominant flow is direct-commit-to-`main`, so CI/preview validation runs **after** code is in the main line, reactively. The gate is built and largely unused. (`develop` has been dead since 05-13; the real flow is `main` + short-lived `claude/*`/`codex/*` worktrees that aren't in the push trigger at all.)
+
+2. **The E2E safety net is switched off.** **61 skip/fixme markers** in the Playwright suite, with a single root cause: **headless-auth** (passkey / account-abstraction injection doesn't persist in CI). Several were deferred "until v1.1.1." This is the one net a newcomer would lean on to refactor safely — and it's off.
+
+3. **Thrash lands in main history.** The Sentry sourcemap saga (~25 micro-commits on 05-27/28: "add temporary sentry proof script" → "remove temporary sentry proof script" → repeat), the service-worker cache saga (05-06), and the wallet-connect fix that was committed → reverted → re-landed as #527. These aren't preview-catchable: they're **env-parity** (Vercel/Sentry build vars) and **SW/cache** behavior that only manifests on the real production domain. The gap is **preview→production**, not the absence of preview.
+
+4. **WIP sprawl.** **9 active plans / 5 archived.** Several "active" plans are actually done (Sentry shipped, dialog-liquid-audit resolved, admin-dashboard-qa merged as #525). The plan lifecycle isn't closing — which is fine solo, but it's noise a second contributor can't navigate.
+
+5. **Monoliths are forming.** `CampaignCookieJarPanel.tsx` **2,115 lines**, `agent/src/api/server.ts` **1,497**, `agent/src/services/db.ts` **1,235**. The campaign cookie jar is also being **reframed as a Seasons primitive** — i.e. a large, recently-churned feature built on a concept that's still moving.
+
+6. **The onboarding doc already drifts.** `CONTRIBUTING.md` step 1 says "pick a scoped **GitHub issue**" — but the repo runs **Linear-as-truth** (GitHub Issues are explicitly not used for backlog). A contributor's literal first step is wrong.
+
+---
+
+## 4. The contributor gap is structural, not documentary
+
+The docs (CLAUDE.md, AGENTS.md, ONBOARDING, CONTRIBUTING, README — 1,136 lines) are decent. The blocker is the **operating model**, and a newcomer hits all four links of the chain at once:
+
+1. **No pickup-able units** — work lives in `.plans/` hubs and Linear initiatives, not in scoped, self-contained "good-first-issue" tickets a stranger can grab.
+2. **No review surface** — direct-commit means there's nothing to review, comment on, or learn the codebase's taste from.
+3. **No safety net** — the E2E net they'd rely on to make a first change without fear is disabled.
+4. **Wrong signpost** — the onboarding doc points at GitHub Issues; reality is Linear.
+
+You can't fix this by writing more docs. The model is solo-shaped; June has to reshape it.
+
+---
+
+## 5. Protocol polish (the contracts ask)
+
+Contracts were the least-churned package — that stability is a strength, not neglect. To "polish the protocol" in June:
+
+- **Resolve the zero-address subsystems on Arbitrum (42161):** `gardenerRegistry`, `gardenerAccountLogic`, `ensReceiver` are all `0x000…`. Decide per subsystem — ship it, or formally render "not available on this network" via `isGreenWillDeployed`-style gating **and document the gap as intentional** so it stops reading as a bug.
+- **Close the deferred security item:** GreenWill CEI (checks-effects-interactions) was deferred to v1.1.1; ADR-015 (self-call pattern) exists. Land it and close the release/1.1.0 audit loop.
+- **Lock the campaign → Seasons reframe** _before_ more code accretes on the 2,115-line panel.
+
+---
+
+## 6. June plan
+
+### Immediate (this week — genuinely actionable)
+
+1. **Reconcile `CONTRIBUTING.md` ↔ Linear** (and the hosted `docs.greengoods.app/builders` guide). Fix the "GitHub issue" → Linear signpost.
+2. **Turn on branch protection for `main`** — require a PR + passing checks. This makes the *already-built* CI/preview gate real with zero new infra.
+3. **Fix the headless-auth E2E blocker** (or quarantine cleanly with a tracked re-enable ticket). Restore the net before inviting anyone to touch the code.
+4. **Close stale plans** — archive Sentry, dialog-liquid-audit, admin-dashboard-qa; cut "active" to what's truly in-flight.
+5. **File ~5 scoped Linear "good-first-issue"-equivalents** — e.g. the ~10 `console.*`→`logger` cleanups in shared utils, one monolith-decomposition slice, one skipped-test re-enable, one zero-address gating task. Real, bounded, reviewable.
+
+### Structural themes (the month)
+
+- **Convert the agentic foundation into contributor leverage.** Finish `ai-native-dev-workflow` Week 6 retro (the only incomplete week). Promote the steps that caught real drift into ONBOARDING/CONTRIBUTING; cut the ceremonial ones. The ledger/scorecard becomes the "how we work with agents here" doc a new contributor reads first — this is the differentiator, lead with it.
+- **Close the preview→prod gap.** A pre-deploy env-contract parity check (production Vercel/Sentry vars validated against `.env.schema` before promotion) + a staging domain that exercises SW/cache. This is what actually kills the thrash class — previews never will.
+- **Decompose the monoliths.** `CampaignCookieJarPanel` (after the Seasons lock), `agent/server.ts`, `agent/db.ts`. Smaller files are also more reviewable — it compounds with the PR-gate change.
+- **Protocol closeout.** GreenWill CEI → v1.1.1; zero-address subsystem decisions; audit-follow-up loop closed.
+- **Make solo→team measurable.** Track four numbers monthly: % of substantive changes that went through a reviewed PR, % of E2E suite enabled, active-plan count, distinct-contributor count. If these don't move, the reshaping didn't take.
+
+---
+
+## 7. The one bet
+
+If only one thing happens in June: **turn on the PR gate + restore the E2E net.** Those two convert the existing — and genuinely excellent — CI/preview/agentic infrastructure from "solo-bypassed" into "contributor-ready." Everything else (monoliths, plan hygiene, protocol closeout) is downstream of having a real gate and a real net.
+
+The codebase isn't the problem. The operating model is solo-shaped, and May proved how much one person plus good agents can carry. June is about building the seams a second person can plug into — and the foundation to do it is already mostly built.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,11 +18,24 @@ bun run dev
 
 ## Contribution Flow
 
-1. Pick a scoped GitHub issue or discuss the change with maintainers first.
-2. Create a focused branch from the active base branch.
+1. Pick a scoped task from the Linear backlog (or discuss the change with maintainers first via Discord/Telegram). Green Goods tracks all work in Linear — GitHub is for PRs and code review only.
+2. Create a focused branch from `develop` (see [Branch Model](#branch-model) below).
 3. Keep the change inside the smallest sensible package boundary.
 4. Add or update tests when behavior changes.
-5. Open a pull request with what changed, why it changed, and how you validated it.
+5. Open a pull request into `develop` with what changed, why it changed, and how you validated it.
+
+## Branch Model
+
+Green Goods runs a **staging → production** flow:
+
+- **`develop`** is the integration/staging branch. Open your PRs here; merges to `develop` deploy to staging for validation.
+- **`main`** is production. Maintainers promote `develop → main` once changes are validated on staging.
+
+Branch from `develop` and PR into `develop`. Don't target `main` directly except for a documented hotfix.
+
+### PR gate
+
+Both branches are protected: a pull request with passing CI checks is required to merge. Maintainers keep an admin fast-path for docs/trivial/hotfix changes only. (Required reviewer approval turns on as the contributor base grows; until then, the passing-checks requirement is the gate — it already applies to every PR, including maintainers'.)
 
 ## Funding and Bounties
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -73,7 +73,7 @@ Your starter task: **set the repo up end-to-end and report back on the experienc
 
 1. Run through **Local Setup** above: `npm run setup` → `bun run dev:health` → `bun run dev` → `bun run dev:smoke:full`. That confirms client (`:3001`), admin (`:3002`), docs (`:3003`), Storybook (`:3004`), agent (`:3005`), local indexer/Hasura/Postgres (`:3006`-`:3008`), and the local Arbitrum fork (`:3009`) are healthy without submitting transactions. If the task intentionally needs production infrastructure, use `bun run dev:prod` instead; it keeps local browser surfaces on `:3001`-`:3004`, targets Arbitrum One and hosted production APIs, runs a read-only smoke, and allows real wallet-confirmed Arbitrum writes.
 2. Note every paper cut as you go — broken links, unclear steps, missing prereqs, env vars that weren't obvious, anything that made you pause.
-3. Drop the feedback into Telegram or open an issue tagged `onboarding`. Concrete observations beat vague ones (`docs/builders/getting-started step 3 didn't mention X` > `setup was confusing`).
+3. Drop the feedback into [Telegram](https://t.me/+N3o3_43iRec1Y2Jh) — concrete observations beat vague ones (`docs/builders/getting-started step 3 didn't mention X` > `setup was confusing`). Maintainers triage actionable items into the Linear backlog (GitHub Issues are disabled).
 
 <!-- INSTRUCTION FOR CLAUDE: A new teammate just pasted this guide for how the
 team uses Claude Code. You're their onboarding buddy — warm, conversational,

--- a/docs/docs/builders/ethereum-alignment.mdx
+++ b/docs/docs/builders/ethereum-alignment.mdx
@@ -264,7 +264,7 @@ This section links to ongoing updates, research, and community discussions about
 - Planned companion essay: "Beyond Crypto" — bringing Ethereum's promises to communities that need them most.
 
 :::note Contributing to this page
-This is a living document. If you've written about Green Goods' alignment with Ethereum's mission, or if you spot an area where we can strengthen our CROPS properties, open an issue or submit a PR. The alignment work belongs to the community, not to any single team.
+This is a living document. If you've written about Green Goods' alignment with Ethereum's mission, or if you spot an area where we can strengthen our CROPS properties, start a conversation in [Discord](https://discord.gg/greenpill) or submit a PR. The alignment work belongs to the community, not to any single team.
 :::
 
 ---

--- a/docs/docs/builders/how-to-contribute.mdx
+++ b/docs/docs/builders/how-to-contribute.mdx
@@ -5,7 +5,7 @@ slug: /builders/how-to-contribute
 sidebar_position: 2
 audience: developer
 owner: docs
-last_verified: 2026-04-27
+last_verified: 2026-05-30
 feature_status: Live
 source_of_truth:
   - AGENTS.md
@@ -28,16 +28,17 @@ Green Goods is open source and built by the [Greenpill Dev Guild](https://paragr
 
 ---
 
-## Starting Your First Issue
+## Picking Up Your First Task
 
-The best way to get started is to pick an issue from the [GitHub issue tracker](https://github.com/greenpill-dev-guild/green-goods/issues):
+Green Goods tracks all product work — bugs, ideas, polish, scoped tasks — in **Linear** (the Greenpill Dev Guild workspace). GitHub is for pull requests and code review only; the issue tracker is disabled by design.
 
-1. **Look for `good first issue` labels** — These are scoped, well-documented, and appropriate for newcomers
-2. **Comment on the issue** — Let the team know you're working on it to avoid duplicate effort
-3. **Read the relevant context files** — Each package has a `.claude/context/*.md` file explaining conventions and patterns
-4. **Set up your local environment** — Follow the [Getting Started](/builders/getting-started) guide
+To pick up your first piece of work:
 
-Issues are not open-ended bounties. Paid implementation work is grant-dependent, must be explicitly scoped with maintainers, and should be tied to clear acceptance criteria before work begins.
+1. **Say hello in [Discord](https://discord.gg/greenpill) or [Telegram](https://t.me/+N3o3_43iRec1Y2Jh)** — Tell a maintainer what you'd like to work on and ask for a scoped starter task. Maintainers track accepted work in Linear and will point you at something `good first issue`-sized.
+2. **Read the relevant context files** — Each package has a `.claude/context/*.md` file explaining conventions and patterns
+3. **Set up your local environment** — Follow the [Getting Started](/builders/getting-started) guide
+
+Work is not open-ended bounties. Paid implementation work is grant-dependent, must be explicitly scoped with maintainers, and should be tied to clear acceptance criteria before work begins.
 
 ### Understanding the codebase
 
@@ -76,6 +77,8 @@ Green Goods welcomes unpaid open-source contributions and clearly scoped funded 
 ---
 
 ## Making A Pull Request
+
+Green Goods uses a **`develop` (staging) → `main` (production)** flow: branch from `develop` and open your PR into `develop`. Maintainers promote `develop → main` for production releases. Both branches require a passing-CI pull request to merge.
 
 ### Branch naming
 
@@ -123,7 +126,7 @@ bun run build         # Build everything (respects dependency order)
 
 ### PR workflow
 
-1. **Create a branch** from `main` with the naming convention above
+1. **Create a branch** from `develop` with the naming convention above
 2. **Make your changes** — Keep PRs focused on a single concern
 3. **Run the quality gate** — All four commands must pass; use `bun run format` if formatting needs to be fixed
 4. **Push and create a PR** — Include a clear description of what and why

--- a/docs/docs/builders/specs/v1-0.mdx
+++ b/docs/docs/builders/specs/v1-0.mdx
@@ -1135,7 +1135,7 @@ This section assesses privacy risks and documents data handling practices.
 |---------|---------|
 | Telegram (per Garden) | Primary Gardener support |
 | Discord #green-goods-support | Secondary technical support |
-| GitHub Issues | Escalation with reproduction steps |
+| Linear (tracked escalations) | Escalation with reproduction steps |
 
 **Severity Definitions:**
 

--- a/docs/docs/reference/faq.mdx
+++ b/docs/docs/reference/faq.mdx
@@ -171,7 +171,7 @@ See [Developer Getting Started](../builders/getting-started).
 
 <QuickAnswer question="How do I contribute?">
 
-Open an issue or PR in GitHub and follow the developer docs in [Developer Hub](../builders/getting-started).
+Submit a pull request, or say hello in [Discord](https://discord.gg/greenpill) or [Telegram](https://t.me/+N3o3_43iRec1Y2Jh) — accepted work is tracked in Linear. Follow the developer docs in [Developer Hub](../builders/getting-started).
 
 </QuickAnswer>
 
@@ -181,7 +181,7 @@ Open an issue or PR in GitHub and follow the developer docs in [Developer Hub](.
 
 - Check connection.
 - Refresh and clear browser cache.
-- Confirm service availability in GitHub issues.
+- Confirm service availability in [Discord](https://discord.gg/greenpill).
 
 </QuickAnswer>
 
@@ -204,5 +204,5 @@ Open an issue or PR in GitHub and follow the developer docs in [Developer Hub](.
 ## Support
 
 - Telegram: [Join chat](https://t.me/+N3o3_43iRec1Y2Jh)
-- Bug reports: [GitHub Issues](https://github.com/greenpill-dev-guild/green-goods/issues)
-- Feature requests: [GitHub Discussions](https://github.com/greenpill-dev-guild/green-goods/discussions)
+- Discord: [Greenpill Dev Guild](https://discord.gg/greenpill) — questions & technical support
+- Bug reports & feature requests: raise them in Discord or Telegram — maintainers triage accepted items into the Linear backlog

--- a/docs/docs/reference/glossary-community.md
+++ b/docs/docs/reference/glossary-community.md
@@ -163,7 +163,7 @@ The full prompt-vocabulary client ban list (including `workbench row`, `inspecto
 1. **Adding a domain entity, persona, or surface**: edit the markdown table above and update the relevant Docusaurus pages that introduce the term. Entities also need a TypeScript type in `@green-goods/shared` and likely a contract or hook surface.
 2. **Adding a lint-enforced banned term**: edit `linter_enforced.terms` in [`banned-vocabulary.json`](https://github.com/greenpill-dev-guild/green-goods/blob/main/docs/docs/reference/banned-vocabulary.json), add a row to the table above, and run `bun run lint:vocab` to confirm the new term enforces. The bash regex rebuilds from the JSON automatically — do not edit the script's term list directly.
 3. **Adding an admin-only or client-only AI-prompt banned term**: edit the matching `prompt_vocabulary_*_banned` array in the JSON, add a row to the table above, and update the `§ Never Use` section in the matching prompt-contract.
-4. **Removing a term**: requires explicit design review — these are load-bearing for both human and AI consumers. Open an issue first; do not remove silently.
+4. **Removing a term**: requires explicit design review — these are load-bearing for both human and AI consumers. Raise it with maintainers first (Discord, tracked in Linear); do not remove silently.
 
 The glossary file and the JSON sidecar are siblings — if you edit one without the other, the cross-references break and the linter falls out of sync with the docs.
 

--- a/tests/helpers/test-utils.ts
+++ b/tests/helpers/test-utils.ts
@@ -208,6 +208,24 @@ export class ClientTestHelper {
   }
 
   /**
+   * Persist dev mock auth before the app boots (mirrors AuthGate / DevAuthProvider).
+   *
+   * Seeds the same sessionStorage key the app reads, so auth survives route
+   * changes and redirects without appending `?mockAuth=` to every navigation.
+   * Only active in dev mode — the Vite dev server the Playwright webServer runs;
+   * tree-shaken from production builds. Preferred over injectWalletAuth(), which
+   * depends on wagmi verifying a real connector and is flaky in headless CI.
+   */
+  async enableMockAuth(role: AdminMockRole = "user") {
+    await this.page.addInitScript(
+      ({ role, storageKey }) => {
+        window.sessionStorage.setItem(storageKey, role);
+      },
+      { role, storageKey: DEV_MOCK_AUTH_STORAGE_KEY }
+    );
+  }
+
+  /**
    * Navigate to login and create a new passkey account.
    *
    * Flow: Click "Sign Up" → Enter username → Click "Create Account"

--- a/tests/specs/client.work-submission.ci.spec.ts
+++ b/tests/specs/client.work-submission.ci.spec.ts
@@ -6,7 +6,7 @@
  *
  * Strategy:
  * - Mock GraphQL responses via page.route() to provide garden/action data
- * - Use wallet auth injection for authenticated state
+ * - Use the dev mock-auth seam (DevAuthProvider) for authenticated state
  * - Test form rendering, validation, and navigation — not actual transactions
  *
  * For full infrastructure tests, use: npx playwright test --project=client-full
@@ -43,7 +43,9 @@ const MOCK_ACTION = {
  */
 async function setupMockedEnvironment(page: import("@playwright/test").Page) {
   const helper = new ClientTestHelper(page);
-  await helper.injectWalletAuth();
+  // Dev mock-auth seam (DevAuthProvider) — reliable in the Vite dev server the
+  // Playwright webServer runs, unlike the legacy wagmi-storage injection.
+  await helper.enableMockAuth("user");
 
   // Intercept GraphQL requests to the indexer and return mock data
   await page.route("**/v1/graphql", async (route) => {
@@ -106,14 +108,9 @@ test.describe("Work Submission CI Tests", () => {
       await page.goto("/home");
       await helper.waitForPageLoad();
 
-      const url = page.url();
-      if (url.includes("/home/login")) {
-        // Auth injection may not persist in all environments
-        // This is expected in CI without real wallet extension
-        // SKIP: #312 owner:afo expiry:2026-06-01 — auth injection unstable in headless CI
-        test.skip(true, "Auth injection did not persist — expected in headless CI");
-        return;
-      }
+      // Dev mock-auth (DevAuthProvider) authenticates synchronously in the Vite
+      // dev server, so /home must not redirect to login (PRD-564).
+      expect(page.url()).not.toContain("/home/login");
 
       // Home page loaded — verify no critical errors
       const hasAppError = await page
@@ -140,12 +137,9 @@ test.describe("Work Submission CI Tests", () => {
       await page.goto("/home");
       await helper.waitForPageLoad();
 
-      const url = page.url();
-      if (url.includes("/home/login")) {
-        // SKIP: #312 owner:afo expiry:2026-06-01 — auth injection unstable in headless CI
-        test.skip(true, "Auth injection did not persist — expected in headless CI");
-        return;
-      }
+      // Dev mock-auth (DevAuthProvider) authenticates synchronously; no login
+      // redirect expected (PRD-564). Downstream skips below are data-shape gaps.
+      expect(page.url()).not.toContain("/home/login");
 
       // Navigate to a garden if garden cards are visible
       const gardenCard = page.locator('[data-testid="garden-card"], a[href*="/home/"]').first();


### PR DESCRIPTION
June maturation **Phase 0** foundation (PRD-563). Targets `main` — see base note.

## Changes
**Docs — contributor intake to Linear (0.1):** reconciles contributor/user-facing docs to Linear-as-truth (the GitHub issue tracker is disabled by design): how-to-contribute, CONTRIBUTING, ONBOARDING, faq, ethereum-alignment, glossary-community, v1-0 support table.

**Docs — staging flow (0.2):** documents the `develop` (staging) → `main` (production) branch model + PR gate.

**Test — restore client E2E auth seam (0.3, PRD-564):** adds `ClientTestHelper.enableMockAuth()` (mirrors the admin helper) seeding the `greengoods_dev_mock_auth` sessionStorage key the `AuthGate`/`DevAuthProvider` read, replacing the flaky `injectWalletAuth()` wagmi-storage injection. Auth-injection `test.skip` guards in `client.work-submission.ci.spec.ts` become assertions; data-shape skips left for follow-up per PRD-564.

Also adds the May 2026 month-in-review (`.plans/reviews/`).

## Validation
- Docs: grep-verified no contributor-facing GitHub-issue-tracker pickup instruction remains.
- E2E: verified in CI via the Playwright Client CI job (the webServer runs `dev:client`, so `import.meta.env.DEV` is true and the DevAuthProvider seam is active). Not run locally (worktree has no deps).

## Base note
Targets `main` because `develop` has diverged (3 unique commits, 90 behind main) and is not a clean staging base yet. Reconciling develop to main is a separate setup step that gates the documented staging flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)