### PR TITLE
fix(client): restore cookie jar wallet auth

### DIFF
--- a/packages/client/src/__tests__/manifest/vercel-routing.test.ts
+++ b/packages/client/src/__tests__/manifest/vercel-routing.test.ts
@@ -2,6 +2,11 @@ import { describe, expect, it } from "vitest";
 import vercelConfig from "../../../vercel.json";
 
 describe("client Vercel public social shell routing", () => {
+  const noStoreHeader = {
+    key: "Cache-Control",
+    value: "no-cache, no-store, must-revalidate",
+  };
+
   it("serves generated editorial shells before the catch-all SPA rewrite", () => {
     const rewrites = vercelConfig.rewrites;
     const catchAllIndex = rewrites.findIndex((rewrite) => rewrite.source === "/(.*)");
@@ -25,6 +30,13 @@ describe("client Vercel public social shell routing", () => {
     expect(vercelConfig.rewrites.at(-1)).toEqual({
       source: "/(.*)",
       destination: "/index.html",
+    });
+  });
+
+  it("serves the cookie jar editorial shell without route-level browser caching", () => {
+    expect(vercelConfig.headers).toContainEqual({
+      source: "/cookies",
+      headers: [noStoreHeader],
     });
   });
 });

--- a/packages/client/src/__tests__/views/Cookies.test.tsx
+++ b/packages/client/src/__tests__/views/Cookies.test.tsx
@@ -13,6 +13,7 @@ const TEST_TOKEN = "0x2222222222222222222222222222222222222222" as const;
 const TEST_WALLET = "0x3333333333333333333333333333333333333333" as const;
 
 const mockOpenWallet = vi.fn();
+const mockLoginWithWallet = vi.fn();
 const mockClaimMutate = vi.fn();
 const mockDepositMutate = vi.fn();
 const mockClaimReset = vi.fn();
@@ -62,10 +63,10 @@ vi.mock("wagmi", () => ({
 }));
 
 vi.mock("@green-goods/shared", async () => {
-  const actual = await vi.importActual<typeof import("@green-goods/shared")>("@green-goods/shared");
+  const React = await vi.importActual<typeof import("react")>("react");
 
   return {
-    ...actual,
+    Alert: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
     Button: ({
       children,
       loading: _loading,
@@ -75,6 +76,18 @@ vi.mock("@green-goods/shared", async () => {
         {children}
       </button>
     ),
+    classifyTxError: (error: Error | null) => ({
+      severity: "error",
+      rawMessage: error?.message ?? "",
+      messageKey: "app.transaction.error.generic",
+      titleKey: "app.transaction.error.title",
+    }),
+    cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(" "),
+    formatTokenAmount: (value: bigint, decimals = 18) => String(Number(value) / 10 ** decimals),
+    ImageWithFallback: (props: React.ImgHTMLAttributes<HTMLImageElement>) => <img {...props} />,
+    isMeaningfulTxErrorMessage: (message?: string) => Boolean(message),
+    resolveIPFSUrl: (url: string) => url,
+    truncateAddress: (address: string) => `${address.slice(0, 6)}...${address.slice(-4)}`,
     TxInlineFeedback: ({
       visible,
       title,
@@ -84,7 +97,9 @@ vi.mock("@green-goods/shared", async () => {
       title: string;
       message: string;
     }) => (visible ? <div role="alert">{`${title}: ${message}`}</div> : null),
+    useInViewReveal: () => ({ ref: React.createRef<HTMLElement>(), revealed: true }),
     useAppKit: () => ({ open: mockOpenWallet }),
+    useAuth: () => ({ loginWithWallet: mockLoginWithWallet }),
     useCampaignCookieJar: (jarAddress: string) => mockUseCampaignCookieJar(jarAddress),
     useCampaignCookieJarCampaigns: () => mockUseCampaignCookieJarCampaigns(),
     useCampaignCookieJarDeposit: () => ({
@@ -101,6 +116,7 @@ vi.mock("@green-goods/shared", async () => {
     }),
     usePublicGardens: () => mockUsePublicGardens(),
     useUser: () => mockUseUser(),
+    validateDecimalInput: () => null,
   };
 });
 
@@ -152,6 +168,7 @@ describe("CookiesPage", () => {
   });
 
   it("asks disconnected visitors to connect before claiming", async () => {
+    const user = userEvent.setup();
     mockUseUser.mockReturnValue({ primaryAddress: undefined });
 
     renderPage();
@@ -165,9 +182,11 @@ describe("CookiesPage", () => {
     expect(
       await screen.findByText(/Connect a wallet to check claim access and add funds/i)
     ).toBeInTheDocument();
-    expect(screen.getAllByRole("button", { name: "Connect wallet" }).length).toBeGreaterThanOrEqual(
-      1
-    );
+    const connectButtons = screen.getAllByRole("button", { name: "Connect wallet" });
+    expect(connectButtons.length).toBeGreaterThanOrEqual(1);
+    await user.click(connectButtons[0]!);
+    expect(mockLoginWithWallet).toHaveBeenCalledTimes(1);
+    expect(mockOpenWallet).not.toHaveBeenCalled();
   });
 
   it("claims a fixed cookie amount for an eligible wallet", async () => {

--- a/packages/client/src/components/Public/PublicCookieJarCard.tsx
+++ b/packages/client/src/components/Public/PublicCookieJarCard.tsx
@@ -11,7 +11,7 @@ import {
   type PublicGardenSummary,
   resolveIPFSUrl,
   TxInlineFeedback,
-  useAppKit,
+  useAuth,
   useCampaignCookieJar,
   useCampaignCookieJarDeposit,
   useCampaignCookieJarWithdraw,
@@ -438,7 +438,7 @@ function CampaignCookieJarInlineActions({
 }) {
   const { formatMessage, locale } = useIntl();
   const { primaryAddress } = useUser();
-  const { open: openWalletModal } = useAppKit();
+  const { loginWithWallet } = useAuth();
   const claimId = useId();
   const depositId = useId();
   const [claimAmount, setClaimAmount] = useState("");
@@ -539,7 +539,7 @@ function CampaignCookieJarInlineActions({
 
   const handleClaim = () => {
     if (!primaryAddress) {
-      openWalletModal();
+      loginWithWallet();
       return;
     }
     if (claimDisabled) return;
@@ -559,7 +559,7 @@ function CampaignCookieJarInlineActions({
 
   const handleDeposit = () => {
     if (!primaryAddress) {
-      openWalletModal();
+      loginWithWallet();
       return;
     }
     if (depositDisabled) return;
@@ -584,7 +584,7 @@ function CampaignCookieJarInlineActions({
             defaultMessage: "Connect a wallet to check claim access and add funds.",
           })}
         </p>
-        <Button className="mt-4" onClick={() => openWalletModal()}>
+        <Button className="mt-4" onClick={() => loginWithWallet()}>
           {formatMessage({
             id: "public.cookies.connectWallet",
             defaultMessage: "Connect wallet",

--- a/packages/client/vercel.json
+++ b/packages/client/vercel.json
@@ -96,6 +96,15 @@
       ]
     },
     {
+      "source": "/cookies",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "no-cache, no-store, must-revalidate"
+        }
+      ]
+    },
+    {
       "source": "/glossary",
       "headers": [
         {


### PR DESCRIPTION
## Summary
- Route `/cookies` wallet connect actions through shared `loginWithWallet()` so wallet auth state is persisted after WalletConnect returns.
- Add no-store cache headers for `/cookies` and route coverage to avoid stale editorial shell state.

## Validation
- [x] `bun run test src/__tests__/views/Cookies.test.tsx src/__tests__/manifest/vercel-routing.test.ts`
- [ ] `bun run build` blocked locally because the installed `node_modules` is missing `@sentry/vite-plugin`, though it is declared in `packages/client/package.json` and `bun.lock`.