### PR TITLE
fix(admin,shared): harden Submit Work validation

### DIFF
--- a/packages/admin/src/views/Community/Community.stories.tsx
+++ b/packages/admin/src/views/Community/Community.stories.tsx
@@ -94,9 +94,49 @@ export const Treasury: Story = {
 };
 
 export const VaultInspector: Story = {
-  tags: ["visual-harness"],
+  tags: ["storybook-ci"],
   args: { initialPath: "/community/treasury/vault" },
   decorators: communityDecorators(),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      await canvas.findByRole(
+        "button",
+        { name: /Rio Rainforest Lab/ },
+        ADMIN_ROUTE_STORY_QUERY_OPTIONS
+      )
+    ).toBeVisible();
+    const leftSheet = await canvas.findByTestId(
+      "left-sheet",
+      undefined,
+      ADMIN_ROUTE_STORY_QUERY_OPTIONS
+    );
+    await expect(leftSheet).toHaveAttribute("data-component", "LeftSheet");
+    await expect(
+      await within(leftSheet).findByText(
+        "Total value locked",
+        undefined,
+        ADMIN_ROUTE_STORY_QUERY_OPTIONS
+      )
+    ).toBeVisible();
+    await expect(
+      await within(leftSheet).findByText(
+        "Net deposited",
+        undefined,
+        ADMIN_ROUTE_STORY_QUERY_OPTIONS
+      )
+    ).toBeVisible();
+    await expect(
+      (
+        await within(leftSheet).findAllByText(
+          "Depositors",
+          undefined,
+          ADMIN_ROUTE_STORY_QUERY_OPTIONS
+        )
+      ).length
+    ).toBeGreaterThan(0);
+  },
 };
 
 export const GovernancePools: Story = {

--- a/packages/admin/src/views/Garden/Garden.stories.tsx
+++ b/packages/admin/src/views/Garden/Garden.stories.tsx
@@ -6,7 +6,7 @@ import {
   type Address,
   type Garden as SharedGarden,
 } from "@green-goods/shared";
-import { expect, waitFor, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import {
   STORYBOOK_ADMIN_GARDENS,
   STORYBOOK_ADMIN_SHELL_SEEDS,
@@ -63,11 +63,25 @@ const STORYBOOK_EMPTY_DOMAIN_GARDEN = {
 const STORYBOOK_EMPTY_DOMAIN_GARDENS = STORYBOOK_ADMIN_GARDENS.map((garden) =>
   garden.id === STORYBOOK_EMPTY_DOMAIN_GARDEN.id ? STORYBOOK_EMPTY_DOMAIN_GARDEN : garden
 );
+const STORYBOOK_SECONDARY_ADMIN_GARDEN = STORYBOOK_ADMIN_GARDENS[1] as SharedGarden;
+const STORYBOOK_SECONDARY_ADMIN_GARDEN_ID =
+  STORYBOOK_SECONDARY_ADMIN_GARDEN.id.toLowerCase() as Address;
 
 const STORYBOOK_EMPTY_DOMAIN_SEEDS: ReadonlyArray<readonly [QueryKey, unknown]> =
   STORYBOOK_ADMIN_SHELL_SEEDS.map(([key, data]) =>
     data === STORYBOOK_ADMIN_GARDENS ? [key, STORYBOOK_EMPTY_DOMAIN_GARDENS] : [key, data]
   );
+const STORYBOOK_SECONDARY_GARDEN_SEEDS: ReadonlyArray<readonly [QueryKey, unknown]> = [
+  ...STORYBOOK_ADMIN_SHELL_SEEDS,
+  [queryKeys.assessments.byGardenBase(STORYBOOK_SECONDARY_ADMIN_GARDEN.id, DEFAULT_CHAIN_ID), []],
+  [queryKeys.works.merged(STORYBOOK_SECONDARY_ADMIN_GARDEN.id, DEFAULT_CHAIN_ID), []],
+  [queryKeys.hypercerts.list(STORYBOOK_SECONDARY_ADMIN_GARDEN.id, DEFAULT_CHAIN_ID, undefined), []],
+  [queryKeys.vaults.byGarden(STORYBOOK_SECONDARY_ADMIN_GARDEN_ID, DEFAULT_CHAIN_ID), []],
+  [queryKeys.yield.allocations(STORYBOOK_SECONDARY_ADMIN_GARDEN_ID, DEFAULT_CHAIN_ID, 20), []],
+  [queryKeys.community.garden(STORYBOOK_SECONDARY_ADMIN_GARDEN_ID, DEFAULT_CHAIN_ID), null],
+  [queryKeys.community.pools(STORYBOOK_SECONDARY_ADMIN_GARDEN_ID, DEFAULT_CHAIN_ID), []],
+  [queryKeys.conviction.strategies(STORYBOOK_SECONDARY_ADMIN_GARDEN_ID, DEFAULT_CHAIN_ID), []],
+];
 
 const STORYBOOK_OPERATOR_ADDRESS_KEY = STORYBOOK_OPERATOR_ADDRESS.toLowerCase() as Address;
 
@@ -145,6 +159,78 @@ export const Settings: Story = {
   decorators: gardenDecorators(),
 };
 
+export const GardenSwitchRemainsInteractive: Story = {
+  tags: ["storybook-ci"],
+  args: { initialPath: "/garden/overview" },
+  decorators: gardenDecorators({ seeds: STORYBOOK_SECONDARY_GARDEN_SEEDS }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const page = within(canvasElement.ownerDocument.body);
+
+    await expect(
+      await canvas.findByRole(
+        "button",
+        { name: /Rio Rainforest Lab/ },
+        ADMIN_ROUTE_STORY_QUERY_OPTIONS
+      )
+    ).toBeVisible();
+
+    await userEvent.click(
+      await canvas.findByRole(
+        "button",
+        { name: /Rio Rainforest Lab/ },
+        ADMIN_ROUTE_STORY_QUERY_OPTIONS
+      )
+    );
+    await userEvent.click(
+      await page.findByRole("button", { name: "Botanic Commons" }, ADMIN_ROUTE_STORY_QUERY_OPTIONS)
+    );
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: /Botanic Commons/ })).toBeVisible()
+    );
+    await expect(
+      await canvas.findByRole("heading", { name: "Garden" }, ADMIN_ROUTE_STORY_QUERY_OPTIONS)
+    ).toBeVisible();
+
+    await userEvent.click(
+      await canvas.findByRole(
+        "button",
+        { name: /Botanic Commons/ },
+        ADMIN_ROUTE_STORY_QUERY_OPTIONS
+      )
+    );
+    await userEvent.click(
+      await page.findByRole(
+        "button",
+        { name: "Rio Rainforest Lab" },
+        ADMIN_ROUTE_STORY_QUERY_OPTIONS
+      )
+    );
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: /Rio Rainforest Lab/ })).toBeVisible()
+    );
+  },
+};
+
+export const UrlGardenSync: Story = {
+  tags: ["storybook-ci"],
+  args: { initialPath: `/garden/settings?gardenAddress=${STORYBOOK_SECONDARY_ADMIN_GARDEN.id}` },
+  decorators: gardenDecorators({ seeds: STORYBOOK_SECONDARY_GARDEN_SEEDS }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      await canvas.findByRole("heading", { name: "Garden" }, ADMIN_ROUTE_STORY_QUERY_OPTIONS)
+    ).toBeVisible();
+    await waitFor(() =>
+      expect(canvas.getByRole("button", { name: /Botanic Commons/ })).toBeVisible()
+    );
+    await expect(
+      (await canvas.findAllByText("Brazil", undefined, ADMIN_ROUTE_STORY_QUERY_OPTIONS)).length
+    ).toBeGreaterThan(0);
+  },
+};
+
 export const CreateGardenRoute: Story = {
   tags: ["storybook-ci"],
   args: { initialPath: "/garden/create" },
@@ -194,5 +280,12 @@ export const EmptyDomains: Story = {
         ADMIN_ROUTE_STORY_QUERY_OPTIONS
       )
     ).toHaveLength(1);
