### PR TITLE
docs(plans): add resend signup migration plan

### DIFF
--- a/.plans/active/resend-email-signup-migration/brief.md
+++ b/.plans/active/resend-email-signup-migration/brief.md
@@ -1,0 +1,50 @@
+# Resend Email Signup Migration
+
+**Slug**: `resend-email-signup-migration`
+**Stage**: `active`
+**Priority**: `p2`
+**Created**: `2026-06-15T19:04:43.563Z`
+**Linear Issue**: PRD-598
+**Linear Project**: Green Goods Public Website & Docs Polish
+**Linear Source**: source:plans
+
+## Problem
+
+Green Goods currently captures public email subscribers by importing people into Luma through the
+public Agent route. That worked as a quick calendar-adjacent list, but it is now an expensive
+dependency for a simple subscriber-capture use case. The product already uses Resend in the wider
+Greenpill ecosystem, and Resend is a better fit for a developer-owned signup flow where Green Goods
+controls the form, consent copy, source metadata, and welcome/update messaging.
+
+The current code also leaks the provider name into public contracts and copy through
+`luma_import_failed`, which makes future provider swaps harder and makes the public API less
+accurate once Luma is removed.
+
+## Desired Outcome
+
+- Green Goods public subscribers are created or updated as Resend contacts from the existing
+  `POST /public/subscribe` route.
+- The public signup form keeps the same simple user experience: email, consent microcopy, honest
+  success only after the provider confirms capture, and a provider-neutral failure state.
+- Resend captures non-sensitive subscriber metadata: source, locale when present, consented
+  timestamp, and a Green Goods signup marker.
+- Luma API keys, calendar IDs, tag IDs, and Luma-specific service/test names are removed or
+  superseded.
+- Existing public API protections remain intact: origin allowlist, rate limiting, body-size guard,
+  email validation, consent requirement, and generic external-provider errors.
+- Contracts, indexer schema, wallet flows, payment flows, and admin UI do not change.
+
+## Scope Notes
+
+- In scope: `packages/agent` subscription provider adapter and config, the public subscribe route
+  dependency injection, focused agent tests, shared public error contracts, shared i18n strings,
+  client comments/tests that mention Luma, and docs/config references for root env variables.
+- Out of scope: adding a marketing CRM UI, importing historical Luma subscribers, creating a new
+  database table, changing the public form layout, changing opt-in policy, adding contracts/indexer
+  work, or wiring production Resend credentials in code.
+
+## Success Signal
+
+A public homepage signup produces a real Resend Green Goods contact with consent/source metadata,
+while the route still rejects invalid/unauthorized/unconfigured requests and the client shows only
+provider-neutral success or failure copy.

--- a/.plans/active/resend-email-signup-migration/eval.md
+++ b/.plans/active/resend-email-signup-migration/eval.md
@@ -1,0 +1,51 @@
+# Resend Email Signup Migration Evaluation Plan
+
+## Release Gates
+
+1. Correctness: valid subscription requests create/update a Resend contact with source, locale
+   when present, consent timestamp, and a Green Goods signup marker.
+2. Usability: the public homepage signup remains visually and behaviorally unchanged except for
+   provider-neutral failure copy.
+3. Regression safety: invalid email, missing consent, disallowed origin, rate limit, oversized
+   body, and missing-provider paths keep returning safe failures.
+4. Evidence quality: research evidence and open assumptions are recorded before implementation.
+5. Human judgment: protected surfaces and maintainer-call decisions are called out before merge.
+
+## Acceptance Checks
+
+| ID | Behavior Boundary | Check | Owner | Evidence |
+|---|---|---|---|---|
+| AC-1 | Resend provider adapter | Adapter tests prove create/update/already-subscribed behavior, request shape, and upstream failure handling without logging sensitive details. | `state_api` | `handoffs/codex-state-api.md` |
+| AC-2 | Public subscribe route | Public API tests prove existing validation guards and success/failure response shape after the provider swap. | `state_api` | `handoffs/codex-state-api.md` |
+| AC-3 | Shared/client provider-neutral copy | Shared public contracts and all locale files use provider-neutral error names; client tests still pass for payload and success reset. | `ui` | `handoffs/claude-ui.md` |
+| AC-4 | No out-of-scope surfaces | Diff review confirms no contracts, indexer schema, wallet, payment, or admin changes. | `qa_pass_1` | `handoffs/claude-qa-pass-1.md` |
+| AC-5 | Live provider proof | Authenticated Brave or operator-led QA confirms a test/staging signup appears in Resend, or records that proof is blocked by missing credentials. | `qa_pass_1` | `handoffs/claude-qa-pass-1.md` |
+| AC-6 | Regression review | Codex reruns focused validation and quick repo verification before PR handoff. | `qa_pass_2` | `handoffs/codex-qa-pass-2.md` |
+
+## Test Strategy
+
+- Unit: focused provider adapter tests replacing `luma.test.ts` with Resend request/response
+  behavior.
+- Integration: public Agent API tests for `POST /public/subscribe` success, duplicate/already
+  subscribed, missing provider, invalid email, missing consent, oversized payload, CORS, and rate
+  limiting.
+- E2E / Playwright: none required for the provider adapter itself; clean-room browser proof is not a
+  substitute for live Resend contact creation.
+- Manual checks: authenticated Brave QA against the public homepage subscribe path when a safe
+  Resend test/staging key is configured.
+- TDD proof: RED/GREEN commands and evidence are recorded in lane handoffs and summarized in
+  `status.json`.
+
+## QA Sequence
+
+### Claude QA Pass 1
+
+- Focus on UX issues, provider-neutral copy, missing requirements, test gaps, and live provider
+  proof availability.
+- If blocked, record the blocker in `handoffs/claude-qa-pass-1.md`
+
+### Codex QA Pass 2
+
+- Start only after `qa_pass_1` is passed
+- Confirm the trigger branch exists: `claude/qa-pass-1/resend-email-signup-migration`
+- Re-run targeted validation and close the loop on remaining defects

