### PR TITLE
fix(admin): propagate workspace color identity to all surfaces

### DIFF
--- a/packages/admin/src/components/AdminButton.stories.tsx
+++ b/packages/admin/src/components/AdminButton.stories.tsx
@@ -120,8 +120,14 @@ const ButtonToneMatrix = ({ theme }: { theme: "light" | "dark" }) => (
             <AdminButton variant="tonal" size="sm">
               Tonal
             </AdminButton>
+            <AdminButton variant="elevated" size="sm">
+              Elevated
+            </AdminButton>
             <AdminButton variant="outlined" size="sm">
               Outlined
+            </AdminButton>
+            <AdminButton variant="text" size="sm" leadingIcon={<RiArrowRightLine />}>
+              Text
             </AdminButton>
           </div>
         </div>

--- a/packages/admin/src/components/AdminButton.tsx
+++ b/packages/admin/src/components/AdminButton.tsx
@@ -44,20 +44,20 @@ export const adminButtonVariants = tv({
       ],
       // Elevated — medium emphasis with surface tint
       elevated: [
-        "bg-[rgb(var(--m3-surface-container-low))] [color:rgb(var(--m3-primary))]",
+        "bg-[rgb(var(--m3-surface-container-low))] [color:rgb(var(--tone-on-surface-accent,var(--m3-primary)))]",
         "shadow-[var(--m3-elevation-1)] hover:shadow-[var(--m3-elevation-2)]",
         "[--state-layer-color:var(--m3-primary)]",
       ],
       // Outlined — low emphasis with border
       outlined: [
-        "bg-transparent [color:rgb(var(--m3-primary))]",
+        "bg-transparent [color:rgb(var(--tone-on-surface-accent,var(--m3-primary)))]",
         "border border-[rgb(var(--m3-outline))]",
         "shadow-[var(--m3-elevation-0)]",
         "[--state-layer-color:var(--m3-primary)]",
       ],
       // Text — lowest emphasis
       text: [
-        "bg-transparent [color:rgb(var(--m3-primary))]",
+        "bg-transparent [color:rgb(var(--tone-on-surface-accent,var(--m3-primary)))]",
         "shadow-[var(--m3-elevation-0)]",
         "[--state-layer-color:var(--m3-primary)]",
       ],

--- a/packages/admin/src/components/AdminTextField.stories.tsx
+++ b/packages/admin/src/components/AdminTextField.stories.tsx
@@ -1,5 +1,6 @@
 import { RiMailLine, RiSearchLine } from "@remixicon/react";
 import type { Meta, StoryObj } from "@storybook/react";
+import { expect, userEvent, within } from "storybook/test";
 import { withAdminPrimitiveFrame } from "../../../shared/.storybook/decorators";
 import { AdminTextField } from "./AdminTextField";
 
@@ -112,4 +113,62 @@ export const OutlinedAtSectionTop: Story = {
       </div>
     </section>
   ),
+};
+
+const WORKSPACE_TONES = [
+  ["hub", "Hub"],
+  ["garden", "Garden"],
+  ["community", "Community"],
+  ["actions", "Actions"],
+] as const;
+
+const TextFieldToneMatrix = ({ theme }: { theme: "light" | "dark" }) => (
+  <section
+    data-theme={theme}
+    className="admin-m3 rounded-[var(--m3-shape-lg)] bg-[rgb(var(--m3-surface))] p-4"
+  >
+    <div className="mb-3 text-label-md font-semibold uppercase text-[rgb(var(--m3-on-surface-variant))]">
+      {theme}
+    </div>
+    <div className="grid gap-3 md:grid-cols-2">
+      {WORKSPACE_TONES.map(([tone, label]) => (
+        <div
+          key={`${theme}-${tone}`}
+          data-tone={tone}
+          className="space-y-3 rounded-[var(--m3-shape-md)] border border-[rgb(var(--m3-outline-variant))] bg-[rgb(var(--m3-surface-container-low))] p-3"
+        >
+          <div className="text-label-md font-medium text-[rgb(var(--m3-on-surface-variant))]">
+            {label}
+          </div>
+          <AdminTextField
+            label={`${theme} ${label} filled`}
+            variant="filled"
+            defaultValue="North Meadow"
+            helperText="Focus shows the workspace accent line."
+          />
+          <AdminTextField
+            label={`${theme} ${label} outlined`}
+            variant="outlined"
+            defaultValue="North Meadow"
+            helperText="Focus shows the workspace accent ring."
+          />
+        </div>
+      ))}
+    </div>
+  </section>
+);
+
+export const WorkspaceToneMatrix: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <TextFieldToneMatrix theme="light" />
+      <TextFieldToneMatrix theme="dark" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const actionsField = canvas.getByRole("textbox", { name: "dark Actions outlined" });
+    await userEvent.click(actionsField);
+    await expect(actionsField).toHaveFocus();
+  },
 };

