### PR TITLE
docs: mark QA artifact freshness and add Artifact Freshness page (Closes PRD-535)

### DIFF
--- a/.plans/qa-triage/README.md
+++ b/.plans/qa-triage/README.md
@@ -1,0 +1,17 @@
+# QA triage artifact index
+
+Freshness pass date: 2026-06-02.
+
+This directory stores repo-local QA triage artifacts. Linear is the accepted-work surface, and the QA Sheet is the append-only reporting surface. Files here are supporting evidence, fixtures, and dry-run payloads; they are not a substitute for accepted Linear records.
+
+| Artifact set | Status | Reporting rule |
+|---|---|---|
+| `product-sync-2026-05-13/` | Accepted production triage run | Count as the current accepted QA Sheet baseline: PRD-496 through PRD-522, 27 linked Customer Needs, 21 Defects-tab rows, and test-tab backfills. |
+| `product-sync-2026-05-20/` | Fixture dry-run only | Do not count in Linear or QA Sheet reporting. `PRD-XXX`, draft Defects rows, and payload examples are synthetic shape checks only. |
+
+## Hygiene rules
+
+- Keep fixture runs visibly labeled as `fixture` and `dry-run` in reports, payloads, row files, and future summaries.
+- Do not promote fixture `PRD-XXX` links into docs prose as accepted records.
+- Keep PostHog replay URLs, session IDs, distinct IDs, wallet addresses, and reporter identifiers out of public reports.
+- Current Linear labels use only the canonical families: `protocol:*`, `package:*`, `activity:*`, `source:*`, `agent:*`, and `funding:*`. Historical fixture text that mentions retired `task:*` labels must be treated as stale fixture metadata, not current guidance.

--- a/.plans/qa-triage/product-sync-2026-05-20/cross-ref.md
+++ b/.plans/qa-triage/product-sync-2026-05-20/cross-ref.md
@@ -1,6 +1,8 @@
 # Cross-reference — Product Sync 2026-05-20 (fixture)
 
 > Mode: `--fixture --dry-run`. Simulated cross-ref data is taken from the fixture's `<!-- skill-fixture-context: ... -->` HTML comment. **The skill does not currently parse this block** — see gap-validate #2 in `report.md`. For this dry-run I'm hand-applying the simulated state so the rest of the phase flow can be validated.
+Freshness note (2026-06-02): this cross-reference is synthetic fixture metadata only. Proposed `task:*` labels are stale historical examples; do not use them for current Linear routing.
+
 
 ### Item 1 — Camera preview clips on iOS Safari standalone PWA
 

--- a/.plans/qa-triage/product-sync-2026-05-20/payloads.md
+++ b/.plans/qa-triage/product-sync-2026-05-20/payloads.md
@@ -2,6 +2,8 @@
 
 Mode: `--fixture --dry-run`. No Linear writes. The payloads below would be submitted via `save_issue` + `save_customer_need` on a real run.
 