+    await userEvent.click(
+      await canvas.findByRole("button", { name: "Edit domains" }, ADMIN_ROUTE_STORY_QUERY_OPTIONS)
+    );
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(
+      await page.findByRole("dialog", { name: "Edit Domains" }, ADMIN_ROUTE_STORY_QUERY_OPTIONS)
+    ).toBeVisible();
   },
 };

--- a/packages/admin/src/views/Garden/SubmitWork.stories.tsx
+++ b/packages/admin/src/views/Garden/SubmitWork.stories.tsx
@@ -3,6 +3,7 @@ import type { QueryKey } from "@tanstack/react-query";
 import {
   DEFAULT_CHAIN_ID,
   queryKeys,
+  ToastViewport,
   type Action,
   type Address,
   type Garden as SharedGarden,
@@ -53,6 +54,15 @@ const STORYBOOK_SUBMIT_ACTIONS: Action[] = STORYBOOK_ADMIN_ACTIONS.map((action, 
           },
         ]
       : [],
+  mediaInfo:
+    index === 0
+      ? {
+          title: "Field photos",
+          required: true,
+          minImageCount: 1,
+          maxImageCount: 3,
+        }
+      : action.mediaInfo,
 }));
 
 const STORYBOOK_EMPTY_DOMAIN_GARDEN = {
@@ -137,10 +147,13 @@ const disconnectedAuthState: AuthStateValue = {
 
 function SubmitWorkRouteStory() {
   return (
-    <Routes>
-      <Route path="/hub/work/submit" element={<SubmitWork />} />
-      <Route path="/garden/settings" element={<div className="p-6">Garden settings route</div>} />
-    </Routes>
+    <>
+      <Routes>
+        <Route path="/hub/work/submit" element={<SubmitWork />} />
+        <Route path="/garden/settings" element={<div className="p-6">Garden settings route</div>} />
+      </Routes>
+      <ToastViewport />
+    </>
   );
 }
 
@@ -148,6 +161,7 @@ function SubmitWorkSheetStory() {
   return (
     <div className="mx-auto max-w-xl p-4">
       <SubmitWorkPanel layout="sheet" onCancel={fn()} onSuccess={fn()} />
+      <ToastViewport />
     </div>
   );
 }
@@ -212,14 +226,19 @@ function disconnectedDecorators() {
 }
 
 export const PageAvailableAction: Story = {
+  tags: ["storybook-ci"],
   render: () => <SubmitWorkRouteStory />,
   decorators: submitWorkDecorators(),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(await canvas.findByRole("heading", { name: "Submit Work" })).toBeVisible();
-    await userEvent.selectOptions(await canvas.findByLabelText("Action"), `${DEFAULT_CHAIN_ID}-1`);
-    await expect(await canvas.findByLabelText("Plot code")).toBeVisible();
+    await userEvent.selectOptions(await canvas.findByLabelText(/Action/), `${DEFAULT_CHAIN_ID}-1`);
+    await expect(await canvas.findByLabelText(/Plot code/)).toBeVisible();
     await expect(await canvas.findByLabelText("Time Spent (hours)")).toBeVisible();
+    await userEvent.type(await canvas.findByLabelText(/Plot code/), "Plot A");
+    await userEvent.click(await canvas.findByRole("button", { name: "Submit Work" }));
+    const page = within(canvasElement.ownerDocument.body);
+    await expect(await page.findByText("At least one image is required")).toBeVisible();
   },
 };
 

--- a/packages/admin/src/views/Garden/SubmitWork.submit.test.tsx
+++ b/packages/admin/src/views/Garden/SubmitWork.submit.test.tsx
@@ -1,0 +1,304 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { IntlProvider } from "react-intl";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Action } from "../../../../shared/src/types/domain";
+import enMessages from "../../../../shared/src/i18n/en.json";
+import { Domain } from "../../../../shared/src/types/domain";
+import { SubmitWorkPanel } from "./SubmitWork";
+
+const gardenAddress = "0xAbCdEf1234567890aBcDeF1234567890aBcDeF12";
+const chainId = 42161;
+const actionId = `${chainId}-42`;
+
+const {
+  mockState,
+  mockSubmitWorkDirectly,
+  mockToastError,
+  mockToastSuccess,
+  mockValidationFormError,
+} = vi.hoisted(() => ({
+  mockState: {
+    actions: [] as Action[],
+    selectedGarden: null as { id: string; tokenAddress: string; name: string } | null,
+  },
+  mockSubmitWorkDirectly: vi.fn(),
+  mockToastError: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockValidationFormError: vi.fn(),
+}));
+
+vi.mock("@green-goods/shared", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@green-goods/shared")>();
+
+  return {
+    ...actual,
+    submitWorkDirectly: mockSubmitWorkDirectly,
+    toastService: {
+      ...actual.toastService,
+      error: mockToastError,
+      success: mockToastSuccess,
+    },
+    validationToasts: {
+      ...actual.validationToasts,
+      formError: mockValidationFormError,
+    },
+    useAdminGardenWorkspaceSelection: () => ({
+      selectedGarden: mockState.selectedGarden,
+    }),
+    useGardens: () => ({
+      data: [
+        {
+          id: gardenAddress,
+          name: "Green Goods Community Garden",
+          domainMask: 1 << Domain.AGRO,
+        },
+      ],
+    }),
+    useActions: () => ({
+      data: mockState.actions,
+    }),
+    useAuthState: () => ({ isAuthenticated: true }),
+    useGardenPermissions: () => ({ canManageGarden: () => true }),
+    useBeforeUnloadWhilePending: () => undefined,
+  };
+});
+
+function createAction(mediaInfo: Action["mediaInfo"] = {}): Action {
+  return {
+    id: actionId,
+    slug: "agro.site_assessment_before",
+    title: "Site Assessment (Before)",
+    startTime: 0,
+    endTime: 0,
+    instructions: "Document site condition before work.",
+    capitals: [],
+    media: [],
+    domain: Domain.AGRO,
+    createdAt: 0,
+    description: "Before assessment",
+    inputs: [
+      {
+        key: "plot",
+        title: "Plot code",
+        placeholder: "Plot A",
+        type: "text",
+        required: true,
+        options: [],
+      },
+    ],
+    mediaInfo: {
+      title: "Before photos",
+      required: true,
+      minImageCount: 1,
+      maxImageCount: 3,
+      ...mediaInfo,
+    },
+  };
+}
+
+async function selectActionAndFillRequiredFields(user: ReturnType<typeof userEvent.setup>) {
+  await user.selectOptions(screen.getByLabelText(/Action/), actionId);
+  await user.type(screen.getByLabelText(/Plot code/), "Plot A");
+}
+
+function uploadFile(container: HTMLElement, fileName = "before.png") {
+  const input = container.querySelector('input[type="file"]');
+  expect(input).not.toBeNull();
+  const file = new File(["photo"], fileName, { type: "image/png" });
+  fireEvent.change(input as HTMLInputElement, { target: { files: [file] } });
+  return file;
+}
+
+function TestProviders({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="en" messages={enMessages}>
+        <MemoryRouter initialEntries={["/hub/work/submit"]}>{children}</MemoryRouter>
+      </IntlProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe("SubmitWorkPanel submit behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState.selectedGarden = {
+      id: gardenAddress,
+      tokenAddress: gardenAddress,
+      name: "Green Goods Community Garden",
+    };
+    mockState.actions = [createAction()];
+    mockSubmitWorkDirectly.mockResolvedValue("0x123");
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:test-preview");
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => undefined);
+  });
+
+  it("renders a safe missing-garden state without a submit surface", async () => {
+    mockState.selectedGarden = null;
+
+    render(
+      <TestProviders>
+        <SubmitWorkPanel layout="page" />
+      </TestProviders>
+    );
+
+    expect(await screen.findByText("Garden not found")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Submit Work" })).not.toBeInTheDocument();
+    expect(mockSubmitWorkDirectly).not.toHaveBeenCalled();
+  });
+
+  it("blocks required-media actions before opening the wallet", async () => {
+    const user = userEvent.setup();
+
+    render(
+      <TestProviders>
+        <SubmitWorkPanel layout="page" />
+      </TestProviders>
+    );
+
+    await selectActionAndFillRequiredFields(user);
+    await user.click(screen.getByRole("button", { name: "Submit Work" }));
+
+    await waitFor(() => {
+      expect(mockValidationFormError).toHaveBeenCalledWith("At least one image is required");
+    });
+    expect(mockSubmitWorkDirectly).not.toHaveBeenCalled();
+  });
+
+  it("treats required media with no minImageCount as requiring one image", async () => {
+    mockState.actions = [createAction({ required: true, minImageCount: undefined })];
+    const user = userEvent.setup();
+
+    render(
+      <TestProviders>
+        <SubmitWorkPanel layout="page" />
+      </TestProviders>
+    );
+
+    await selectActionAndFillRequiredFields(user);
+    await user.click(screen.getByRole("button", { name: "Submit Work" }));
+
+    await waitFor(() => {
+      expect(mockValidationFormError).toHaveBeenCalledWith("At least one image is required");
+    });
+    expect(mockSubmitWorkDirectly).not.toHaveBeenCalled();
+  });
+
+  it("allows optional media actions with minImageCount 0 to submit without images", async () => {
+    mockState.actions = [createAction({ required: false, minImageCount: 0 })];
+    const user = userEvent.setup();
+
+    render(
+      <TestProviders>
+        <SubmitWorkPanel layout="page" />
+      </TestProviders>
+    );
+
+    await selectActionAndFillRequiredFields(user);
+    await user.click(screen.getByRole("button", { name: "Submit Work" }));
+
+    await waitFor(() => {
+      expect(mockSubmitWorkDirectly).toHaveBeenCalledWith(
+        expect.objectContaining({ media: [] }),
+        gardenAddress,
+        42,
+        "Site Assessment (Before)",
+        chainId,
+        [],
+        expect.any(Object)
+      );
+    });
+    expect(mockValidationFormError).not.toHaveBeenCalled();
+  });
+
+  it("blocks required-media actions until the configured minImageCount is met", async () => {
+    mockState.actions = [createAction({ required: true, minImageCount: 2 })];
+    const user = userEvent.setup();
+
+    const { container } = render(
+      <TestProviders>
+        <SubmitWorkPanel layout="page" />
+      </TestProviders>
+    );
+
+    await selectActionAndFillRequiredFields(user);
+    uploadFile(container);
+    await user.click(screen.getByRole("button", { name: "Submit Work" }));
+
+    await waitFor(() => {
+      expect(mockValidationFormError).toHaveBeenCalledWith("At least 2 images are required");
+    });
+    expect(mockSubmitWorkDirectly).not.toHaveBeenCalled();
+  });
+
+  it("submits when required media is present", async () => {
+    const user = userEvent.setup();
+
+    const { container } = render(
+      <TestProviders>
+        <SubmitWorkPanel layout="page" />
+      </TestProviders>
+    );
+
+    await selectActionAndFillRequiredFields(user);
+    const file = uploadFile(container);
+
+    await user.click(screen.getByRole("button", { name: "Submit Work" }));
+
+    await waitFor(() => {
+      expect(mockSubmitWorkDirectly).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionUID: 42,
+          details: expect.objectContaining({ plot: "Plot A" }),
+          media: [file],
+          title: "Site Assessment (Before)",
+        }),
+        gardenAddress,
+        42,
+        "Site Assessment (Before)",
+        chainId,
+        [file],
+        expect.any(Object)
+      );
+    });
+  });
+
+  it("shows reconnect guidance when a wrapped wallet session error is available", async () => {
+    mockSubmitWorkDirectly.mockRejectedValue(
+      new Error("Transaction failed", { cause: new Error("Connector not connected") })
+    );
+
+    const user = userEvent.setup();
+
+    const { container } = render(
+      <TestProviders>
+        <SubmitWorkPanel layout="page" />
+      </TestProviders>
+    );
+
+    await selectActionAndFillRequiredFields(user);
+    uploadFile(container);
+
+    await user.click(screen.getByRole("button", { name: "Submit Work" }));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            "Wallet session unavailable. Disconnect and reconnect your wallet, then try again.",
+        })
+      );
+    });
+  });
+});

