### PR TITLE
ci(client,admin): fail prod build on unresolved Sentry DSN (env-parity gate)

### DIFF
--- a/packages/admin/vite.config.ts
+++ b/packages/admin/vite.config.ts
@@ -145,6 +145,21 @@ export default defineConfig(async ({ command, mode }): Promise<UserConfig> => {
   }
   const enableSourceMaps = shouldUploadSentrySourceMaps;
   const sentryDsn = resolveAdminSentryDsn();
+  // Env-parity gate (PRD-567): a production deploy must ship with a resolvable
+  // Sentry DSN, or error tracking silently no-ops — the May Sentry thrash. This
+  // reuses the value resolved above, so it only fires when Sentry would truly be
+  // dead. Fail closed on production; warn on other Vercel builds so staging
+  // surfaces the same gap without blocking non-prod deploys.
+  if (command === "build" && !sentryDsn) {
+    const detail =
+      "Sentry DSN did not resolve from any known alias (VITE_SENTRY_ADMIN_DSN, VITE_SENTRY_DSN, SENTRY_DSN via the Vercel integration, ...); error tracking would be disabled in this build.";
+    if (process.env.VERCEL_ENV === "production") {
+      throw new Error(`[env-parity] ${detail} Refusing to ship a production build without it.`);
+    }
+    if (process.env.VERCEL) {
+      console.warn(`[env-parity] ${detail} Staging should mirror production — set the DSN for this environment.`);
+    }
+  }
   const sentryRelease = `green-goods-admin@${shortAppVersion}`;
 
   // Dev-only plugin: serves admin's tunnel URL at /__dev/tunnel for QR-code testing

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -148,6 +148,23 @@ export default defineConfig(async ({ command, mode }) => {
   }
   const enableSourceMaps = shouldUploadSentrySourceMaps;
   const sentryDsn = resolveClientSentryDsn();
+  // Env-parity gate (PRD-567): a production deploy must ship with a resolvable
+  // Sentry DSN, or error tracking silently no-ops — the May Sentry thrash. This
+  // reuses the value resolved above, so it only fires when Sentry would truly be
+  // dead. Fail closed on production; warn on other Vercel builds so staging
+  // surfaces the same gap without blocking non-prod deploys.
+  if (command === "build" && !sentryDsn) {
+    const detail =
+      "Sentry DSN did not resolve from any known alias (VITE_SENTRY_CLIENT_DSN, VITE_SENTRY_DSN, SENTRY_DSN via the Vercel integration, ...); error tracking would be disabled in this build.";
+    if (process.env.VERCEL_ENV === "production") {
+      throw new Error(`[env-parity] ${detail} Refusing to ship a production build without it.`);
+    }
+    if (process.env.VERCEL) {
+      console.warn(
+        `[env-parity] ${detail} Staging should mirror production — set the DSN for this environment.`
+      );
+    }
+  }
   const sentryRelease = `green-goods-client@${shortAppVersion}`;
   const indexerProxyTarget =
     process.env.VITE_ENVIO_INDEXER_URL?.trim() ||


### PR DESCRIPTION
## What
Build-time **env-parity gate** in both Vite configs (PRD-567 / Phase 3.1): on `build`, if the Sentry DSN does not resolve from any known alias, **fail closed on production** (`VERCEL_ENV=production`) and **warn on other Vercel builds** (preview/staging).

## Why
The May Sentry thrash (~25 commits) was a production deploy shipping without working error tracking — a *silent* failure only caught after deploy. This gate makes it loud, at the deploy point, before it ships.

## How (and why here, not env-check.js)
The DSN resolves via an 8-alias cascade (`VITE_SENTRY_*_DSN`, `SENTRY_DSN` from the Vercel-Sentry integration, etc.) that lives in the Vite configs. The gate **reuses that resolved value**, so it only fires when Sentry would truly be dead and cannot drift. Duplicating the cascade in a standalone script would drift and false-fail — so the gate lives where the truth is.

## Scope / safety
- **Production:** throws (refuses to ship). Reuses the exact value the app uses, so it only throws if Sentry is already broken in prod.
- **Preview / staging (Vercel):** warns (surfaces the gap without blocking).
- **Local / CI builds (no `VERCEL`):** silent.

## Validation
First feature PR through the `develop` (staging) flow. CI `Lint And Build` exercises `bun run build`; the Vercel preview build runs the gate live (warn/silent, never throws on preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)