--- a/.plans/active/resend-email-signup-migration/handoffs/README.md
+++ b/.plans/active/resend-email-signup-migration/handoffs/README.md
@@ -1,0 +1,28 @@
+# Handoffs
+
+Keep lane handoffs short and factual. Use one file per lane:
+
+- `claude-ui.md`
+- `codex-state-api.md`
+- `codex-contracts.md`
+- `claude-qa-pass-1.md`
+- `codex-qa-pass-2.md`
+
+Each handoff should capture:
+
+1. What changed
+2. What remains
+3. TDD proof
+4. Validation run
+5. Known risks or blockers
+6. Repo-truth references from the active hub or reports, not tool-local memory claims
+
+Use this short proof block for implementation lanes:
+
+```markdown
+## TDD Proof
+
+- RED: command + expected failing result
+- GREEN: command + passing result
+- Proof limit: `none`, `not_applicable`, or the exact reason TDD could not honestly apply
+```

--- a/.plans/active/resend-email-signup-migration/plan.todo.md
+++ b/.plans/active/resend-email-signup-migration/plan.todo.md
@@ -1,0 +1,99 @@
+# Resend Email Signup Migration Plan
+
+**Linear Issue**: PRD-598
+**Linear Project**: Green Goods Public Website & Docs Polish
+**Linear Source**: source:plans
+**Feature Slug**: `resend-email-signup-migration`
+**Stage**: `active`
+**Status**: `ACTIVE`
+**Created**: `2026-06-15T19:04:43.563Z`
+**Last Updated**: `2026-06-15T19:12:00Z`
+
+## Decision Log
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Use Resend as the replacement provider | It matches the existing Greenpill ecosystem and is a simpler fit for subscriber capture than Luma calendar import. |
+| 2 | Keep `POST /public/subscribe` as the public API boundary | The client form and tests already depend on this route; swapping the backend provider should not change the user flow. |
+| 3 | Rename public errors to provider-neutral language | `luma_import_failed` will become inaccurate after migration and would make future provider changes more expensive. |
+| 4 | Treat historical subscriber import as out of scope | Export/import needs real Luma data and operator review; mixing it into the adapter PR raises risk. |
+| 5 | No contracts/indexer/admin lane | The migration is provider/API/client-copy work only. |
+
+## Research / Plan Gate
+
+- [x] Record research evidence in `spec.md`
+- [x] Identify the existing repo pattern to mirror
+- [x] List human judgment points before implementation
+- [x] Define what is out of scope
+- [x] Choose the lightest honest validation commands
+
+## Requirements Coverage
+
+| Requirement | Lane | Planned Step | Status |
+|---|---|---|---|
+| Resend captures public subscribers through existing route | `state_api` | Steps 1-3 | Not started |
+| Existing validation/CORS/rate-limit behavior remains intact | `state_api` | Steps 2-3 | Not started |
+| Provider errors are neutral and translated | `state_api`, `ui` | Steps 3-4 | Not started |
+| Client form keeps same behavior and copy intent | `ui` | Step 4 | Not started |
+| Root env/config/docs identify Resend requirements | `state_api` | Step 5 | Not started |
+| No contract/indexer/admin work included | `contracts` | Step 0 boundary | N/A |
+
+## TDD / Proof Order
+
+- [x] Identify the behavior boundary for each implementation lane before editing code
+- [ ] Write or select the minimal failing test/proof first
+- [ ] Run the RED command and record evidence in the lane handoff
+- [ ] Implement the smallest change that can satisfy the proof
+- [ ] Run the GREEN command and record evidence in the lane handoff
+- [ ] Record machine-readable proof with `node scripts/harness/plan-hub.mjs record-tdd`
+- [ ] If TDD cannot honestly apply, record `not_applicable` or `proof_limit` with a concrete note in `status.json`
+
+## Lane Checklists
+
+### UI (`claude/ui/resend-email-signup-migration`)
+
+- [ ] Update `PublicGetInTouch` comments/tests only where they mention Luma-specific behavior.
+- [ ] Preserve the current email field, consent microcopy, source payload, success reset, and
+  schedule-a-call fallback behavior.
+- [ ] Add or rename i18n keys in `en`, `es`, and `pt` for provider-neutral failure copy.
+- [ ] Record RED/GREEN proof or a proof-limit note before marking the lane complete
+- [ ] Write `handoffs/claude-ui.md`
+
+### State / API (`codex/state-api/resend-email-signup-migration`)
+
+- [ ] Step 1: add a Resend subscription client in `packages/agent` with focused adapter tests.
+- [ ] Step 2: change Agent config/bootstrap/server deps from Luma-specific names to a
+  provider-neutral subscription client.
+- [ ] Step 3: preserve public subscribe validation while routing success/failure through Resend.
+- [ ] Step 4: update shared public error contracts and all three locale files.
+- [ ] Step 5: update docs/config references for required root env variables, segment/topic IDs, and
+  Luma shutdown notes.
+- [ ] Record RED/GREEN proof or a proof-limit note before marking the lane complete
+- [ ] Write `handoffs/codex-state-api.md`
+
+### Contracts (`codex/contracts/resend-email-signup-migration`)
+
+- [x] Mark lane `n/a`; no Solidity, deployment, or indexer schema change is planned.
+
+### QA Pass 1 (`claude/qa-pass-1/resend-email-signup-migration`)
+
+- [ ] Review UI behavior and public user flow.
+- [ ] Verify acceptance criteria from `eval.md`
+- [ ] Use authenticated Brave QA for the public homepage subscribe path if Resend test/staging
+  credentials are configured; otherwise record QA as blocked by missing provider credentials.
+- [ ] Write `handoffs/claude-qa-pass-1.md`
+
+### QA Pass 2 (`codex/qa-pass-2/resend-email-signup-migration`)
+
+- [ ] Review regressions and implementation edges
+- [ ] Run targeted validation commands
+- [ ] Write `handoffs/codex-qa-pass-2.md`
+
+## Validation
+
+- [ ] Focused Agent tests after provider rename, for example
+  `bun run --filter @green-goods/agent test -- resend public-api`
+- [ ] Focused Client test:
+  `bun run --filter @green-goods/client test -- PublicGetInTouch`
+- [ ] Vocabulary/i18n guard if strings change: `bun run lint:vocab`
+- [ ] Quick repo verification before PR: `node scripts/dev/ci-local.js --quick`

