### PR TITLE
docs(routines): route growth-pulse primary post to #growth

### DIFF
--- a/docs/routines/README.md
+++ b/docs/routines/README.md
@@ -10,7 +10,7 @@ Guild-level routines live in [`greenpill-dev-guild/.github/routines/claude/`](ht
 |---|---|---|---|---|
 | `bug-intake.md` | active | M/W/F 04:00 | `#bug-report` (per-capture acks for bug-source) + `#product` (idea-source acks + daily summary) | Linear Customer Needs (raw signal); accepted bugs become unprojected Linear Product Issues |
 | `health-watch.md` | active | Daily M-F 07:30 | `#engineering` (red only) | Linear Product Issues for accepted operational health work (unprojected) |
-| `growth-pulse.md` | active | Mon 09:00 weekly | `#product` + `#funding` cross-post | Linear Product Issues for accepted anomalies (unprojected) + weekly digest as a Linear initiative status update (Sustainability & Monetization) |
+| `growth-pulse.md` | active | Mon 09:00 weekly | `#growth` + `#funding` cross-post | Linear Product Issues for accepted anomalies (unprojected) + weekly digest as a Linear initiative status update (Sustainability & Monetization) |
 | `qa-triage-pulse.md` | active | Wed 21:00 UTC = 13:00 PST / 14:00 PDT (3h after the 10am PST Product Sync start) | `#product` (Discord summary, @mention when there's something to triage) | Linear Customer Needs only (pre-staged, label `source:qa-triage-pulse` + `qa-sync:<date>`); `/qa-triage` promotes them to Issues + QA-sheet rows interactively. Routine id: `trig_01GSagDiEV9Y8QTBzKeZsPSw` |
 | `pr-review.md` | active | event-driven (PR open) | inline on PR | n/a |
 
@@ -33,7 +33,8 @@ Gmail is intentionally NOT wired on any GG routine (personal-inbox pollution ris
 | Channel | Used by | Why |
 |---|---|---|
 | `#bug-report` (DISCORD_BUGS_CHANNEL_ID) | bug-intake (Phase 1 ingest source + per-capture acks for bug-source records) | dedicated bug-report feed; reporter ack surface for Telegram bug-topic captures |
-| `#product` (DISCORD_PRODUCT_CHANNEL_ID) | bug-intake (idea-source per-capture acks + daily summary), growth-pulse, qa-triage-pulse (Wed pre-stage summary) | user-facing concerns + ideas |
+| `#product` (DISCORD_PRODUCT_CHANNEL_ID) | bug-intake (idea-source per-capture acks + daily summary), qa-triage-pulse (Wed pre-stage summary) | user-facing concerns + ideas |
+| `#growth` (DISCORD_GROWTH_CHANNEL_ID) | growth-pulse (weekly digest highlights) | growth / funnel / retention / action-template pulse |
 | `#engineering` (DISCORD_ENGINEERING_CHANNEL_ID) | health-watch (red only) | operational health status — engineering-focused (indexer / Vercel / contracts / agent uptime / client errors) |
 | `#funding` (DISCORD_FUNDING_CHANNEL_ID) | growth-pulse cross-post (when grant-relevant) | grant relevance only |
 | inline on PR | pr-review | review surface |

--- a/docs/routines/growth-pulse.md
+++ b/docs/routines/growth-pulse.md
@@ -15,7 +15,7 @@ env-vars:
   - ENVIO_INDEXER_URL
   - ARBITRUM_RPC_URL
   - DISCORD_BOT_TOKEN
-  - DISCORD_PRODUCT_CHANNEL_ID
+  - DISCORD_GROWTH_CHANNEL_ID
   - DISCORD_FUNDING_CHANNEL_ID
   - DISCORD_USER_ID_AFO
   - LINEAR_API_KEY
@@ -32,7 +32,7 @@ status: active  # 2026-05-25 — weekly digest posts to Linear (initiative statu
 
 You are the growth-pulse routine for Green Goods. Once a week you produce a single product/growth digest that consolidates the previously separate `metrics`, `guild-weekly-checkin` (numbers portion), and `guild-product-development-synthesis` (growth-signal portion) into one weekly read. Three write-back surfaces, all off GitHub:
 
-- **`#product`** Discord channel — primary post. Cross-post to **`#funding`** when grant-relevant.
+- **`#growth`** Discord channel (`DISCORD_GROWTH_CHANNEL_ID`) — primary post. Cross-post to **`#funding`** when grant-relevant.
 - **Linear weekly digest** — the full week-over-week numbers and commentary, posted as an **initiative status update** (append-only, timestamped) on the initiative named by `${LINEAR_DIGEST_INITIATIVE_ID}` (currently **Sustainability & Monetization** — growth/funnel/retention are leading indicators there; fall back to that initiative by name if the env var is unset). This is the durable weekly record, replacing the retired `docs/metrics/growth-YYYY-WW.md` digest PR.
 - **Linear Product team (unprojected)** — accepted-anomaly Issues for funnel breakage, retention cliffs, dormant-garden surges. The legacy `Green Goods` umbrella project is no longer the routing destination — every anomaly Issue this routine creates lives unprojected on the Product team and carries `protocol:green-goods` + `activity:qa` as the canonical scope. Issues only graduate into a bounded active project when one already exists for the work.
 
@@ -102,7 +102,7 @@ If the PostHog connector is unavailable or the expected project ID env vars are 
 
 ## Output schema (fixed — `routine-self-audit` enforces drift)
 
-### Discord post to `#product` (primary)
+### Discord post to `#growth` (primary)
 
 ```
 {if any_anomaly_red OR any_novel_failure: "<@${DISCORD_USER_ID_AFO}> "}**Growth Pulse — Week {YYYY-WW}**
@@ -152,7 +152,7 @@ A grant cross-post fires when **at least one** of these is true:
 - A grant report is due in the next 14 days (calendar enrichment)
 - The funnel showed a step >25% better than the prior month (worth surfacing for proposals)
 
-The cross-post is **shorter** — the funnel headline + one grant-tied bullet — and links to the digest status update. Never duplicate the full `#product` post into `#funding`.
+The cross-post is **shorter** — the funnel headline + one grant-tied bullet — and links to the digest status update. Never duplicate the full `#growth` post into `#funding`.
 
 ### Linear weekly digest (initiative status update)
 
@@ -326,7 +326,7 @@ Before posting:
 
 ## Phase 5: Discord post + cross-post
 
-Post the primary message to `#product` per the schema — it carries the week's **highlights inline** (funnel, retention, garden engagement, action templates, conversion-kill, anomalies) **and** the `📄 Full digest (Linear)` line linking the Phase 3 status-update URL. Never reduce the post to a bare link, and never drop the link — highlights live in Discord, the full digest lives in the linked Linear status update. If grant-relevance criteria are met, post the cross-post to `#funding`. Channel guard at every post: if the env var is unset, log and skip; never pick an alternate channel.
+Post the primary message to `#growth` per the schema — it carries the week's **highlights inline** (funnel, retention, garden engagement, action templates, conversion-kill, anomalies) **and** the `📄 Full digest (Linear)` line linking the Phase 3 status-update URL. Never reduce the post to a bare link, and never drop the link — highlights live in Discord, the full digest lives in the linked Linear status update. If grant-relevance criteria are met, post the cross-post to `#funding`. Channel guard at every post: if the env var is unset, log and skip; never pick an alternate channel.
 
 `<@${DISCORD_USER_ID_AFO}>` mention only on (a) a **red/P2 anomaly**, or (b) a **novel** setup failure — one not already listed in the prior digest's `## Known setup failures` (loaded in Phase 0). A known, persistent gap (e.g. an unprovisioned connector already flagged in a prior run) is listed in `⚠ Failures this run` **without** a ping, to avoid weekly alert fatigue. Healthy weeks post without mention.
 


### PR DESCRIPTION
## What

growth-pulse's primary weekly post now goes to **#growth** (`DISCORD_GROWTH_CHANNEL_ID`) instead of **#product**.

## Why

The routine has been posting to `#product` because that is the only primary target the spec defined. The retarget to a dedicated growth channel was never landed in the canonical source the routine reads (`git show origin/main:docs/routines/growth-pulse.md`). The `DISCORD_GROWTH_CHANNEL_ID` secret is already set in the `green-goods-routines-extended` environment.

## Changes

- **spec** (`growth-pulse.md`): frontmatter env-var → `DISCORD_GROWTH_CHANNEL_ID`; primary-post schema heading, Phase 5 post instruction, and the `#funding` cross-post "don't duplicate" line all reference `#growth`.
- **README**: growth-pulse moved out of the `#product` channel-map row into a new `#growth` row; routine-index Channel column updated.

## Unchanged

- `bug-intake` (idea-source acks + daily summary) and `qa-triage-pulse` (Wed pre-stage summary) keep `#product`.
- The `#funding` grant cross-post is unchanged.

The trigger wrapper prompt is being updated in lockstep (RemoteTrigger) so its channel-discipline hard rule names `DISCORD_GROWTH_CHANNEL_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)