+Freshness note (2026-06-02): this file is fixture-only and is not an accepted Linear or QA Sheet record. `PRD-XXX` links are placeholders. Historical `task:*` label examples from the dry-run are stale and are not part of the current canonical label scheme.
+
 ## Assignee dialog (bulk-default + exceptions-only)
 
 ```

--- a/.plans/qa-triage/product-sync-2026-05-20/report.md
+++ b/.plans/qa-triage/product-sync-2026-05-20/report.md
@@ -1,5 +1,8 @@
 # /qa-triage report — Product Sync 2026-05-20 (fixture dry-run)
 
+## Freshness note — 2026-06-02
+This artifact is a synthetic fixture dry-run. It did not write Linear records or QA Sheet rows, and its `PRD-XXX` placeholders are not accepted issue links. Any historical `task:*` label examples in this fixture are stale metadata from the test run; current Linear hygiene uses only `protocol:*`, `package:*`, `activity:*`, `source:*`, `agent:*`, and `funding:*`.
+
 ## Source
 `.claude/skills/qa-triage/fixtures/example-product-sync.md` · synthetic, dated 2026-05-20 (future). Mode: `--fixture --dry-run`.
 

--- a/docs/docs/builders/quality/artifact-freshness.mdx
+++ b/docs/docs/builders/quality/artifact-freshness.mdx
@@ -1,0 +1,66 @@
+---
+title: Artifact Freshness
+sidebar_label: Artifact Freshness
+slug: /builders/quality/artifact-freshness
+audience: developer
+owner: docs
+last_verified: 2026-06-02
+feature_status: Live
+source_of_truth:
+  - .plans/active/docs-freshness-routine/status.json
+  - .plans/qa-triage/README.md
+  - docs/static/img/screenshots/FRESHNESS.md
+keywords: [artifact freshness, QA Sheet, screenshots, docs hardening, Linear]
+description: Freshness rules for docs screenshots, proof artifacts, and QA Sheet records during the June 10 hardening window.
+---
+
+# Artifact Freshness
+
+This page is the docs-site freshness ledger for the June 10 hardening window. It keeps the repo docs, docs media, and QA reporting artifacts aligned without expanding the pass into grants, stakeholder documents, or app-runtime bug fixes.
+
+## Scope for this pass
+
+| Surface | In scope | Out of scope |
+|---|---|---|
+| Docs site | Builder/community pages, quality pages, sidebars, docs static screenshots, social-card references | Grant drafts, external stakeholder docs, and non-repo decks unless a repo docs page embeds them |
+| QA artifacts | `.plans/qa-triage/**` reports, draft rows, accepted Linear record references, and QA Sheet hygiene notes | Creating new QA rows, changing Linear issue status, or rerunning product-sync triage |
+| Plan truth | `.plans/active/*/status.json` as implementation proof for plan-backed work | Treating docs prose or Linear issue text as execution proof |
+| Roadmap truth | Linear issues/projects for ownership, reporting, and accepted work | Duplicating roadmap status into repo docs |
+
+## Source-of-truth rule
+
+- `.plans/active/*/status.json` remains the execution truth for active plan-backed work.
+- Linear remains the roadmap, ownership, and reporting surface.
+- QA Sheet rows are append-only evidence for accepted defects. Fixture or dry-run rows stay in `.plans/qa-triage/**` and must not be described as Sheet writes.
+- Proof artifacts are current only when the artifact itself, the nearby docs copy, and the referenced app surface still agree.
+
+## Current freshness decisions
+
+| Artifact family | Current decision | Reason |
+|---|---|---|
+| `docs/static/img/screenshots/client-work-dashboard.png` | Stale-but-retained | The docs-freshness hub already identifies it as a refresh candidate; retaining avoids replacing it with a fabricated or empty capture. |
+| `docs/static/img/screenshots/admin-create-garden.png` | Stale-but-retained | Needs a stable real admin Create Garden form capture before replacement. |
+| `docs/static/img/screenshots/admin-work-queue.png` | Stale-but-retained | Needs pending-work fixture data or a safe staging record before replacement. |
+| `docs/static/img/screenshots/admin-work-detail.png` | Stale-but-retained | Needs selected-submission review context before replacement. |
+| `docs/static/img/screenshots/admin-garden-impact.png` | Stale-but-retained | Needs a stable Certify/Create Hypercert surface before replacement. |
+| `docs/static/img/social/donating-to-a-garden.webp` | Deferred | Distinct Donate artwork is still a planned addition; do not reuse Endow imagery as a placeholder. |
+| `.plans/qa-triage/product-sync-2026-05-13/**` | Current accepted QA artifact | The report records accepted Linear records PRD-496 through PRD-522 and a successful QA Sheet write. |
+| `.plans/qa-triage/product-sync-2026-05-20/**` | Fixture-only, not accepted | The run is synthetic and dry-run only; `PRD-XXX` and drafted rows are examples, not accepted Linear or QA Sheet records. |
+
+## QA Sheet alignment
+
+The accepted QA Sheet/reporting baseline is the Product Sync 2026-05-13 run:
+
+- 27 Linear Issues and 27 linked Customer Needs were accepted in the triage report.
+- 21 Defects-tab rows were appended.
+- Test-tab `Defect Link` cells were backfilled without exposing PostHog replay URLs or session IDs.
+
+The Product Sync 2026-05-20 run is deliberately fixture-only. Its draft rows and `PRD-XXX` placeholders are useful for validating payload shape, but they are not accepted QA Sheet records and should not be counted in reporting.
+
+## Operator checklist for future docs freshness runs
+
+1. Start from `.plans/active/docs-freshness-routine/status.json` before editing docs or media.
+2. Replace screenshots only with real app/admin/docs surfaces and safe fixture data.
+3. If a screenshot cannot be safely recaptured, mark it stale or deferred instead of inventing proof.
+4. Keep QA Sheet evidence tied to accepted Linear records; mark fixture artifacts clearly.
+5. Validate with `bun run build:docs` before opening a PR that claims docs-site freshness.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -266,6 +266,7 @@ const sidebars: SidebarsConfig = {
         {type: 'doc', id: 'builders/quality/test-cases', label: 'Test Cases'},
         {type: 'doc', id: 'builders/quality/regression', label: 'Regression Testing'},
         {type: 'doc', id: 'builders/quality/agentic-eval', label: 'Agentic Evaluation'},
+        {type: 'doc', id: 'builders/quality/artifact-freshness', label: 'Artifact Freshness'},
         {type: 'doc', id: 'builders/quality/husky', label: 'Husky'},
         {type: 'doc', id: 'builders/quality/gh-actions', label: 'GitHub Actions'},
       ],

--- a/docs/static/img/screenshots/FRESHNESS.md
+++ b/docs/static/img/screenshots/FRESHNESS.md
@@ -1,0 +1,14 @@
+# Screenshot freshness manifest — June 10 hardening window
+
+This manifest records the freshness decision for checked-in docs screenshots. It is intentionally metadata-only: stale screenshots are retained until a real, safe app/admin/docs surface can replace them.
+
+| Path | Size | Freshness decision | Replacement condition |
+|---|---:|---|---|
+| `admin-create-garden.png` | 2880×1086 | Stale-but-retained | Replace with the stable admin Create Garden form, populated enough to teach the flow. |
+| `admin-work-queue.png` | 1280×800 | Stale-but-retained | Replace with a pending-work queue sourced from safe fixture/staging data. |
+| `admin-work-detail.png` | 2544×1328 | Stale-but-retained | Replace with a selected submission review surface showing evidence and approve/reject context. |
+| `admin-garden-impact.png` | 1280×800 | Stale-but-retained | Replace with the stable Certify/Create Hypercert surface. |
+| `client-work-dashboard.png` | 622×1198 | Stale-but-retained | Replace with the Work Dashboard/status surface, not a home or garden-list view. |
+| Other screenshots in this directory | varies | Out of scope for PRD-535 | Reassess only when the nearby docs page is in the hardening scope. |
+
+Do not delete stale screenshots unless the MDX reference is removed or a replacement is committed in the same PR.


### PR DESCRIPTION
### Motivation

- Record and surface a scoped docs + QA artifact freshness policy for the June 10 hardening window so reviewers do not mistake fixture/dry-run artifacts for accepted evidence. 
- Preserve existing accepted QA Sheet/Linear truth (Product Sync 2026-05-13) while clearly flagging the 2026-05-20 run as a fixture dry-run. 
- Provide operators with a small, actionable checklist and a screenshot manifest that defers screenshot replacement until UI/CSS readiness gates are met.

### Description

- Added a new docs page `docs/docs/builders/quality/artifact-freshness.mdx` that documents the artifact-freshness rules, scope, and operator checklist. 
- Added `docs/static/img/screenshots/FRESHNESS.md` as a checked-in screenshot freshness manifest and `.plans/qa-triage/README.md` as a QA triage artifact index. 
- Updated the Product Sync 2026-05-20 fixture artifacts (`.plans/qa-triage/product-sync-2026-05-20/report.md`, `payloads.md`, `cross-ref.md`) to mark them explicitly as fixture/dry-run and avoid treating `PRD-XXX` placeholders as accepted evidence. 
- Wired the new page into the Quality Assurance sidebar (`docs/sidebars.ts`) so the Artifact Freshness guidance is discoverable from the docs site.

### Testing

- Ran the docs build with `bun run build:docs`, which produced a successful static `build` output. 
- Ran the docs audit with `bun run docs:audit:ci` and resolved frontmatter warnings so `docs-audit` reported no warnings for the new page. 
- Ran formatting checks with `bun run format:check` and style checks (`biome`), which returned clean. 
- Verified the changes are limited to the new docs/manifest/qa artifacts and the sidebar entry by running `git diff --check` as part of the validation ladder (no outstanding diff-check failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6b3098488323bd43d2ce8d038444)