--- a/.plans/active/resend-email-signup-migration/spec.md
+++ b/.plans/active/resend-email-signup-migration/spec.md
@@ -1,0 +1,121 @@
+# Resend Email Signup Migration Spec
+
+## Summary
+
+Replace the public email subscriber provider from Luma to Resend while preserving the existing
+Green Goods public subscription contract. The Agent should expose the same protected
+`POST /public/subscribe` route, but internally create/update a Resend contact and route that contact
+into the Green Goods subscriber audience using current Resend contact metadata, segment, and topic
+capabilities. Public client behavior remains intentionally quiet and honest: no fake success when
+the provider is unavailable, no new consent checkbox, and no provider-specific error copy.
+
+## Users
+
+- Primary: public Green Goods visitors who subscribe from the homepage contact section.
+- Secondary: Green Goods operators who need a lower-cost subscriber list that can be used for
+  seasonal broadcasts and lightweight welcome/follow-up automation.
+
+## Functional Requirements
+
+1. `POST /public/subscribe` creates or updates a Resend contact for the submitted email and returns
+   `{ ok: true, status: "subscribed" | "already_subscribed" }` without changing the public success
+   shape.
+2. The Resend contact stores non-sensitive properties: source, locale when supplied, consented
+   timestamp, and a Green Goods signup marker.
+3. Subscriber routing uses current Resend contacts, segments, and/or topics APIs; do not build on
+   deprecated Resend Audiences APIs.
+4. If Resend is not configured or returns an upstream error, the API returns a provider-neutral
+   error code and the client renders translated, provider-neutral failure copy.
+5. Existing public protections stay in place: CORS origin checks, rate limiting, payload-size
+   limits, email validation, consent validation, and generic external-error responses.
+6. Luma-specific config names, service names, tests, and public i18n keys are removed or superseded
+   where touched by this migration.
+7. No package-level `.env` files are added; all provider configuration stays in the root environment
+   pattern and typed Agent config.
+
+## Research Evidence
+
+- Existing pattern references:
+  - `packages/agent/src/services/luma.ts` is the current provider adapter with a narrow injected
+    client interface and focused fetch tests.
+  - `packages/agent/src/api/server.ts` owns public route validation before provider calls.
+  - `packages/client/src/components/Public/PublicGetInTouch.tsx` owns the public form and already
+    sends `email`, `consent: true`, and `source: "homepage_get_in_touch"`.
+  - `packages/shared/src/public-contracts/index.ts` owns public API error/status types.
+  - `packages/shared/src/i18n/en.json`, `es.json`, and `pt.json` contain the current public
+    subscribe success/error messages.
+- Source files, tests, or docs reviewed:
+  - `packages/agent/src/__tests__/luma.test.ts`
+  - `packages/agent/src/__tests__/public-api.test.ts`
+  - `packages/client/src/__tests__/components/PublicGetInTouch.test.tsx`
+  - `packages/agent/src/config.ts`
+  - `packages/agent/src/index.ts`
+  - `packages/client/DESIGN.browser.md`
+  - Resend docs for contact creation, broadcasts, and automations.
+- Evidence confirmed:
+  - Current code calls Luma `calendar/import-people` with calendar and tag config.
+  - Public API tests already cover consent/email validation, honest provider success, missing
+    provider failure, and oversized payload rejection.
+  - Client tests already verify consent microcopy, API payload shape, configured route usage, and
+    clearing the email field after confirmed success.
+  - Shared public contracts currently include `luma_import_failed`.
+- Open inferences or assumptions:
+  - A Resend API key and contact routing identifiers will be supplied in the root environment, not
+    committed to the repo.
+  - Green Goods wants single opt-in to remain unchanged unless product explicitly decides to add
+    double opt-in or an out-of-band confirmation automation.
+  - Historical Luma subscriber export/import is intentionally separate from this implementation
+    unless a maintainer supplies an export and asks to add an import lane.
+
+## Human Judgment Points
+
+- Decisions that need maintainer judgment:
+  - Whether Resend should route contacts through a segment, topic, both, or a naming convention that
+    mirrors Greenpill Network.
+  - Whether to send an immediate welcome/confirmation automation in Resend as part of launch or keep
+    the first release to capture-only.
+  - Whether any historical Luma subscribers should be migrated manually before Luma is turned down.
+- Protected or high-risk surfaces:
+  - Public Agent route behavior in `packages/agent/src/api/server.ts`.
+  - Public API contract changes in `packages/shared/src/public-contracts/index.ts`.
+  - Root environment variable naming and deployment configuration.
+- Tradeoffs to keep visible during review:
+  - Provider-neutral API names cost a little refactor time now but make future email-provider changes
+    cheaper.
+  - Capture-only migration is safer than adding automation and migration in the same PR.
+  - Real provider QA needs a staging/test Resend key; without it, local tests can prove request
+    shape but not live contact creation.
+
+## Non-Functional Constraints
+
+- Package boundaries: provider integration belongs in `packages/agent`; shared API shapes and i18n
+  belong in `packages/shared`; the public form remains in `packages/client`.
+- Performance: keep the route synchronous and bounded, matching current behavior; do not introduce a
+  polling or queue dependency for the first migration.
+- Security: do not log email addresses, API keys, Resend contact IDs, or provider response bodies in
+  public errors. Preserve generic user-facing failures.
+- Offline / sync: no offline behavior is required for the public browser subscribe route.
+- Localization: every new or renamed user-facing string must be added to `en`, `es`, and `pt`.
+
+## Package / Lane Mapping
+
+| Area | Lane | Notes |
+|---|---|---|
+| UI | `ui` | Provider-neutral public form comments/copy/tests only; no layout change planned |
+| State / API | `state_api` | Primary lane: Agent Resend adapter, config, route dependency, shared contract/i18n |
+| Contracts | `contracts` | `n/a`; no Solidity/deployment/indexer work planned |
+| QA | `qa_pass_1`, `qa_pass_2` | Sequential; live provider QA requires configured Resend test/staging credentials |
+
+## Risks
+
+- Risk: Resend duplicate-contact semantics differ from Luma's current `409` handling.
+  Mitigation: codify expected create/update/already-subscribed behavior in focused adapter tests
+  before changing the public route.
+- Risk: provider-specific error code rename breaks client error lookup.
+  Mitigation: update shared type, i18n keys, client tests, and public API tests in the same lane.
+- Risk: production is deployed without Resend credentials and public signup goes dark.
+  Mitigation: keep missing-provider failure explicit, document root env variables, and require a
+  staging/prod config checklist before Luma shutdown.
+- Risk: scope creeps into newsletter strategy or subscriber import.
+  Mitigation: keep capture migration separate; track welcome automations and historical import only
+  if a maintainer accepts them as follow-up work.

