### PR TITLE
fix(client,admin): tag staging sentry environment

### DIFF
--- a/docs/docs/builders/env-management.mdx
+++ b/docs/docs/builders/env-management.mdx
@@ -62,6 +62,17 @@ bun run env:check
 
 The app gracefully degrades when optional values are missing (analytics off, fallback gateways used, etc.) — only a small set of keys are strictly required to boot the dev stack: `APP_ENV`, `VITE_CHAIN_ID`, `VITE_API_BASE_URL`, `VITE_ENVIO_INDEXER_URL`.
 
+## Sentry deployment environment
+
+Client and admin Sentry DSNs resolve during the Vite build, then the browser bundle receives them
+as `VITE_SENTRY_CLIENT_DSN` and `VITE_SENTRY_ADMIN_DSN`. The browser Sentry `environment` tag
+resolves separately from `SENTRY_ENVIRONMENT`, `VERCEL_TARGET_ENV`, `VERCEL_ENV`, `APP_ENV`, and
+finally Vite mode.
+
+For Vercel staging, prefer the custom deployment target so `VERCEL_TARGET_ENV=staging` is available
+at build time. If that system variable is unavailable for a deployment path, set
+`SENTRY_ENVIRONMENT=staging` on the staging environment.
+
 ## Regenerating `.env.template`
 
 Run this when `.env.schema` adds or removes keys, or when the team's 1Password vault structure changes:

