### PR TITLE
Emit admin_action_create_started/_success/_failed telemetry for action creation (Closes PRD-550)

### DIFF
--- a/packages/shared/src/__tests__/hooks/admin-ui/useCreateActionController.test.tsx
+++ b/packages/shared/src/__tests__/hooks/admin-ui/useCreateActionController.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import React from "react";
+import { act, renderHook } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useCreateActionController } from "../../../hooks/admin-ui/actions/useCreateActionController";
+
+const mockNavigate = vi.fn();
+const mockRegisterAction = vi.fn();
+const mockUploadFileToIPFS = vi.fn();
+const mockTrackStarted = vi.fn();
+const mockTrackSuccess = vi.fn();
+const mockTrackFailed = vi.fn();
+const mockToastLoading = vi.fn();
+const mockToastDismiss = vi.fn();
+const mockToastError = vi.fn();
+const mockLoggerError = vi.fn();
+const mockSetFormState = vi.fn();
+const mockClearViewState = vi.fn();
+const mockRestoreViewState = vi.fn(() => null);
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useLocation: () => ({ pathname: "/actions/create", search: "" }),
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock("@green-goods/shared", () => ({
+  adminRoutes: {
+    actions: () => "/actions",
+  },
+  buildActionInstructionsV2: vi.fn(() => ({ version: 2, fields: [] })),
+  Domain: { SOLAR: 0, AGRO: 1, EDU: 2, WASTE: 3 },
+  getActionsListSearch: vi.fn(() => ({})),
+  getNetworkContracts: vi.fn(() => ({
+    gardenToken: "0x1111111111111111111111111111111111111111",
+  })),
+  logger: { error: (...args: unknown[]) => mockLoggerError(...args) },
+  toastService: {
+    loading: (...args: unknown[]) => mockToastLoading(...args),
+    dismiss: (...args: unknown[]) => mockToastDismiss(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+  trackAdminActionCreateFailed: (...args: unknown[]) => mockTrackFailed(...args),
+  trackAdminActionCreateStarted: (...args: unknown[]) => mockTrackStarted(...args),
+  trackAdminActionCreateSuccess: (...args: unknown[]) => mockTrackSuccess(...args),
+  uploadFileToIPFS: (...args: unknown[]) => mockUploadFileToIPFS(...args),
+  useActionOperations: () => ({
+    registerAction: (...args: unknown[]) => mockRegisterAction(...args),
+    isLoading: false,
+  }),
+  useFormWizardStepValidation: ({
+    onBack,
+    onValidNext,
+  }: {
+    onBack?: () => void;
+    onValidNext: () => void;
+  }) => ({
+    handleBack: () => onBack?.(),
+    handleNext: () => onValidNext(),
+  }),
+  useSheetOrchestratorStore: Object.assign(
+    (selector: (state: Record<string, unknown>) => unknown) =>
+      selector({
+        setFormState: mockSetFormState,
+        clearViewState: mockClearViewState,
+      }),
+    {
+      getState: () => ({
+        restoreViewState: mockRestoreViewState,
+      }),
+    }
+  ),
+}));
+
+vi.mock("@hookform/resolvers/zod", () => ({
+  zodResolver: () => async (values: unknown) => ({ values, errors: {} }),
+}));
+
+vi.mock("../../../hooks/admin-ui/actions/createAction.utils", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../../hooks/admin-ui/actions/createAction.utils")
+  >("../../../hooks/admin-ui/actions/createAction.utils");
+  return {
+    ...actual,
+    CREATE_ACTION_DEFAULT_CHAIN_ID: 42161,
+    createActionResolver: async (values: unknown) => ({ values, errors: {} }),
+  };
+});
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return React.createElement(IntlProvider, { locale: "en", messages: {} }, children);
+}
+
+function createFormData() {
+  return {
+    title: "Repair Event",
+    slug: " Repair.Event ",
+    domain: 2,
+    startTime: new Date("2026-06-02T00:00:00.000Z"),
+    endTime: new Date("2026-06-09T00:00:00.000Z"),
+    capitals: [],
+    media: [],
+    instructionConfig: {
+      title: "Work Submission",
+      description: "",
+      feedbackPlaceholder: "",
+      inputs: [],
+    },
+    translations: {},
+  };
+}
+
+describe("useCreateActionController telemetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUploadFileToIPFS.mockResolvedValue({ cid: "bafy-instructions" });
+    mockRegisterAction.mockResolvedValue({ success: true, hash: "0xabc" });
+  });
+
+  it("emits started and success analytics around action registration", async () => {
+    const { result } = renderHook(() => useCreateActionController(), { wrapper });
+
+    await act(async () => {
+      await result.current.onSubmit(createFormData());
+    });
+
+    const expectedBase = {
+      gardenAddress: "0x1111111111111111111111111111111111111111",
+      chainId: 42161,
+      actionTitle: "Repair Event",
+      actionSlug: "repair.event",
+      actionDomain: 2,
+    };
+
+    expect(mockTrackStarted).toHaveBeenCalledWith(expectedBase);
+    expect(mockRegisterAction).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Repair Event", slug: "repair.event", domain: 2 })
+    );
+    expect(mockTrackSuccess).toHaveBeenCalledWith({ ...expectedBase, txHash: "0xabc" });
+    expect(mockTrackFailed).not.toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith("/actions");
+  });
+
+  it("emits failed analytics when action registration returns an unsuccessful result", async () => {
+    mockRegisterAction.mockResolvedValue({
+      success: false,
+      error: { name: "SimulationFailed", message: "Simulation failed" },
+    });
+    const { result } = renderHook(() => useCreateActionController(), { wrapper });
+
+    await act(async () => {
+      await result.current.onSubmit(createFormData());
+    });
+
+    expect(mockTrackStarted).toHaveBeenCalledOnce();
+    expect(mockTrackFailed).toHaveBeenCalledWith({
+      gardenAddress: "0x1111111111111111111111111111111111111111",
+      chainId: 42161,
+      actionTitle: "Repair Event",
+      actionSlug: "repair.event",
+      actionDomain: 2,
+      error: "Simulation failed",
+    });
+    expect(mockTrackSuccess).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/shared/src/hooks/admin-ui/actions/useCreateActionController.ts
+++ b/packages/shared/src/hooks/admin-ui/actions/useCreateActionController.ts
@@ -3,9 +3,13 @@ import {
   adminRoutes,
   buildActionInstructionsV2,
   Domain,
+  getNetworkContracts,
   logger,
   type Step,
   toastService,
+  trackAdminActionCreateFailed,
+  trackAdminActionCreateStarted,
+  trackAdminActionCreateSuccess,
   uploadFileToIPFS,
   useActionOperations,
   useFormWizardStepValidation,
@@ -35,6 +39,8 @@ export function useCreateActionController() {
   const location = useLocation();
   const { formatMessage } = useIntl();
   const { registerAction, isLoading } = useActionOperations(CREATE_ACTION_DEFAULT_CHAIN_ID);
+  const createActionContracts = getNetworkContracts(CREATE_ACTION_DEFAULT_CHAIN_ID);
+  const actionCreateGardenAddress = createActionContracts.gardenToken;
   const [currentStep, setCurrentStep] = useState(0);
   const setDraftFormState = useSheetOrchestratorStore((state) => state.setFormState);
   const clearDraftFormState = useSheetOrchestratorStore((state) => state.clearViewState);
@@ -155,6 +161,10 @@ export function useCreateActionController() {
   }, [currentStep, form, setDraftFormState]);
 
   const onSubmit = async (data: CreateActionFormData) => {
+    let mutationStarted = false;
+    const actionSlug = data.slug.trim().toLowerCase();
+    const actionDomain = data.domain as Domain;
+
     try {
       toastService.loading({
         title: formatMessage({
@@ -182,15 +192,41 @@ export function useCreateActionController() {
 
       toastService.dismiss();
 
-      await registerAction({
+      const telemetryBase = {
+        gardenAddress: actionCreateGardenAddress,
+        chainId: CREATE_ACTION_DEFAULT_CHAIN_ID,
+        actionTitle: data.title,
+        actionSlug,
+        actionDomain,
+      };
+
+      mutationStarted = true;
+      trackAdminActionCreateStarted(telemetryBase);
+
+      const result = await registerAction({
         title: data.title,
-        slug: data.slug.trim().toLowerCase(),
-        domain: data.domain as Domain,
+        slug: actionSlug,
+        domain: actionDomain,
         startTime: Math.floor(data.startTime.getTime() / 1000),
         endTime: Math.floor(data.endTime.getTime() / 1000),
         capitals: data.capitals,
         media: mediaCIDs,
         instructions: instructionsUpload.cid,
+      });
+
+      if (!result.success) {
+        const errorMessage = result.error?.message ?? "Action registration failed";
+        mutationStarted = false;
+        trackAdminActionCreateFailed({
+          ...telemetryBase,
+          error: errorMessage,
+        });
+        throw new Error(errorMessage);
+      }
+
+      trackAdminActionCreateSuccess({
+        ...telemetryBase,
+        txHash: result.hash ?? "",
       });
 
       clearDraftFormState(ACTION_CREATE_DRAFT_PATH);
@@ -203,6 +239,17 @@ export function useCreateActionController() {
         title: data.title,
         mediaCount: data.media.length,
       });
+      if (mutationStarted) {
+        trackAdminActionCreateFailed({
+          gardenAddress: actionCreateGardenAddress,
+          chainId: CREATE_ACTION_DEFAULT_CHAIN_ID,
+          actionTitle: data.title,
+          actionSlug,
+          actionDomain,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+
       toastService.error({
         title: formatMessage({
           id: "app.admin.actions.create.errorTitle",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -710,6 +710,10 @@ export {
   submitApprovalBot,
   submitWorkBot,
   track,
+  trackAdminActionCreateFailed,
+  // Admin action tracking
+  trackAdminActionCreateStarted,
+  trackAdminActionCreateSuccess,
   trackAdminDeployFailed,
   // Admin deploy tracking
   trackAdminDeployStarted,

--- a/packages/shared/src/modules/app/analytics-events.ts
+++ b/packages/shared/src/modules/app/analytics-events.ts
@@ -409,3 +409,33 @@ export const trackAdminDeployFailed = createTracker<{
   contractType: string;
   error: string;
 }>(ANALYTICS_EVENTS.ADMIN_DEPLOY_FAILED);
+
+// ============================================================================
+// ADMIN: ACTION MANAGEMENT
+// ============================================================================
+
+export const trackAdminActionCreateStarted = createTracker<{
+  gardenAddress: string;
+  chainId: number;
+  actionTitle: string;
+  actionSlug: string;
+  actionDomain: number;
+}>(ANALYTICS_EVENTS.ADMIN_ACTION_CREATE_STARTED);
+
+export const trackAdminActionCreateSuccess = createTracker<{
+  gardenAddress: string;
+  chainId: number;
+  actionTitle: string;
+  actionSlug: string;
+  actionDomain: number;
+  txHash: string;
+}>(ANALYTICS_EVENTS.ADMIN_ACTION_CREATE_SUCCESS);
+
+export const trackAdminActionCreateFailed = createTracker<{
+  gardenAddress: string;
+  chainId: number;
+  actionTitle: string;
+  actionSlug: string;
+  actionDomain: number;
+  error: string;
+}>(ANALYTICS_EVENTS.ADMIN_ACTION_CREATE_FAILED);

--- a/packages/shared/src/modules/index.ts
+++ b/packages/shared/src/modules/index.ts
@@ -2,6 +2,10 @@
 
 export {
   ANALYTICS_EVENTS,
+  trackAdminActionCreateFailed,
+  // Admin: action events
+  trackAdminActionCreateStarted,
+  trackAdminActionCreateSuccess,
   trackAdminDeployFailed,
   // Admin: deployment events
   trackAdminDeployStarted,


### PR DESCRIPTION
### Motivation

- Growth-pulse and the Admin PostHog metric `actions.template-creation-rate` were blind because `admin_action_create_success` had no call sites, so action-template creation was never instrumented.  

### Description

- Added admin action telemetry trackers to `packages/shared/src/modules/app/analytics-events.ts`: `trackAdminActionCreateStarted`, `trackAdminActionCreateSuccess`, and `trackAdminActionCreateFailed`.  
- Wired telemetry into the admin create-action flow by updating `useCreateActionController` to emit `ADMIN_ACTION_CREATE_STARTED` before calling `registerAction`, then emit `_SUCCESS` or `_FAILED` depending on the `registerAction` result (and treat `success: false` as a failure).  
- Exported the new trackers via the shared modules/entry exports so they are available to consumers.  
- Added a focused unit test `packages/shared/src/__tests__/hooks/admin-ui/useCreateActionController.test.tsx` that covers started/success/failure telemetry paths and navigation/side-effects.  
- Ran repository formatting on changed files (biome) and small housekeeping edits to module exports to include the new trackers.  

### Testing

- Ran the focused test: `bun run --filter @green-goods/shared test src/__tests__/hooks/admin-ui/useCreateActionController.test.tsx` and it passed (2 tests).  
- Ran the full package test suite via `bun run test`; `@green-goods/shared` test suite completed successfully (258 test files, 3,079 tests total) and package-level suites (agent, admin, client) executed; test run exited with code 0.  
- Formatting step executed (`bunx @biomejs/biome format`) and fixed/normalized the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6b198c588323816c076054e55738)