--- a/.plans/active/resend-email-signup-migration/status.json
+++ b/.plans/active/resend-email-signup-migration/status.json
@@ -1,0 +1,157 @@
+{
+  "version": 1,
+  "feature": {
+    "slug": "resend-email-signup-migration",
+    "title": "Resend Email Signup Migration",
+    "kind": "feature",
+    "stage": "active"
+  },
+  "workflow": {
+    "overall_status": "active",
+    "priority": "p2",
+    "created_at": "2026-06-15T19:04:43.563Z",
+    "updated_at": "2026-06-15T19:07:32.438Z"
+  },
+  "links": {
+    "brief": "brief.md",
+    "spec": "spec.md",
+    "plan": "plan.todo.md",
+    "eval": "eval.md"
+  },
+  "linear": {
+    "parentIssue": "PRD-598",
+    "project": "Green Goods Public Website & Docs Polish",
+    "initiative": null,
+    "syncDirection": "plans_to_linear_visibility",
+    "lastSyncedAt": "2026-06-15T19:07:32.438Z",
+    "lanes": {}
+  },
+  "taxonomy": {
+    "initiative": "public-experience",
+    "tracks": ["agent", "client-browser", "shared"],
+    "work_types": ["implementation", "ops", "qa"],
+    "surfaces": ["packages/agent", "packages/client", "packages/shared"],
+    "depends_on_features": []
+  },
+  "notes": [
+    "Linear mirror: PRD-598.",
+    "Primary implementation surface is packages/agent; packages/client and packages/shared are secondary touched surfaces.",
+    "Current code imports public subscribers into Luma through packages/agent/src/services/luma.ts and exposes luma_import_failed through shared public contracts.",
+    "Use current Resend contacts/segments/topics APIs; do not build new work on deprecated Resend Audiences APIs.",
+    "Historical Luma subscriber import is out of scope unless a maintainer supplies an export and accepts a follow-up lane.",
+    "Live provider QA needs a safe Resend test/staging key. Without credentials, record QA as blocked instead of claiming live capture proof.",
+    "Mark unused lanes as n/a before promoting QA.",
+    "status.json is authoritative; branch names are automation signals.",
+    "Use targeted bun run test or bun run test as the iterative gate for the touched surface; coverage is scheduled or pre-merge evidence.",
+    ".plans/ is the durable repo truth; any tool-local or .claude/agent-memory surface stays environment-local until freshness and ownership rules exist."
+  ],
+  "lanes": {
+    "ui": {
+      "owner": "claude",
+      "status": "ready",
+      "branch": "claude/ui/resend-email-signup-migration",
+      "depends_on": ["state_api"],
+      "handoff": "handoffs/claude-ui.md",
+      "handoff_note": "Provider-neutral client comments/tests and localized failure copy only; preserve the current public form layout and payload.",
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": ""
+      },
+      "skill_tags": ["ui", "frontend-design", "react"]
+    },
+    "state_api": {
+      "owner": "codex",
+      "status": "ready",
+      "branch": "codex/state-api/resend-email-signup-migration",
+      "depends_on": [],
+      "handoff": "handoffs/codex-state-api.md",
+      "handoff_note": "Primary lane. Replace Luma adapter/config/bootstrap with a Resend-backed subscription client, preserve public subscribe route guards, and update shared public contracts/i18n.",
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": ""
+      },
+      "skill_tags": ["agent", "api", "testing"]
+    },
+    "contracts": {
+      "owner": "codex",
+      "status": "n/a",
+      "branch": "codex/contracts/resend-email-signup-migration",
+      "depends_on": [],
+      "handoff": "handoffs/codex-contracts.md",
+      "handoff_note": "No Solidity, deployment, or indexer schema work is planned for this provider migration.",
+      "tdd": {
+        "mode": "not_applicable",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": "Provider migration only; no contract behavior changes."
+      },
+      "skill_tags": ["contracts"]
+    },
+    "qa_pass_1": {
+      "owner": "claude",
+      "status": "blocked",
+      "ready_when_dependencies_met": true,
+      "manual_blocked": false,
+      "branch": "claude/qa-pass-1/resend-email-signup-migration",
+      "depends_on": ["ui", "state_api"],
+      "handoff": "handoffs/claude-qa-pass-1.md",
+      "handoff_note": "Review public homepage subscribe behavior, provider-neutral copy, Resend live-proof availability, and no out-of-scope surface changes.",
+      "skill_tags": ["testing", "review", "ui"]
+    },
+    "qa_pass_2": {
+      "owner": "codex",
+      "status": "blocked",
+      "ready_when_dependencies_met": true,
+      "manual_blocked": false,
+      "branch": "codex/qa-pass-2/resend-email-signup-migration",
+      "branch_trigger": "claude/qa-pass-1/resend-email-signup-migration",
+      "depends_on": ["qa_pass_1"],
+      "handoff": "handoffs/codex-qa-pass-2.md",
+      "handoff_note": "Re-run focused provider/API/client validation and node scripts/dev/ci-local.js --quick before PR handoff.",
+      "skill_tags": ["testing", "review"]
+    }
+  },
+  "history": [
+    {
+      "timestamp": "2026-06-15T19:04:43.565Z",
+      "actor": "human",
+      "lane": "system",
+      "status": "scaffolded",
+      "branch": null,
+      "note": "Scaffolded feature hub in active"
+    },
+    {
+      "timestamp": "2026-06-15T19:07:32.438Z",
+      "actor": "codex",
+      "lane": "system",
+      "status": "linear_recorded",
+      "branch": null,
+      "note": "Recorded Linear parent/lane issue identifiers"
+    }
+  ]
+}

