### PR TITLE
docs(plans): monolith-decomposition tracking hub

### DIFF
--- a/.plans/active/monolith-decomposition/brief.md
+++ b/.plans/active/monolith-decomposition/brief.md
@@ -1,0 +1,25 @@
+# Monolith Decomposition — brief
+
+Structure-only decomposition of three oversized files. **No behavior change.** Reuses the Hub `views/<View>/components/` pattern (Hub went 1376 → 605 LOC). Part of the June maturation push ([PRD-563](https://linear.app/greenpill-dev-guild/issue/PRD-563)).
+
+> No decomposition code was written when this hub was created — capture/tracking only. Execution happens later through the `develop → PR → main` flow.
+
+## Targets, sequencing, risk
+
+| # | File | LOC | Approach | Risk | Linear |
+|---|---|---|---|---|---|
+| 1.2 | `packages/agent/src/services/db.ts` | ~1235 | `DB` class → domain repositories (`users`, `sessions`, `pendingWork`, `idempotency`, `chatMessages`, `fundingIntents`); facade `export const` wrappers unchanged | **low — do first** | PRD-566 |
+| 1.1 | `packages/agent/src/api/server.ts` | ~1497 | `middleware/` + `funding/` + `routes/`; `createServer()` stays the composition root | medium (sensitive — live public API) | PRD-574 |
+| 1.3 | `packages/admin/src/views/Cookies/components/CampaignCookieJarPanel.tsx` | ~2115 | mechanical extraction of the ~9 already-separated sub-components | **PARKED** | PRD-565 |
+
+**1.3 is parked** pending the Seasons reframe (§2.3) + a campaign-cookie-jar roadmap call: the underlying `cookie-jar` protocol/repo is dormant and the campaign concept is being reframed as a Seasons primitive, so decomposing now risks churning components that get reworked. (It is green-goods *admin UI* — not the separate, dormant `cookie-jar` sibling repo.)
+
+## Acceptance (each, when executed)
+- No behavior change; public exports / route paths unchanged.
+- No decomposed file > ~600 LOC.
+- `bun run build` + package tests green (agent: `bun run build:agent` + `bun run test:agent`).
+- Lands via the flow: branch from `develop` → PR → CI Gate → promote `develop → main`.
+
+## Notes
+- This hub is execution truth; Linear PRD-574 / PRD-566 / PRD-565 mirror it for visibility (`source:plans`).
+- The machine-tracking `status.json` for this hub should be formalized via `node scripts/harness/plan-hub.mjs scaffold` in a deps-enabled checkout — the plan-hub CLI is env-gated in fresh worktrees, so it was not generated here.

--- a/.plans/active/monolith-decomposition/plan.todo.md
+++ b/.plans/active/monolith-decomposition/plan.todo.md
@@ -1,0 +1,23 @@
+# Monolith Decomposition — plan
+
+Sequence: **1.2 → 1.1** (both active), **1.3 parked**. Each is structure-only; keep tests green.
+
+## 1.2 — `agent/services/db.ts` → domain repositories (PRD-566) — do first
+- [ ] Extract the `sessions` domain into a repository module (good first slice; proves the pattern).
+- [ ] Extract the remaining domains (`users`, `pendingWork`, `idempotency`, `chatMessages`, `fundingIntents`).
+- [ ] Keep the facade `export const` wrappers byte-identical (no caller moves).
+- [ ] `bun run build:agent` + `bun run test:agent` green.
+
+## 1.1 — `agent/api/server.ts` → middleware/funding/routes (PRD-574)
+- [ ] Extract `middleware/` (auth, rate-limit, body-limits, CORS).
+- [ ] Extract `funding/` (request validation, records, webhook normalization).
+- [ ] Extract `routes/` (health, ready, uploadSign, funding).
+- [ ] Keep `createServer()` as the composition root; route paths unchanged.
+- [ ] `bun run build:agent` + `bun run test:agent` green.
+
+## 1.3 — `CampaignCookieJarPanel.tsx` (PRD-565) — PARKED
+- [ ] BLOCKED: decide the Seasons reframe (§2.3) + campaign-cookie-jar roadmap first.
+- [ ] When unparked: mechanical extraction of sub-components into `views/Cookies/components/CampaignCookieJar/` (no behavior change).
+
+## Hub hygiene
+- [ ] Formalize `status.json` via `node scripts/harness/plan-hub.mjs scaffold` in a deps-enabled checkout.


### PR DESCRIPTION
Adds the `.plans/active/monolith-decomposition/` tracking hub (brief + plan.todo) — execution truth for the three monolith decompositions, mirrored by Linear PRD-574 (server.ts) / PRD-566 (db.ts) / PRD-565 (cookie-jar, parked) under PRD-563.

Tracking only — **no decomposition code**. A docs PR through the `develop` flow.

Note: the machine `status.json` is to be formalized via `plan-hub.mjs scaffold` in a deps-enabled checkout (CLI is env-gated in fresh worktrees).

🤖 Generated with [Claude Code](https://claude.com/claude-code)