--- a/packages/admin/src/components/AdminTextField.tsx
+++ b/packages/admin/src/components/AdminTextField.tsx
@@ -125,7 +125,9 @@ export const AdminTextField = React.forwardRef<HTMLInputElement, AdminTextFieldP
       // Remove browser defaults
       "outline-none border-none focus:outline-none focus:border-none",
       // Caret color
-      hasError ? "caret-[rgb(var(--m3-error))]" : "caret-[rgb(var(--m3-primary))]",
+      hasError
+        ? "caret-[rgb(var(--m3-error))]"
+        : "caret-[rgb(var(--tone-on-surface-accent,var(--m3-primary)))]",
       // Placeholder — only visible when focused and empty
       "placeholder-[rgb(var(--m3-on-surface-variant)/0.6)]",
       !focused && "placeholder-transparent",
@@ -198,7 +200,7 @@ export const AdminTextField = React.forwardRef<HTMLInputElement, AdminTextFieldP
                       hasError
                         ? "text-[rgb(var(--m3-error))]"
                         : focused
-                          ? "text-[rgb(var(--m3-primary))]"
+                          ? "text-[rgb(var(--tone-on-surface-accent,var(--m3-primary)))]"
                           : "text-[rgb(var(--m3-on-surface-variant))]",
                     ]
                   : [
@@ -270,7 +272,7 @@ export const AdminTextField = React.forwardRef<HTMLInputElement, AdminTextFieldP
               hasError
                 ? "h-0.5 bg-[rgb(var(--m3-error))]"
                 : focused
-                  ? "h-0.5 bg-[rgb(var(--m3-primary))]"
+                  ? "h-0.5 bg-[rgb(var(--tone-on-surface-accent,var(--m3-primary)))]"
                   : "h-px bg-[rgb(var(--m3-on-surface-variant))]",
               disabled && "bg-[rgb(var(--m3-on-surface)/0.38)] h-px"
             )}
@@ -325,7 +327,7 @@ export const AdminTextField = React.forwardRef<HTMLInputElement, AdminTextFieldP
                 ? "ring-2 ring-inset ring-[rgb(var(--m3-error))]"
                 : "ring-2 ring-inset ring-[rgb(var(--m3-error))]"
               : focused
-                ? "ring-2 ring-inset ring-[rgb(var(--m3-primary))]"
+                ? "ring-2 ring-inset ring-[rgb(var(--tone-on-surface-accent,var(--m3-primary)))]"
                 : "ring-1 ring-inset ring-[rgb(var(--m3-outline))]",
             disabled && "ring-1 ring-inset ring-[rgb(var(--m3-on-surface)/0.38)]"
           )}
@@ -364,7 +366,7 @@ export const AdminTextField = React.forwardRef<HTMLInputElement, AdminTextFieldP
                     hasError
                       ? "text-[rgb(var(--m3-error))]"
                       : focused
-                        ? "text-[rgb(var(--m3-primary))]"
+                        ? "text-[rgb(var(--tone-on-surface-accent,var(--m3-primary)))]"
                         : "text-[rgb(var(--m3-on-surface-variant))]",
                   ]
                 : [

--- a/packages/admin/src/index.css
+++ b/packages/admin/src/index.css
@@ -419,6 +419,11 @@
   --tone-surface-tint: var(--blue-600) / 8%;
   --tone-outline: var(--blue-200);
   --tone-surface-variant: var(--blue-50);
+  /* Contrast-safe accent for tone-colored TEXT / outline / icon on light
+     surfaces (AA ≥4.5 on white). Distinct from --tone-action (filled bg w/ white
+     text) and --tone-primary (the mid fill step — too light as text, e.g.
+     green-600 ≈ 2.85:1). Consumed directly via var(); never indirected at :root. */
+  --tone-on-surface-accent: var(--blue-700);
   --tone-surface-tint-color: rgb(var(--blue-600) / 8%);
 }
 
@@ -435,6 +440,7 @@
   --tone-surface-tint: var(--green-600) / 8%;
   --tone-outline: var(--green-200);
   --tone-surface-variant: var(--green-50);