--- a/packages/admin/src/views/Garden/SubmitWork.tsx
+++ b/packages/admin/src/views/Garden/SubmitWork.tsx
@@ -22,6 +22,7 @@ import {
   submitWorkDirectly,
   Textarea,
   toastService,
+  validationToasts,
   useAdminGardenWorkspaceSelection,
   useActions,
   useAuthState,
@@ -31,6 +32,7 @@ import {
   useWorkForm,
   type WorkInput,
 } from "@green-goods/shared";
+import { validateWorkSubmissionContext } from "@green-goods/shared/modules";
 import { RiUploadCloudLine } from "@remixicon/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
@@ -212,6 +214,15 @@ function DynamicWorkFields({
   );
 }
 
+function getMinRequiredImages(action: Action | null) {
+  if (!action?.mediaInfo?.required) return 0;
+  return action.mediaInfo.minImageCount ?? 1;
+}
+
+function getOriginalError(error: unknown) {
+  return error instanceof Error && error.cause instanceof Error ? error.cause : error;
+}
+
 type SubmitWorkLayout = "page" | "sheet";
 
 export interface SubmitWorkPanelProps {
@@ -322,14 +333,15 @@ export function SubmitWorkPanel({ layout = "page", onSuccess, onCancel }: Submit
     },
     onError: (error: unknown) => {
       setProgressMessage("");
-      const { title, message } = parseAndFormatError(error);
-      logger.error("Admin work submission failed", { error });
+      const originalError = getOriginalError(error);
+      const { title, message } = parseAndFormatError(originalError);
+      logger.error("Admin work submission failed", { error, originalError });
 
       toastService.error({
         title: title || formatMessage({ id: "app.admin.work.submit.error" }),
         message,
         context: "admin work submission",
-        error,
+        error: originalError,
       });
     },
     onSettled: () => {
@@ -340,6 +352,21 @@ export function SubmitWorkPanel({ layout = "page", onSuccess, onCancel }: Submit
   useBeforeUnloadWhilePending(mutation.isPending);
 
   const onSubmit = handleSubmit((data) => {
+    const actionUID = selectedAction ? parseActionUID(selectedAction.id) : null;
+    const validationErrors = validateWorkSubmissionContext(
+      garden.id as Address,
+      actionUID,
+      images,
+      {
+        minRequired: getMinRequiredImages(selectedAction),
+      }
+    );
+
+    if (validationErrors.length > 0) {
+      validationToasts.formError(validationErrors[0]);
+      return;
+    }
+
     if (!selectedAction) return;
     mutation.mutate(data as Record<string, unknown>);
   });

--- a/packages/admin/src/views/Hub/Hub.stories.tsx
+++ b/packages/admin/src/views/Hub/Hub.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
-import { expect, waitFor, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import {
   STORYBOOK_ADMIN_SHELL_SEEDS,
   STORYBOOK_PRIMARY_ADMIN_GARDEN,
@@ -90,10 +90,20 @@ export const WorkDetail: Story = {
 };
 
 export const SubmitWorkSheet: Story = {
-  args: { initialPath: "/hub/work/submit?sort=newest" },
+  tags: ["storybook-ci"],
+  args: {
+    initialPath: `/hub/work/submit?gardenAddress=${STORYBOOK_PRIMARY_ADMIN_GARDEN.id}&sort=oldest`,
+  },
   decorators: hubDecorators(),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+    await expect(
+      await canvas.findByRole(
+        "button",
+        { name: /Rio Rainforest Lab/ },
+        ADMIN_ROUTE_STORY_QUERY_OPTIONS
+      )
+    ).toBeVisible();
     const leftSheet = await canvas.findByTestId(
       "left-sheet",
       undefined,
@@ -103,6 +113,20 @@ export const SubmitWorkSheet: Story = {
     await expect(
       await within(leftSheet).findByText("Submit Work", undefined, ADMIN_ROUTE_STORY_QUERY_OPTIONS)
     ).toBeVisible();
+    await userEvent.click(
+      await within(leftSheet).findByTestId(
+        "left-sheet-close",
+        undefined,
+        ADMIN_ROUTE_STORY_QUERY_OPTIONS
+      )
+    );
+    await waitFor(() => expect(canvas.queryByTestId("left-sheet")).not.toBeInTheDocument());
+    await expect(
+      await canvas.findByText("Canopy transect upload", undefined, ADMIN_ROUTE_STORY_QUERY_OPTIONS)
+    ).toBeVisible();
+    await expect(
+      await canvas.findByLabelText("Sort by", undefined, ADMIN_ROUTE_STORY_QUERY_OPTIONS)
+    ).toHaveValue("oldest");
   },
 };
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -198,6 +198,7 @@ export {
   toastService,
   TxInlineFeedback,
   updateToasts,
+  validationToasts,
   VaultPositionCard,
   WorkCard as WorkCardComponent,
   GardenCard as GardenCardComponent,

--- a/packages/shared/src/modules/index.ts
+++ b/packages/shared/src/modules/index.ts
@@ -313,4 +313,5 @@ export { submitWorkDirectly } from "./work/wallet-submission";
 export {
   getSubmissionStatusText,
   validateApprovalDraft,
+  validateWorkSubmissionContext,
 } from "./work/work-submission";

--- a/packages/shared/src/utils/errors/__tests__/contract-errors.test.ts
+++ b/packages/shared/src/utils/errors/__tests__/contract-errors.test.ts
@@ -330,4 +330,14 @@ describe("parseAndFormatError", () => {
     expect(result.parsed.name).toBe("NotGardenOperator");
     expect(result.title).toContain("Garden Operator");
   });
+
+  it("formats wallet session errors with reconnect guidance", () => {
+    const result = parseAndFormatError(new Error("Connector not connected"));
+
+    expect(result.parsed.name).toBe("WalletSessionUnavailable");
+    expect(result.title).toBe("Wallet Session Unavailable");
+    expect(result.message).toBe(
+      "Wallet session unavailable. Disconnect and reconnect your wallet, then try again."
+    );
+  });
 });

--- a/packages/shared/src/utils/errors/contract-errors.ts
+++ b/packages/shared/src/utils/errors/contract-errors.ts
@@ -488,7 +488,30 @@ export function parseContractError(error: unknown): ParsedContractError {
     };
   }
 
-  // 2. Wallet balance / gas errors
+  // 2. Wallet connector/session errors. Keep this before generic network
+  // handling so stale WalletConnect/AppKit sessions get actionable recovery.
+  if (
+    lowerStr.includes("connector not connected") ||
+    lowerStr.includes("wallet not connected") ||
+    lowerStr.includes("wallet disconnected") ||
+    lowerStr.includes("provider disconnected") ||
+    lowerStr.includes("session expired") ||
+    lowerStr.includes("session disconnected") ||
+    ((lowerStr.includes("wallet") || lowerStr.includes("connector")) &&
+      lowerStr.includes("session") &&
+      (lowerStr.includes("expired") || lowerStr.includes("unavailable")))
+  ) {
+    return {
+      raw: signature ?? errorStr,
+      name: "WalletSessionUnavailable",
+      message: "Wallet session unavailable. Disconnect and reconnect your wallet, then try again.",
+      isKnown: true,
+      recoverable: true,
+      suggestedAction: "check-wallet",
+    };
+  }
+
+  // 3. Wallet balance / gas errors
   if (
     lowerStr.includes("insufficient funds") ||
     lowerStr.includes("insufficient balance") ||
@@ -530,7 +553,7 @@ export function parseContractError(error: unknown): ParsedContractError {
     };
   }
 
-  // 3. Manual validation errors (from simulation layer) — must precede the
+  // 4. Manual validation errors (from simulation layer) — must precede the
   //    generic "validation" word match below.
   if (errorStr.includes("Validation failed")) {
     const cleanMessage = errorStr.replace(/^Error:\s*/, "");
@@ -544,7 +567,7 @@ export function parseContractError(error: unknown): ParsedContractError {
     };
   }
 
-  // 4. Media upload service unconfigured (specific — must precede generic IPFS).
+  // 5. Media upload service unconfigured (specific — must precede generic IPFS).
   if (
     lowerStr.includes("media upload not initialized") ||
     lowerStr.includes("ipfs upload service is not configured") ||
@@ -560,7 +583,7 @@ export function parseContractError(error: unknown): ParsedContractError {
     };
   }
 
-  // 5. IPFS / media upload failures (recoverable)
+  // 6. IPFS / media upload failures (recoverable)
   if (
     lowerStr.includes("ipfs") ||
     lowerStr.includes("failed to upload") ||
@@ -576,7 +599,7 @@ export function parseContractError(error: unknown): ParsedContractError {
     };
   }
 
-  // 6. Storage errors (quota first — more specific message)
+  // 7. Storage errors (quota first — more specific message)
   if (lowerStr.includes("quota")) {
     return {
       raw: signature ?? errorStr,
@@ -599,7 +622,7 @@ export function parseContractError(error: unknown): ParsedContractError {
     };
   }
 
-  // 7. Offline (specific) before generic network
+  // 8. Offline (specific) before generic network
   if (lowerStr.includes("offline") || lowerStr.includes("you are offline")) {
     return {
       raw: signature ?? errorStr,
@@ -611,7 +634,7 @@ export function parseContractError(error: unknown): ParsedContractError {
     };
   }
 
-  // 8. Network / timeout (recoverable)
+  // 9. Network / timeout (recoverable)
   if (lowerStr.includes("timeout") || lowerStr.includes("timed out")) {
     return {
       raw: signature ?? errorStr,
@@ -639,7 +662,7 @@ export function parseContractError(error: unknown): ParsedContractError {
     };
   }
 
-  // 9. Permission / authorization (generic — specific contract reverts like
+  // 10. Permission / authorization (generic — specific contract reverts like
   //    NotGardenMember are caught by the signature/name loop above).
   if (
     lowerStr.includes("unauthorized") ||
@@ -658,7 +681,7 @@ export function parseContractError(error: unknown): ParsedContractError {
     };
   }
 
-  // 10. Generic execution reverted with no specific reason — last because
+  // 11. Generic execution reverted with no specific reason — last because
   //     "reverted" is broad and signature-based reverts above carry richer copy.
   if (
     lowerStr.includes("execution reverted") ||
@@ -674,7 +697,7 @@ export function parseContractError(error: unknown): ParsedContractError {
     };
   }
 
-  // 11. Generic validation fallback (after the more-specific "Validation failed" above)
+  // 12. Generic validation fallback (after the more-specific "Validation failed" above)
   if (
     lowerStr.includes("required field") ||
     lowerStr.includes("invalid format") ||


### PR DESCRIPTION
## Summary
- Block invalid admin Submit Work required-media submissions before wallet/upload/direct submit by reusing shared validation.
- Preserve specific wallet/session root-cause errors when admin submit fails.
- Add regression tests and Storybook proof for Submit Work, Hub deep-link context, garden switching, vault context, and Domains modal coverage.

## Validation
- [x] GitHub PR checks / CI Gate — passed on PR #542
- [x] `APP_ENV=test node ../../scripts/dev/node-cli.js vitest run src/views/Garden/garden-domain-ui.test.tsx src/views/Garden/SubmitWork.submit.test.tsx` — 12 passed
- [x] shared parser/work tests — 55 passed
- [x] `bun run --cwd packages/admin test` — 444 passed / 3 skipped
- [x] `bun run --cwd packages/admin build`
- [x] `bun lint` — passed with existing warnings
- [x] `bun run lint:vocab`
- [x] Story coverage — 174/174
- [x] Full Storybook CI — 138 passed
- [ ] `bun run test` root aggregate — local linked-worktree/env blockers outside this diff: contracts submodule install denied, indexer generated setup could not fetch pnpm, and one agent storage test failed

Refs PRD-577