--- a/packages/admin/src/main.tsx
+++ b/packages/admin/src/main.tsx
@@ -38,7 +38,7 @@ const cleanupTheme = initTheme();
 
 initBrowserSentry({
   dsn: import.meta.env.VITE_SENTRY_ADMIN_DSN,
-  environment: import.meta.env.MODE,
+  environment: import.meta.env.VITE_SENTRY_ENVIRONMENT || import.meta.env.MODE,
   release: import.meta.env.VITE_APP_VERSION
     ? `green-goods-admin@${import.meta.env.VITE_APP_VERSION}`
     : undefined,

--- a/packages/admin/src/vite-env.d.ts
+++ b/packages/admin/src/vite-env.d.ts
@@ -19,6 +19,7 @@ interface ImportMetaEnv {
   readonly VITE_PINATA_GATEWAY_URL?: string;
   readonly VITE_APP_VERSION?: string;
   readonly VITE_SENTRY_ADMIN_DSN?: string;
+  readonly VITE_SENTRY_ENVIRONMENT?: string;
   readonly VITE_SENTRY_DEBUG?: string;
 }
 

--- a/packages/admin/vite.config.ts
+++ b/packages/admin/vite.config.ts
@@ -36,6 +36,27 @@ function resolveAdminSentryDsn(): string | undefined {
   );
 }
 
+function normalizeSentryEnvironment(value: string | undefined): string | undefined {
+  const environment = value?.trim().toLowerCase();
+  if (!environment) return undefined;
+  if (environment === "prod") return "production";
+  return environment;
+}
+
+function resolveSentryEnvironment(mode: string): string {
+  return (
+    normalizeSentryEnvironment(envValue("SENTRY_ENVIRONMENT")) ||
+    normalizeSentryEnvironment(envValue("VITE_SENTRY_ENVIRONMENT")) ||
+    normalizeSentryEnvironment(envValue("VERCEL_TARGET_ENV")) ||
+    normalizeSentryEnvironment(envValue("VITE_VERCEL_TARGET_ENV")) ||
+    normalizeSentryEnvironment(envValue("VERCEL_ENV")) ||
+    normalizeSentryEnvironment(envValue("VITE_VERCEL_ENV")) ||
+    normalizeSentryEnvironment(envValue("APP_ENV")) ||
+    normalizeSentryEnvironment(mode) ||
+    "development"
+  );
+}
+
 function deleteSourceMapsInDirectory(directory: string): void {
   if (!existsSync(directory)) return;
 
@@ -145,6 +166,7 @@ export default defineConfig(async ({ command, mode }): Promise<UserConfig> => {
   }
   const enableSourceMaps = shouldUploadSentrySourceMaps;
   const sentryDsn = resolveAdminSentryDsn();
+  const sentryEnvironment = resolveSentryEnvironment(mode);
   // Env-parity gate (PRD-567): a production deploy must ship with a resolvable
   // Sentry DSN, or error tracking silently no-ops — the May Sentry thrash. This
   // reuses the value resolved above, so it only fires when Sentry would truly be
@@ -252,6 +274,7 @@ export default defineConfig(async ({ command, mode }): Promise<UserConfig> => {
     define: {
       "import.meta.env.VITE_APP_VERSION": JSON.stringify(shortAppVersion),
       "import.meta.env.VITE_SENTRY_ADMIN_DSN": JSON.stringify(sentryDsn ?? ""),
+      "import.meta.env.VITE_SENTRY_ENVIRONMENT": JSON.stringify(sentryEnvironment),
     },
     plugins,
     // Deduplicate React, PostHog, and Sentry to prevent multiple instances

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -17,7 +17,7 @@ initTheme();
 
 initBrowserSentry({
   dsn: import.meta.env.VITE_SENTRY_CLIENT_DSN,
-  environment: import.meta.env.MODE,
+  environment: import.meta.env.VITE_SENTRY_ENVIRONMENT || import.meta.env.MODE,
   release: import.meta.env.VITE_APP_VERSION
     ? `green-goods-client@${import.meta.env.VITE_APP_VERSION}`
     : undefined,

--- a/packages/client/src/vite-env.d.ts
+++ b/packages/client/src/vite-env.d.ts
@@ -22,6 +22,7 @@ interface ImportMetaEnv {
   readonly VITE_PINATA_GATEWAY_URL?: string;
   readonly VITE_CAMPAIGN_COOKIE_JARS?: string;
   readonly VITE_SENTRY_CLIENT_DSN?: string;
+  readonly VITE_SENTRY_ENVIRONMENT?: string;
   readonly VITE_SENTRY_DEBUG?: string;
 }
 

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -39,6 +39,27 @@ function resolveClientSentryDsn(): string | undefined {
   );
 }
 
+function normalizeSentryEnvironment(value: string | undefined): string | undefined {
+  const environment = value?.trim().toLowerCase();
+  if (!environment) return undefined;
+  if (environment === "prod") return "production";
+  return environment;
+}
+
+function resolveSentryEnvironment(mode: string): string {
+  return (
+    normalizeSentryEnvironment(envValue("SENTRY_ENVIRONMENT")) ||
+    normalizeSentryEnvironment(envValue("VITE_SENTRY_ENVIRONMENT")) ||
+    normalizeSentryEnvironment(envValue("VERCEL_TARGET_ENV")) ||
+    normalizeSentryEnvironment(envValue("VITE_VERCEL_TARGET_ENV")) ||
+    normalizeSentryEnvironment(envValue("VERCEL_ENV")) ||
+    normalizeSentryEnvironment(envValue("VITE_VERCEL_ENV")) ||
+    normalizeSentryEnvironment(envValue("APP_ENV")) ||
+    normalizeSentryEnvironment(mode) ||
+    "development"
+  );
+}
+
 function deleteSourceMapsInDirectory(directory: string): void {
   if (!existsSync(directory)) return;
 
@@ -148,6 +169,7 @@ export default defineConfig(async ({ command, mode }) => {
   }
   const enableSourceMaps = shouldUploadSentrySourceMaps;
   const sentryDsn = resolveClientSentryDsn();
+  const sentryEnvironment = resolveSentryEnvironment(mode);
   // Env-parity gate (PRD-567): a production deploy must ship with a resolvable
   // Sentry DSN, or error tracking silently no-ops — the May Sentry thrash. This
   // reuses the value resolved above, so it only fires when Sentry would truly be
@@ -433,6 +455,7 @@ export default defineConfig(async ({ command, mode }) => {
       "import.meta.env.PROD": JSON.stringify(nodeEnv === "production"),
       "import.meta.env.VITE_APP_VERSION": JSON.stringify(shortAppVersion),
       "import.meta.env.VITE_SENTRY_CLIENT_DSN": JSON.stringify(sentryDsn ?? ""),
+      "import.meta.env.VITE_SENTRY_ENVIRONMENT": JSON.stringify(sentryEnvironment),
       "process.env.NODE_ENV": JSON.stringify(nodeEnv),
     },
     esbuild: {


### PR DESCRIPTION
## Summary
- Resolve the browser Sentry environment separately from Vite mode so staging deployments can report `environment=staging`.
- Define `VITE_SENTRY_ENVIRONMENT` at build time from `SENTRY_ENVIRONMENT`, Vercel target env, Vercel env, or `APP_ENV` before falling back to Vite mode.
- Document the staging Sentry environment behavior in env management docs.

## Validation
- [x] `git diff --check`
- [x] `bun run format:check`
- [x] `VERCEL_TARGET_ENV=staging ... bun run build:client` passes and emitted `environment:"staging"`
- [x] `VERCEL_TARGET_ENV=staging ... bun run build:admin` passes and emitted `environment:"staging"`
- [x] `git push` pre-push checks passed; repo lint emitted existing warnings only