+  --tone-on-surface-accent: var(--green-800);
   --tone-surface-tint-color: rgb(var(--green-600) / 8%);
 }
 
@@ -459,6 +465,7 @@
   --tone-surface-tint: var(--yellow-500) / 8%;
   --tone-outline: var(--yellow-200);
   --tone-surface-variant: var(--yellow-50);
+  --tone-on-surface-accent: var(--orange-700);
   --tone-surface-tint-color: rgb(var(--yellow-500) / 8%);
 }
 
@@ -475,6 +482,7 @@
   --tone-surface-tint: var(--red-500) / 8%;
   --tone-outline: var(--red-200);
   --tone-surface-variant: var(--red-50);
+  --tone-on-surface-accent: var(--red-700);
   --tone-surface-tint-color: rgb(var(--red-500) / 8%);
 }
 
@@ -491,6 +499,7 @@
   --tone-surface-tint: 120 113 108 / 8%;
   --tone-outline: 214 211 209;
   --tone-surface-variant: 245 245 244;
+  --tone-on-surface-accent: 68 64 60;
   --tone-surface-tint-color: rgb(120 113 108 / 8%);
 }
 
@@ -508,6 +517,7 @@
   --tone-surface-tint: var(--blue-200) / 10%;
   --tone-outline: var(--blue-700);
   --tone-surface-variant: var(--blue-900);
+  --tone-on-surface-accent: var(--blue-200);
   --tone-surface-tint-color: rgb(var(--blue-200) / 10%);
 }
 
@@ -523,6 +533,7 @@
   --tone-surface-tint: var(--green-200) / 10%;
   --tone-outline: var(--green-700);
   --tone-surface-variant: var(--green-900);
+  --tone-on-surface-accent: var(--green-200);
   --tone-surface-tint-color: rgb(var(--green-200) / 10%);
 }
 
@@ -538,6 +549,7 @@
   --tone-surface-tint: var(--yellow-200) / 10%;
   --tone-outline: var(--yellow-700);
   --tone-surface-variant: var(--yellow-900);
+  --tone-on-surface-accent: var(--yellow-200);
   --tone-surface-tint-color: rgb(var(--yellow-200) / 10%);
 }
 
@@ -553,6 +565,7 @@
   --tone-surface-tint: var(--red-200) / 10%;
   --tone-outline: var(--red-700);
   --tone-surface-variant: var(--red-900);
+  --tone-on-surface-accent: var(--red-200);
   --tone-surface-tint-color: rgb(var(--red-200) / 10%);
 }
 
@@ -568,6 +581,7 @@
   --tone-surface-tint: 214 211 209 / 10%;
   --tone-outline: 87 83 78;
   --tone-surface-variant: 68 64 60;
+  --tone-on-surface-accent: 214 211 209;
   --tone-surface-tint-color: rgb(214 211 209 / 10%);
 }
 

--- a/packages/admin/src/styles/admin-m3-overrides.css
+++ b/packages/admin/src/styles/admin-m3-overrides.css
@@ -236,13 +236,22 @@
   background: transparent;
 }
 
-/* Sheets — liquid shell, solid inner content supplied by panels/SheetBody */
+/* Sheets — liquid shell, solid inner content supplied by panels/SheetBody.
+ * A subtle workspace wash (--tone-surface-tint-color: rgb(hue / 8–10%)) is
+ * layered OVER the neutral --admin-sheet-bg so the sheet quietly carries the
+ * active view's hue (sheets sit inside [data-tone], so the wash resolves to the
+ * current workspace; falls back to transparent when no tone is set). */
 .admin-m3 [data-component="RightSheet"][data-slot="surface"].glass-floating,
 .admin-m3 [data-component="LeftSheet"][data-slot="surface"].glass-floating,
 .admin-m3 [data-component="BottomSheet"][data-slot="surface"].glass-floating {
   backdrop-filter: blur(var(--admin-chrome-blur)) saturate(1.14);
   -webkit-backdrop-filter: blur(var(--admin-chrome-blur)) saturate(1.14);
-  background: var(--admin-sheet-bg);
+  background:
+    linear-gradient(
+      var(--tone-surface-tint-color, transparent),
+      var(--tone-surface-tint-color, transparent)
+    ),
+    var(--admin-sheet-bg);
   border-color: var(--admin-chrome-border);
 }
 

