### PR TITLE
fix(shared,admin): rebind admin garden switching context

### DIFF
--- a/packages/admin/src/__tests__/components/CanvasLayout.test.tsx
+++ b/packages/admin/src/__tests__/components/CanvasLayout.test.tsx
@@ -340,6 +340,37 @@ describe("CanvasLayout", () => {
     expect(screen.getByTestId("active-path")).toHaveTextContent("/actions");
   });
 
+  it("passes the selected garden through the app bar switcher to URL sync", async () => {
+    const user = userEvent.setup();
+    mockEligibleAdminGardens.current = {
+      eligibleGardens: [
+        { id: "garden-1", name: "Garden One", location: "Quito" },
+        { id: "garden-2", name: "Garden Two", location: "Bogota" },
+      ],
+      resolvedDefaultGarden: { id: "garden-1", name: "Garden One", location: "Quito" },
+      persistedGardenId: null,
+      scopeKey: "0x123:10",
+      canCreateGarden: true,
+      isLoaded: true,
+    };
+
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/hub/work?gardenAddress=garden-1"]}>
+        <CanvasLayout />
+      </MemoryRouter>
+    );
+
+    await user.click(screen.getByRole("button", { name: "Select Garden Two" }));
+
+    expect(mockSetUrlGarden).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "garden-2",
+        name: "Garden Two",
+        location: "Bogota",
+      })
+    );
+  });
+
   it.each([
     ["/hub/work/attestation-1", "/hub"],
     ["/hub/work/submit", "/hub"],

--- a/packages/admin/src/__tests__/views/GardenVaultView.test.tsx
+++ b/packages/admin/src/__tests__/views/GardenVaultView.test.tsx
@@ -6,6 +6,10 @@ const mockUseGardens = vi.fn();
 const mockUseGardenVaults = vi.fn();
 const mockUseGardenPermissions = vi.fn();
 const mockUseLocation = vi.fn();
+const mockRouteParams = { current: { id: "garden-1" } as { id?: string } };
+const mockSelectedGarden = {
+  current: { id: "garden-1", tokenAddress: "garden-1", name: "Alpha Garden" },
+};
 
 vi.mock("@green-goods/shared", () => ({
   cn: (...classes: Array<string | false | null | undefined>) => classes.filter(Boolean).join(" "),
@@ -17,10 +21,10 @@ vi.mock("@green-goods/shared", () => ({
   },
   useAdminStore: (selector: (state: any) => any) =>
     selector({
-      selectedGarden: { id: "garden-1", name: "Alpha Garden" },
+      selectedGarden: mockSelectedGarden.current,
     }),
   useAdminGardenWorkspaceSelection: () => ({
-    selectedGarden: { id: "garden-1", name: "Alpha Garden" },
+    selectedGarden: mockSelectedGarden.current,
   }),
   useGardens: () => mockUseGardens(),
   useGardenVaults: (...args: unknown[]) => mockUseGardenVaults(...args),
@@ -42,15 +46,16 @@ vi.mock("wagmi", () => ({
 }));
 
 vi.mock("react-router-dom", () => ({
-  useParams: () => ({ id: "garden-1" }),
+  useParams: () => mockRouteParams.current,
   useLocation: () => mockUseLocation(),
 }));
 
 vi.mock("@/components/Layout/PageHeader", () => ({
-  PageHeader: ({ backLink }: { backLink?: { to: string } }) =>
+  PageHeader: ({ backLink, description }: { backLink?: { to: string }; description?: string }) =>
     React.createElement("div", {
       "data-testid": "page-header",
       "data-back-link": backLink?.to ?? "",
+      "data-description": description ?? "",
     }),
 }));
 
@@ -66,6 +71,8 @@ import GardenVaultView from "@/views/Garden/Vault";
 describe("GardenVaultView", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRouteParams.current = { id: "garden-1" };
+    mockSelectedGarden.current = { id: "garden-1", tokenAddress: "garden-1", name: "Alpha Garden" };
     mockUseGardenPermissions.mockReturnValue({
       canManageGarden: () => false,
       isOwnerOfGarden: () => false,
@@ -103,5 +110,28 @@ describe("GardenVaultView", () => {
       "data-back-link",
       "/community/treasury?gardenAddress=garden-1"
     );
+  });
+
+  it("renders the selected garden vault context when the base garden list is stale", () => {
+    mockRouteParams.current = {};
+    mockSelectedGarden.current = {
+      id: "garden-2",
+      tokenAddress: "garden-2",
+      name: "Beta Garden",
+    };
+    mockUseLocation.mockReturnValue({ state: null });
+    mockUseGardens.mockReturnValue({
+      data: [{ id: "garden-1", name: "Alpha Garden" }],
+      isLoading: false,
+    });
+
+    renderWithProviders(<GardenVaultView />);
+
+    expect(screen.getByTestId("page-header")).toHaveAttribute(
+      "data-description",
+      "Manage direct endowment positions and impact-yield routing for Beta Garden."
+    );
+    expect(mockUseGardenVaults).toHaveBeenCalledWith("garden-2", { enabled: true });
+    expect(screen.queryByText("app.treasury.gardenNotFound")).not.toBeInTheDocument();
   });
 });

--- a/packages/admin/src/__tests__/views/GardenVaultView.test.tsx
+++ b/packages/admin/src/__tests__/views/GardenVaultView.test.tsx
@@ -112,6 +112,28 @@ describe("GardenVaultView", () => {
     );
   });
 
+  it("matches the route garden case-insensitively before using the selected fallback", () => {
+    mockRouteParams.current = { id: "GARDEN-1" };
+    mockSelectedGarden.current = {
+      id: "garden-2",
+      tokenAddress: "garden-2",
+      name: "Beta Garden",
+    };
+    mockUseLocation.mockReturnValue({ state: null });
+    mockUseGardens.mockReturnValue({
+      data: [{ id: "garden-1", name: "Alpha Garden" }],
+      isLoading: false,
+    });
+
+    renderWithProviders(<GardenVaultView />);
+
+    expect(screen.getByTestId("page-header")).toHaveAttribute(
+      "data-description",
+      "Manage direct endowment positions and impact-yield routing for Alpha Garden."
+    );
+    expect(mockUseGardenVaults).toHaveBeenCalledWith("garden-1", { enabled: true });
+  });
+
   it("renders the selected garden vault context when the base garden list is stale", () => {
     mockRouteParams.current = {};
     mockSelectedGarden.current = {

--- a/packages/admin/src/components/Garden/GardenSettingsEditor.test.tsx
+++ b/packages/admin/src/components/Garden/GardenSettingsEditor.test.tsx
@@ -8,6 +8,7 @@ import { resolveIPFSUrl } from "../../../../shared/src/modules/data/ipfs/resolve
 import { GardenSettingsEditor } from "./GardenSettingsEditor";
 
 const gardenAddress = "0xAbCdEf1234567890aBcDeF1234567890aBcDeF12" as `0x${string}`;
+const secondGardenAddress = "0xbBbBbBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB" as `0x${string}`;
 
 const {
   mockUpdateName,
@@ -58,6 +59,15 @@ const GARDEN = {
   bannerImage: "",
   openJoining: false,
   maxGardeners: 0,
+};
+
+const SECOND_GARDEN = {
+  name: "Bogota Botanic Guild",
+  description: "Urban canopy and compost loops.",
+  location: "Bogota, Colombia",
+  bannerImage: "",
+  openJoining: true,
+  maxGardeners: 42,
 };
 
 function renderEditor(overrides: Partial<Parameters<typeof GardenSettingsEditor>[0]> = {}) {
@@ -157,6 +167,31 @@ describe("GardenSettingsEditor explicit save", () => {
     for (const mutation of allMutations()) {
       expect(mutation).not.toHaveBeenCalled();
     }
+  });
+
+  it("adopts the next garden after a garden switch instead of keeping the old draft", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderEditor();
+
+    const nameInput = screen.getByLabelText(/Name/);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Unsaved Rio edit");
+    expect(screen.getByText("1 unsaved change")).toBeInTheDocument();
+
+    rerender(
+      <GardenSettingsEditor
+        gardenAddress={secondGardenAddress}
+        garden={SECOND_GARDEN}
+        canManage
+        isOwner
+      />
+    );
+
+    expect(screen.getByLabelText(/Name/)).toHaveValue(SECOND_GARDEN.name);
+    expect(screen.getByLabelText("Description")).toHaveValue(SECOND_GARDEN.description);
+    expect(screen.getByLabelText("Location")).toHaveValue(SECOND_GARDEN.location);
+    expect(screen.getByRole("switch", { name: "Open Joining" })).toBeChecked();
+    expect(screen.getByText("All changes saved")).toBeInTheDocument();
   });
 
   it("previews a selected banner locally and uploads to IPFS only on Save", async () => {

--- a/packages/admin/src/components/Garden/GardenSettingsEditor.tsx
+++ b/packages/admin/src/components/Garden/GardenSettingsEditor.tsx
@@ -108,6 +108,7 @@ export function GardenSettingsEditor({
   // Adopt refreshed garden values (post-save invalidation, garden switch)
   // whenever the operator has no pending edits — never clobber a dirty draft.
   const gardenSnapshot = JSON.stringify([
+    gardenAddress,
     garden.name,
     garden.description,
     garden.location,
@@ -116,6 +117,7 @@ export function GardenSettingsEditor({
     garden.maxGardeners ?? 0,
   ]);
   const lastSnapshotRef = useRef(gardenSnapshot);
+  const lastGardenAddressRef = useRef(gardenAddress);
 
   // Plain per-render computation — string compares against the saved values.
   const baseline = draftFromGarden(garden);
@@ -130,15 +132,19 @@ export function GardenSettingsEditor({
   const isDirty = dirtyFields.length > 0;
 
   useEffect(() => {
-    if (lastSnapshotRef.current === gardenSnapshot) return;
+    const gardenAddressChanged =
+      lastGardenAddressRef.current.toLowerCase() !== gardenAddress.toLowerCase();
+
+    if (lastSnapshotRef.current === gardenSnapshot && !gardenAddressChanged) return;
     lastSnapshotRef.current = gardenSnapshot;
-    if (!isDirty && !isSaving) {
+    lastGardenAddressRef.current = gardenAddress;
+    if (gardenAddressChanged || (!isDirty && !isSaving)) {
       setDraft(draftFromGarden(garden));
     }
     // The snapshot-equality guard above is the real trigger; isDirty/isSaving/
     // garden are listed so the guard always reads current values (no stale
     // closure) and the effect no longer needs an exhaustive-deps suppression.
-  }, [gardenSnapshot, isDirty, isSaving, garden]);
+  }, [gardenAddress, gardenSnapshot, isDirty, isSaving, garden]);
 
   const canEditProfile = canManage;
   const canEditName = isOwner;

--- a/packages/admin/src/components/Layout/RightSheetRegistry.stories.tsx
+++ b/packages/admin/src/components/Layout/RightSheetRegistry.stories.tsx
@@ -1,5 +1,6 @@
 import {
   NOTIFICATIONS_SHEET_CONTENT_ID,
+  NotificationPanel,
   PROFILE_SHEET_CONTENT_ID,
   RightSheet,
   SETTINGS_SHEET_CONTENT_ID,
@@ -10,7 +11,7 @@ import {
 } from "@green-goods/shared";
 import type { Meta, StoryObj } from "@storybook/react";
 import { useCallback, useState } from "react";
-import { expect, userEvent, within } from "storybook/test";
+import { expect, userEvent, waitFor, within } from "storybook/test";
 import { STORYBOOK_ADMIN_SHELL_SEEDS } from "../../../../shared/.storybook/adminFixtures";
 import {
   withAdminIdentity,
@@ -36,10 +37,12 @@ function RightSheetRegistryHarness({ initialContentId }: RightSheetRegistryHarne
   const [overlayRoot, setOverlayRoot] = useState<HTMLDivElement | null>(null);
   const renderAccountProfile = useCallback(() => <AccountProfilePanel />, []);
   const renderAccountSettings = useCallback(() => <AccountSettingsPanel />, []);
+  const renderNotifications = useCallback(() => <NotificationPanel items={[]} />, []);
   const descriptor = useAdminRightSheetDescriptor({
     contentId,
     renderAccountProfile,
     renderAccountSettings,
+    renderNotifications,
   });
 
   const openRegisteredContent = (nextContentId: string) => {
@@ -203,11 +206,13 @@ export const StateCatalog: Story = {
     await expect(notificationsPanel.queryByText("Failed to load")).not.toBeInTheDocument();
 
     const closeButton = notificationsPanel.getByRole("button", { name: "Close" });
-    const notificationActions = notificationsPanel
-      .getAllByRole("button")
-      .filter((button) => button !== closeButton);
-    const hasEmptyState = notificationsPanel.queryByText("No notifications") !== null;
-    await expect(hasEmptyState || notificationActions.length > 0).toBe(true);
+    await waitFor(() => {
+      const notificationActions = notificationsPanel
+        .getAllByRole("button")
+        .filter((button) => button !== closeButton);
+      const hasEmptyState = notificationsPanel.queryByText("No notifications") !== null;
+      expect(hasEmptyState || notificationActions.length > 0).toBe(true);
+    });
 
     await userEvent.click(closeButton);
     await expect(canvas.getByTestId("right-sheet-current")).toHaveTextContent("none");

--- a/packages/admin/src/views/Community/index.tsx
+++ b/packages/admin/src/views/Community/index.tsx
@@ -140,7 +140,10 @@ export default function CommunityView() {
         />
       </CanvasRouteHeader>
 
-      <CommunityWorkspaceContent workspace={community} />
+      <CommunityWorkspaceContent
+        key={community.selectedGarden?.id ?? "no-garden"}
+        workspace={community}
+      />
     </CanvasRouteFrame>
   );
 }

--- a/packages/admin/src/views/Garden/Vault.tsx
+++ b/packages/admin/src/views/Garden/Vault.tsx
@@ -16,6 +16,7 @@ import {
   useGardens,
   useGardenVaults,
   useUser,
+  type Garden,
 } from "@green-goods/shared";
 import { RiExternalLinkLine } from "@remixicon/react";
 import { useMemo, useState } from "react";
@@ -59,7 +60,25 @@ export default function GardenVaultView({ layout = "page" }: GardenVaultViewProp
   const resolvedGardenId = id ?? selectedGarden?.id;
 
   const { data: gardens = [], isLoading: gardensLoading } = useGardens();
-  const garden = gardens.find((item) => item.id === resolvedGardenId);
+  const selectedGardenFallback = useMemo<Garden | undefined>(() => {
+    if (!selectedGarden) return undefined;
+    if (resolvedGardenId && selectedGarden.id.toLowerCase() !== resolvedGardenId.toLowerCase()) {
+      return undefined;
+    }
+
+    return {
+      ...selectedGarden,
+      evaluators: [],
+      owners: [],
+      funders: [],
+      communities: [],
+      assessments: [],
+      works: [],
+      openJoining: false,
+      domainMask: 0,
+    };
+  }, [resolvedGardenId, selectedGarden]);
+  const garden = gardens.find((item) => item.id === resolvedGardenId) ?? selectedGardenFallback;
   const gardenRouteContext = {
     gardenAddress:
       garden?.tokenAddress ?? garden?.id ?? selectedGarden?.tokenAddress ?? resolvedGardenId,

--- a/packages/admin/src/views/Garden/Vault.tsx
+++ b/packages/admin/src/views/Garden/Vault.tsx
@@ -78,7 +78,10 @@ export default function GardenVaultView({ layout = "page" }: GardenVaultViewProp
       domainMask: 0,
     };
   }, [resolvedGardenId, selectedGarden]);
-  const garden = gardens.find((item) => item.id === resolvedGardenId) ?? selectedGardenFallback;
+  const normalizedResolvedGardenId = resolvedGardenId?.toLowerCase();
+  const garden =
+    gardens.find((item) => item.id.toLowerCase() === normalizedResolvedGardenId) ??
+    selectedGardenFallback;
   const gardenRouteContext = {
     gardenAddress:
       garden?.tokenAddress ?? garden?.id ?? selectedGarden?.tokenAddress ?? resolvedGardenId,

--- a/packages/admin/src/views/Garden/index.tsx
+++ b/packages/admin/src/views/Garden/index.tsx
@@ -114,7 +114,7 @@ export default function GardenView() {
         />
       </CanvasRouteHeader>
 
-      <GardenWorkspaceContent workspace={garden} />
+      <GardenWorkspaceContent key={garden.selectedGarden?.id ?? "no-garden"} workspace={garden} />
     </CanvasRouteFrame>
   );
 }

--- a/packages/admin/src/views/Hub/index.tsx
+++ b/packages/admin/src/views/Hub/index.tsx
@@ -80,6 +80,7 @@ export default function HubView() {
         />
       ) : (
         <div
+          key={hub.selectedGarden?.id ?? "no-garden"}
           className="hub-route-stack"
           role="tabpanel"
           id={`${HUB_STAGE_RAIL_ID}-panel`}

--- a/packages/shared/src/__tests__/hooks/garden/useAdminGardenWorkspaceSelection.test.ts
+++ b/packages/shared/src/__tests__/hooks/garden/useAdminGardenWorkspaceSelection.test.ts
@@ -8,9 +8,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockEligibleState = {
   eligibleGardens: [] as Array<{ id: string; name: string; location?: string }>,
   isLoaded: true,
+  resolvedDefaultGarden: null as { id: string; name: string; location?: string } | null,
 };
 const mockSetSelectedGarden = vi.fn();
 const mockSetUrlGarden = vi.fn();
+const mockUrlGardenId = { current: null as string | null };
 const mockStoreState = {
   selectedGarden: null as { id: string; name: string; location?: string } | null,
   setSelectedGarden: mockSetSelectedGarden,
@@ -26,6 +28,7 @@ vi.mock("../../../stores/useAdminStore", () => ({
 
 vi.mock("../../../hooks/navigation/useGardenUrlSync", () => ({
   useGardenUrlSync: () => ({
+    gardenId: mockUrlGardenId.current,
     setGarden: mockSetUrlGarden,
   }),
 }));
@@ -37,6 +40,8 @@ describe("hooks/garden/useAdminGardenWorkspaceSelection", () => {
     vi.clearAllMocks();
     mockEligibleState.eligibleGardens = [];
     mockEligibleState.isLoaded = true;
+    mockEligibleState.resolvedDefaultGarden = null;
+    mockUrlGardenId.current = null;
     mockStoreState.selectedGarden = null;
   });
 
@@ -96,6 +101,39 @@ describe("hooks/garden/useAdminGardenWorkspaceSelection", () => {
       expect(mockSetUrlGarden).toHaveBeenCalledWith(firstGarden);
     });
     expect(onAutoSelectGarden).toHaveBeenCalledWith(firstGarden);
+  });
+
+  it("auto-selects the resolved default garden when there is no URL garden", async () => {
+    const firstGarden = { id: "garden-a", name: "Alpha" };
+    const defaultGarden = { id: "garden-b", name: "Beta" };
+    const onAutoSelectGarden = vi.fn();
+    mockEligibleState.eligibleGardens = [firstGarden, defaultGarden];
+    mockEligibleState.resolvedDefaultGarden = defaultGarden;
+
+    renderHook(() =>
+      useAdminGardenWorkspaceSelection({
+        autoSelectFirstGarden: true,
+        onAutoSelectGarden,
+      })
+    );
+
+    await waitFor(() => {
+      expect(mockSetUrlGarden).toHaveBeenCalledWith(defaultGarden);
+    });
+    expect(onAutoSelectGarden).toHaveBeenCalledWith(defaultGarden);
+  });
+
+  it("does not auto-select over an explicit URL-selected garden", () => {
+    mockUrlGardenId.current = "garden-b";
+    mockEligibleState.eligibleGardens = [
+      { id: "garden-a", name: "Alpha" },
+      { id: "garden-b", name: "Beta" },
+    ];
+
+    renderHook(() => useAdminGardenWorkspaceSelection({ autoSelectFirstGarden: true }));
+
+    expect(mockSetUrlGarden).not.toHaveBeenCalled();
+    expect(mockSetSelectedGarden).not.toHaveBeenCalled();
   });
 
   it("does not auto-select before eligible gardens are loaded", () => {

--- a/packages/shared/src/__tests__/hooks/garden/useAdminGardenWorkspaceSelection.test.ts
+++ b/packages/shared/src/__tests__/hooks/garden/useAdminGardenWorkspaceSelection.test.ts
@@ -10,6 +10,7 @@ const mockEligibleState = {
   isLoaded: true,
 };
 const mockSetSelectedGarden = vi.fn();
+const mockSetUrlGarden = vi.fn();
 const mockStoreState = {
   selectedGarden: null as { id: string; name: string; location?: string } | null,
   setSelectedGarden: mockSetSelectedGarden,
@@ -21,6 +22,12 @@ vi.mock("../../../hooks/garden/useEligibleAdminGardens", () => ({
 
 vi.mock("../../../stores/useAdminStore", () => ({
   useAdminStore: (selector: (state: typeof mockStoreState) => unknown) => selector(mockStoreState),
+}));
+
+vi.mock("../../../hooks/navigation/useGardenUrlSync", () => ({
+  useGardenUrlSync: () => ({
+    setGarden: mockSetUrlGarden,
+  }),
 }));
 
 import { useAdminGardenWorkspaceSelection } from "../../../hooks/garden/useAdminGardenWorkspaceSelection";
@@ -47,7 +54,7 @@ describe("hooks/garden/useAdminGardenWorkspaceSelection", () => {
     ]);
   });
 
-  it("selects the full eligible garden from a workspace option id", () => {
+  it("selects the full eligible garden through URL sync from a workspace option id", () => {
     const garden = { id: "garden-a", name: "Alpha", location: "Lisbon" };
     mockEligibleState.eligibleGardens = [garden];
 
@@ -57,10 +64,11 @@ describe("hooks/garden/useAdminGardenWorkspaceSelection", () => {
       result.current.handleSelectGarden({ id: "garden-a" });
     });
 
-    expect(mockSetSelectedGarden).toHaveBeenCalledWith(garden);
+    expect(mockSetUrlGarden).toHaveBeenCalledWith(garden);
+    expect(mockSetSelectedGarden).not.toHaveBeenCalled();
   });
 
-  it("clears selection when the selected option id is not eligible", () => {
+  it("clears selection through URL sync when the selected option id is not eligible", () => {
     mockEligibleState.eligibleGardens = [{ id: "garden-a", name: "Alpha" }];
 
     const { result } = renderHook(() => useAdminGardenWorkspaceSelection());
@@ -69,7 +77,7 @@ describe("hooks/garden/useAdminGardenWorkspaceSelection", () => {
       result.current.handleSelectGarden({ id: "garden-missing" });
     });
 
-    expect(mockSetSelectedGarden).toHaveBeenCalledWith(null);
+    expect(mockSetUrlGarden).toHaveBeenCalledWith(null);
   });
 
   it("auto-selects the first loaded garden when requested", async () => {
@@ -85,7 +93,7 @@ describe("hooks/garden/useAdminGardenWorkspaceSelection", () => {
     );
 
     await waitFor(() => {
-      expect(mockSetSelectedGarden).toHaveBeenCalledWith(firstGarden);
+      expect(mockSetUrlGarden).toHaveBeenCalledWith(firstGarden);
     });
     expect(onAutoSelectGarden).toHaveBeenCalledWith(firstGarden);
   });
@@ -96,6 +104,7 @@ describe("hooks/garden/useAdminGardenWorkspaceSelection", () => {
 
     renderHook(() => useAdminGardenWorkspaceSelection({ autoSelectFirstGarden: true }));
 
+    expect(mockSetUrlGarden).not.toHaveBeenCalled();
     expect(mockSetSelectedGarden).not.toHaveBeenCalled();
   });
 });

--- a/packages/shared/src/hooks/admin-ui/garden/useGardenWorkspaceController.ts
+++ b/packages/shared/src/hooks/admin-ui/garden/useGardenWorkspaceController.ts
@@ -220,11 +220,11 @@ export function useGardenWorkspaceController() {
         navigate(adminRoutes.gardenSettings({ gardenAddress: selectedGardenAddress }));
       } else if (nextView === "activity") {
         // Tier 4: Activity + Members are net-new tabs per audit IA-Garden.
-        // First-delivery navigation is path-only; range/garden context is
-        // carried in the workspace controller, not the URL.
-        navigate("/garden/activity");
+        // Keep garden context shareable so route changes cannot fall back to
+        // the persisted/default garden on the next URL sync pass.
+        navigate(adminRoutes.gardenActivity({ gardenAddress: selectedGardenAddress, range }));
       } else if (nextView === "members") {
-        navigate("/garden/members");
+        navigate(adminRoutes.gardenMembers({ gardenAddress: selectedGardenAddress, range }));
       } else {
         navigate(adminRoutes.gardenOverview({ gardenAddress: selectedGardenAddress, range }));
       }

--- a/packages/shared/src/hooks/garden/useAdminGardenWorkspaceSelection.ts
+++ b/packages/shared/src/hooks/garden/useAdminGardenWorkspaceSelection.ts
@@ -26,10 +26,10 @@ export function useAdminGardenWorkspaceSelection({
   autoSelectFirstGarden = false,
   onAutoSelectGarden,
 }: AdminGardenWorkspaceSelectionOptions = {}): AdminGardenWorkspaceSelection {
-  const { eligibleGardens, isLoaded } = useEligibleAdminGardens();
+  const { eligibleGardens, isLoaded, resolvedDefaultGarden } = useEligibleAdminGardens();
   const selectedGarden = useAdminStore((state) => state.selectedGarden);
   const setSelectedGarden = useAdminStore((state) => state.setSelectedGarden);
-  const { setGarden } = useGardenUrlSync();
+  const { gardenId: syncedGardenId, setGarden } = useGardenUrlSync();
 
   const gardenOptions = useMemo<AdminGardenWorkspaceOption[]>(
     () =>
@@ -50,22 +50,30 @@ export function useAdminGardenWorkspaceSelection({
   );
 
   useEffect(() => {
-    if (!autoSelectFirstGarden || !isLoaded || selectedGarden || eligibleGardens.length === 0) {
+    if (
+      !autoSelectFirstGarden ||
+      !isLoaded ||
+      selectedGarden ||
+      syncedGardenId ||
+      eligibleGardens.length === 0
+    ) {
       return;
     }
 
-    const firstGarden = eligibleGardens[0];
-    if (!firstGarden) return;
+    const nextGarden = resolvedDefaultGarden ?? eligibleGardens[0];
+    if (!nextGarden) return;
 
-    setGarden(firstGarden);
-    onAutoSelectGarden?.(firstGarden);
+    setGarden(nextGarden);
+    onAutoSelectGarden?.(nextGarden);
   }, [
     autoSelectFirstGarden,
     eligibleGardens,
     isLoaded,
     onAutoSelectGarden,
+    resolvedDefaultGarden,
     selectedGarden,
     setGarden,
+    syncedGardenId,
   ]);
 
   return {

--- a/packages/shared/src/hooks/garden/useAdminGardenWorkspaceSelection.ts
+++ b/packages/shared/src/hooks/garden/useAdminGardenWorkspaceSelection.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useAdminStore, type Garden } from "../../stores/useAdminStore";
+import { useGardenUrlSync } from "../navigation/useGardenUrlSync";
 import { useEligibleAdminGardens } from "./useEligibleAdminGardens";
 
 export interface AdminGardenWorkspaceOption {
@@ -28,6 +29,7 @@ export function useAdminGardenWorkspaceSelection({
   const { eligibleGardens, isLoaded } = useEligibleAdminGardens();
   const selectedGarden = useAdminStore((state) => state.selectedGarden);
   const setSelectedGarden = useAdminStore((state) => state.setSelectedGarden);
+  const { setGarden } = useGardenUrlSync();
 
   const gardenOptions = useMemo<AdminGardenWorkspaceOption[]>(
     () =>
@@ -42,9 +44,9 @@ export function useAdminGardenWorkspaceSelection({
   const handleSelectGarden = useCallback(
     (garden: Pick<AdminGardenWorkspaceOption, "id">) => {
       const fullGarden = eligibleGardens.find((entry) => entry.id === garden.id);
-      setSelectedGarden(fullGarden ?? null);
+      setGarden(fullGarden ?? null);
     },
-    [eligibleGardens, setSelectedGarden]
+    [eligibleGardens, setGarden]
   );
 
   useEffect(() => {
@@ -55,7 +57,7 @@ export function useAdminGardenWorkspaceSelection({
     const firstGarden = eligibleGardens[0];
     if (!firstGarden) return;
 
-    setSelectedGarden(firstGarden);
+    setGarden(firstGarden);
     onAutoSelectGarden?.(firstGarden);
   }, [
     autoSelectFirstGarden,
@@ -63,7 +65,7 @@ export function useAdminGardenWorkspaceSelection({
     isLoaded,
     onAutoSelectGarden,
     selectedGarden,
-    setSelectedGarden,
+    setGarden,
   ]);
 
   return {


### PR DESCRIPTION
## Summary
- Reset garden settings draft state on selected-garden identity changes so Garden A data does not stay rendered after switching to Garden B.
- Rebind admin Hub/Garden/Community route content and Garden activity/members navigation to the selected garden context.
- Route workspace body garden selection through URL sync so every selector entry point updates `?gardenAddress`, the selected-garden store, and rendered context.
- Harden Garden Vault rendering when the base garden list is stale and add two-garden regression coverage.

## Root Cause
`GardenSettingsEditor` treated a Garden A draft as a dirty edit when Garden B arrived, so it refused to adopt Garden B's values even though the selector/URL had changed. Adjacent route-local state, body selection, and garden-tab navigation also needed selected-garden context hardening.

## Validation
- [x] `APP_ENV=test node ../../scripts/dev/node-cli.js vitest run src/__tests__/hooks/garden/useAdminGardenWorkspaceSelection.test.ts src/__tests__/hooks/navigation/useGardenUrlSync.test.ts`
- [x] `APP_ENV=test node ../../scripts/dev/node-cli.js vitest run src/__tests__/components/CanvasLayout.test.tsx src/components/Garden/GardenSettingsEditor.test.tsx src/__tests__/views/GardenVaultView.test.tsx`
- [x] `bun run --cwd packages/shared typecheck`
- [x] `bun run --cwd packages/admin test` passed earlier in-session: 52 files, 464 passed, 3 skipped
- [x] `VITE_CHAIN_ID=11155111 bun run --cwd packages/admin build`
- [x] `git diff --check`
- [x] `git push` pre-push checks passed with existing repo warnings and 0 errors

Browser proof note: authenticated A->B browser proof is still blocked. Local mock-auth could not render eligible garden data due indexer/operator-garden read failures, and the live admin session exposed only one eligible garden (`Aiyeloja Family Garden`), so no switcher was available to exercise.