--- a/.plans/active/resend-email-signup-migration/status.json
+++ b/.plans/active/resend-email-signup-migration/status.json
@@ -10,7 +10,7 @@
     "overall_status": "active",
     "priority": "p2",
     "created_at": "2026-06-15T19:04:43.563Z",
-    "updated_at": "2026-06-15T19:07:32.438Z"
+    "updated_at": "2026-06-15T23:27:27.976Z"
   },
   "links": {
     "brief": "brief.md",
@@ -23,8 +23,15 @@
     "project": "Green Goods Public Website & Docs Polish",
     "initiative": null,
     "syncDirection": "plans_to_linear_visibility",
-    "lastSyncedAt": "2026-06-15T19:07:32.438Z",
-    "lanes": {}
+    "lastSyncedAt": "2026-06-15T23:27:27.976Z",
+    "lanes": {
+      "state_api": {
+        "issue": "PRD-599"
+      },
+      "ui": {
+        "issue": "PRD-600"
+      }
+    }
   },
   "taxonomy": {
     "initiative": "public-experience",
@@ -147,6 +154,14 @@
     },
     {
       "timestamp": "2026-06-15T19:07:32.438Z",
+      "actor": "codex",
+      "lane": "system",
+      "status": "linear_recorded",
+      "branch": null,
+      "note": "Recorded Linear parent/lane issue identifiers"
+    },
+    {
+      "timestamp": "2026-06-15T23:27:27.977Z",
       "actor": "codex",
       "lane": "system",
       "status": "linear_recorded",


### PR DESCRIPTION
## Summary
- Extract the Resend email signup migration `.plans` hub into its own metadata-only PR.
- Preserve the Linear-backed plan source for PRD-598, PRD-599, and PRD-600 without coupling it to admin or garden-access fixes.

## Validation
- [x] `node scripts/harness/plan-hub.mjs validate`

Linear: PRD-598