--- a/packages/admin/src/styles/admin-m3-tokens.css
+++ b/packages/admin/src/styles/admin-m3-tokens.css
@@ -70,6 +70,32 @@
 }
 
 /* --------------------------------------------------------------------------
+ * Tone-derived primary roles — RE-DECLARED at `.admin-m3` scope (scoping fix)
+ *
+ * `--m3-primary` (and the primary-container pair) indirect through
+ * `--tone-primary`, which is set per-workspace on the `[data-tone]` element —
+ * the SAME element that carries `.admin-m3` (see CanvasLayout). Declaring these
+ * only at `:root` (above) substitutes `var(--tone-primary)` at `:root`, where
+ * it is unset, so the value locks to the green fallback and that COMPUTED green
+ * inherits DOWN past the `[data-tone]` element that would have tinted it — which
+ * is why "everything was green" while only the canvas + filled button (which
+ * read `--tone-action` directly) picked up the workspace hue.
+ *
+ * Re-declaring them here, on the element that also sets `--tone-primary`,
+ * resolves the indirection in-scope, so every consumer that reads `--m3-primary`
+ * (secondary buttons, checkbox, progress, text-field accents, list selection)
+ * tints to the active workspace. Do NOT delete this as a "duplicate of :root":
+ * the `:root` copy is the no-tone fallback; THIS copy is what makes tone work.
+ * Enforced by scripts/design/check-tokens.sh.
+ * -------------------------------------------------------------------------- */
+.admin-m3 {
+  --m3-primary: var(--tone-primary, var(--green-500));
+  --m3-on-primary: var(--tone-on-primary, 255 255 255);
+  --m3-primary-container: var(--tone-primary-container, var(--green-100));
+  --m3-on-primary-container: var(--tone-on-primary-container, var(--green-900));
+}
+
+/* --------------------------------------------------------------------------
  * M3 Surface Color Aliases — Dark Mode
  * Overrides for [data-theme="dark"] adaptive dark palette
  * -------------------------------------------------------------------------- */
@@ -100,6 +126,14 @@
   --m3-on-tertiary-container: var(--warning-dark);
   --m3-error-container: var(--error-light);
   --m3-on-error-container: var(--error-dark);
+}
+
+/* Dark-mode pair of the tone-derived re-declaration above (same scoping fix). */
+[data-theme="dark"] .admin-m3 {
+  --m3-primary: var(--tone-primary, var(--green-200));
+  --m3-on-primary: var(--tone-on-primary, var(--green-900));
+  --m3-primary-container: var(--tone-primary-container, var(--green-900));
+  --m3-on-primary-container: var(--tone-on-primary-container, var(--green-100));
 }
 
 /* --------------------------------------------------------------------------

--- a/packages/admin/src/styles/admin-m3-tokens.css
+++ b/packages/admin/src/styles/admin-m3-tokens.css
@@ -129,7 +129,7 @@
 }
 
 /* Dark-mode pair of the tone-derived re-declaration above (same scoping fix). */
-[data-theme="dark"] .admin-m3 {
+:is(.admin-m3[data-theme="dark"], [data-theme="dark"] .admin-m3) {
   --m3-primary: var(--tone-primary, var(--green-200));
   --m3-on-primary: var(--tone-on-primary, var(--green-900));
   --m3-primary-container: var(--tone-primary-container, var(--green-900));

--- a/scripts/design/check-tokens.sh
+++ b/scripts/design/check-tokens.sh
@@ -329,9 +329,49 @@ if [[ -n "$ADMIN_CHROME_VIOLATIONS" ]]; then
   exit 1
 fi
 
+# ----------------------------------------------------------------------------
+# Workspace tone propagation guard
+#
+# Two regressions shipped silently before this guard existed:
+#   1. The tone-derived M3 roles (--m3-primary etc.) were declared ONLY at
+#      :root, so var(--tone-primary) substituted above the [data-tone] element
+#      and locked to the green fallback — "everything admin rendered green"
+#      while only the canvas + filled button (which read --tone-action directly)
+#      picked up the workspace hue. The fix re-declares them at .admin-m3 scope
+#      (the same element that sets --tone-primary).
+#   2. Tone-colored TEXT needs a contrast-safe step (--tone-on-surface-accent);
+#      the mid --tone-primary step fails AA as text on white (green-600 ≈ 2.85).
+# A passing story is not proof the tint reaches the DOM — these checks are.
+# ----------------------------------------------------------------------------
+ADMIN_INDEX_CSS="packages/admin/src/index.css"
+
+# (1) --m3-primary must be re-declared inside a `.admin-m3` rule, not only :root.
+if ! awk '
+  /^[^{}]*\{/ { in_admin = ($0 ~ /\.admin-m3/) }
+  /\}/        { in_admin = 0 }
+  in_admin && /--m3-primary:[[:space:]]*var\(--tone-primary/ { found = 1 }
+  END { exit(found ? 0 : 1) }
+' "$ADMIN_M3_TOKENS"; then
+  echo "❌ Workspace tone scoping regression: --m3-primary is not re-declared at .admin-m3 scope in $ADMIN_M3_TOKENS."
+  echo "   Without a .admin-m3 { --m3-primary: var(--tone-primary, …) } block, var(--tone-primary) resolves at :root (unset)"
+  echo "   and every --m3-primary consumer locks to the green fallback regardless of the active workspace."
+  exit 1
+fi
+
+# (2) Every tone block that defines --tone-action must also define a
+#     contrast-safe --tone-on-surface-accent (text/outline/icon role).
+TONE_ACTION_COUNT="$(grep -cE '^[[:space:]]*--tone-action:' "$ADMIN_INDEX_CSS" || true)"
+TONE_ACCENT_COUNT="$(grep -cE '^[[:space:]]*--tone-on-surface-accent:' "$ADMIN_INDEX_CSS" || true)"
+if [[ "$TONE_ACTION_COUNT" -eq 0 || "$TONE_ACCENT_COUNT" -ne "$TONE_ACTION_COUNT" ]]; then
+  echo "❌ Tone accent role drift in $ADMIN_INDEX_CSS: ${TONE_ACTION_COUNT} --tone-action vs ${TONE_ACCENT_COUNT} --tone-on-surface-accent declarations."
+  echo "   Every [data-tone] block (light + dark) must define a contrast-safe --tone-on-surface-accent for tone-colored text/outline/icon."
+  exit 1
+fi
+
 node scripts/design/check-css-custom-properties.mjs
 
 echo "✅ check-design-tokens: ${#EXPECTED_TOKENS[@]} runtime tokens present in theme.css."
+echo "✅ workspace tone propagation guard: --m3-primary re-declared at .admin-m3 scope; ${TONE_ACCENT_COUNT} --tone-on-surface-accent roles present."
 echo "✅ DesignMD radius outputs present in $GENERATED_CSS."
 echo "✅ admin M3 variable usages resolve to defined tokens."
 echo "✅ no new raw cubic-bezier, duration, color, radius literals, or primitive palette utilities outside token-definition or audited baseline files."


### PR DESCRIPTION
## What
Phase 1 of the admin surface-consistency overhaul. Fixes the top review complaint — "admin is all green; the per-view color only shows on the canvas + primary button."

## Root cause
`--m3-primary: var(--tone-primary, green)` was declared only at `:root`, *above* the `[data-tone]` element that sets each workspace's hue. CSS substitutes the indirection at `:root` (where `--tone-primary` is unset) → it locks to the green fallback and that computed green inherits down **past** the element that would tint it. The filled button escaped only because it reads `--tone-action` directly.

## Changes
- **Scoping fix** — re-declare the tone-derived `--m3-*` roles at `.admin-m3` scope (light + dark). One block fixes every `--m3-primary` consumer (secondary buttons, checkbox, progress, text-field accents, list selection) — zero component churn.
- **Contrast-safe accent role** — new `--tone-on-surface-accent` per tone: an AA-verified deep step for tone-colored *text/outline/icon*. The mid fill step fails on white (garden green-600 = 2.85:1); the accent uses green-800 (5.72:1). Re-points AdminButton outlined/text/elevated labels + AdminTextField accents.
- **Sheet tint** — layer a subtle per-view wash over the neutral sheet glass.
- **Enforcement** — `check:design-tokens` now asserts the `.admin-m3` re-declaration exists and every tone block defines the accent role, so neither regression ships silently again.

## Verification
- `check:design-tokens` (+ new guard), admin lint (0 errors), admin build — all green.
- Enforcement self-test: simulated regression → guard **fails**; real file → passes.
- Live DOM (authenticated Brave): `--m3-primary` resolves to blue/green/amber/red/stone per workspace (was always green-500); the accent role lands on the AA-safe deep step for each; sheet bg carries the per-tone wash. Exact RGB match across all 5 tones.

First of five phases (color → actions → surfaces → chrome → enshrine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
