### PR TITLE
fix(shared,admin): stabilize garden switch context

### DIFF
--- a/packages/admin/src/__tests__/components/CanvasLayout.test.tsx
+++ b/packages/admin/src/__tests__/components/CanvasLayout.test.tsx
@@ -98,7 +98,7 @@ vi.mock("@green-goods/shared", async (importOriginal) => {
     GardenChip: (props: {
       gardens: Array<{ id: string; name: string }>;
       selectedGarden: { id: string; name: string } | null;
-      onSelectGarden: (garden: { id: string; name: string } | null) => void;
+      onSelectGarden: (garden: { id: string; name: string }) => void;
     }) => {
       mockGardenChipProps(props);
       return (
@@ -109,9 +109,6 @@ vi.mock("@green-goods/shared", async (importOriginal) => {
               Select {garden.name}
             </button>
           ))}
-          <button type="button" onClick={() => props.onSelectGarden(null)}>
-            Select All Gardens
-          </button>
         </div>
       );
     },

--- a/packages/admin/src/__tests__/routing/command-palette-routes.test.tsx
+++ b/packages/admin/src/__tests__/routing/command-palette-routes.test.tsx
@@ -18,12 +18,35 @@ import { OPEN_ACCOUNT_SHEET_EVENT } from "@green-goods/shared";
 
 const mockNavigate = vi.fn();
 const mockSetSelectedGarden = vi.fn();
-const mockEligibleGardens = vi.hoisted(() => ({
-  current: [
-    { id: "garden-1", name: "Chakra Farm", location: "Quito", tokenAddress: "0xAAA" },
-    { id: "garden-2", name: "Solar Orchard", location: "Lima", tokenAddress: "0xBBB" },
-  ],
-}));
+const { CHAKRA_GARDEN_ID, SOLAR_GARDEN_ID, SHARED_GARDEN_TOKEN, mockEligibleGardens } = vi.hoisted(
+  () => {
+    const chakraGardenId = "0x0000000000000000000000000000000000000aaa";
+    const solarGardenId = "0x0000000000000000000000000000000000000bbb";
+    const sharedGardenToken = "0x9990000000000000000000000000000000000999";
+
+    return {
+      CHAKRA_GARDEN_ID: chakraGardenId,
+      SOLAR_GARDEN_ID: solarGardenId,
+      SHARED_GARDEN_TOKEN: sharedGardenToken,
+      mockEligibleGardens: {
+        current: [
+          {
+            id: chakraGardenId,
+            name: "Chakra Farm",
+            location: "Quito",
+            tokenAddress: sharedGardenToken,
+          },
+          {
+            id: solarGardenId,
+            name: "Solar Orchard",
+            location: "Lima",
+            tokenAddress: sharedGardenToken,
+          },
+        ],
+      },
+    };
+  }
+);
 
 vi.mock("react-router-dom", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-router-dom")>();
@@ -67,8 +90,18 @@ describe("CommandPalette Routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockEligibleGardens.current = [
-      { id: "garden-1", name: "Chakra Farm", location: "Quito", tokenAddress: "0xAAA" },
-      { id: "garden-2", name: "Solar Orchard", location: "Lima", tokenAddress: "0xBBB" },
+      {
+        id: CHAKRA_GARDEN_ID,
+        name: "Chakra Farm",
+        location: "Quito",
+        tokenAddress: SHARED_GARDEN_TOKEN,
+      },
+      {
+        id: SOLAR_GARDEN_ID,
+        name: "Solar Orchard",
+        location: "Lima",
+        tokenAddress: SHARED_GARDEN_TOKEN,
+      },
     ];
     Object.defineProperty(window, "matchMedia", {
       writable: true,
@@ -264,14 +297,19 @@ describe("CommandPalette Routes", () => {
     await userEvent.click(gardenButton!);
 
     expect(mockSetSelectedGarden).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "garden-1", tokenAddress: "0xAAA" })
+      expect.objectContaining({ id: CHAKRA_GARDEN_ID, tokenAddress: SHARED_GARDEN_TOKEN })
     );
-    expect(mockNavigate).toHaveBeenCalledWith("/garden/overview?gardenAddress=0xAAA");
+    expect(mockNavigate).toHaveBeenCalledWith(`/garden/overview?gardenAddress=${CHAKRA_GARDEN_ID}`);
   });
 
   it("does not expose gardens outside the eligible admin set", async () => {
     mockEligibleGardens.current = [
-      { id: "garden-1", name: "Chakra Farm", location: "Quito", tokenAddress: "0xAAA" },
+      {
+        id: CHAKRA_GARDEN_ID,
+        name: "Chakra Farm",
+        location: "Quito",
+        tokenAddress: SHARED_GARDEN_TOKEN,
+      },
     ];
 
     renderWithProviders(

--- a/packages/admin/src/components/Layout/CanvasLayout.tsx
+++ b/packages/admin/src/components/Layout/CanvasLayout.tsx
@@ -539,7 +539,7 @@ function AdminNotificationPanel({ onCloseSheet }: { onCloseSheet: () => void }) 
   const { formatMessage } = useIntl();
   const navigate = useNavigate();
   const { selectedGarden } = useAdminGardenWorkspaceSelection();
-  const selectedGardenAddress = selectedGarden?.tokenAddress ?? selectedGarden?.id;
+  const selectedGardenAddress = selectedGarden?.id;
   const workspace = useGardenDetailData(selectedGarden?.id);
 
   const navigateFromNotification = useCallback(

--- a/packages/admin/src/components/Layout/CanvasLayout.tsx
+++ b/packages/admin/src/components/Layout/CanvasLayout.tsx
@@ -323,15 +323,11 @@ export function CanvasLayout() {
     [selectedGarden]
   );
   const handleSelectGarden = useCallback(
-    (garden: { id: string; name: string } | null) => {
-      if (garden) {
-        const fullGarden = eligibleGardens.find((eligibleGarden) =>
-          compareAddresses(eligibleGarden.id, garden.id)
-        );
-        setGarden(fullGarden ?? null);
-      } else {
-        setGarden(null);
-      }
+    (garden: { id: string; name: string }) => {
+      const fullGarden = eligibleGardens.find((eligibleGarden) =>
+        compareAddresses(eligibleGarden.id, garden.id)
+      );
+      setGarden(fullGarden ?? null);
     },
     [eligibleGardens, setGarden]
   );

--- a/packages/admin/src/components/Layout/CanvasLayout.tsx
+++ b/packages/admin/src/components/Layout/CanvasLayout.tsx
@@ -37,6 +37,7 @@ import {
   useMediaQuery,
   useSheetOrchestrator,
   useStaleGardenGuard,
+  compareAddresses,
   type AccountSheetTab,
   type AdminRightSheetContentId,
   type AdminWorkspaceSectionTab,
@@ -324,8 +325,8 @@ export function CanvasLayout() {
   const handleSelectGarden = useCallback(
     (garden: { id: string; name: string } | null) => {
       if (garden) {
-        const fullGarden = eligibleGardens.find(
-          (eligibleGarden) => eligibleGarden.id === garden.id
+        const fullGarden = eligibleGardens.find((eligibleGarden) =>
+          compareAddresses(eligibleGarden.id, garden.id)
         );
         setGarden(fullGarden ?? null);
       } else {

--- a/packages/admin/src/components/Layout/commandPalette.results.test.ts
+++ b/packages/admin/src/components/Layout/commandPalette.results.test.ts
@@ -12,10 +12,10 @@ const formatMessage = ((descriptor: { defaultMessage?: string; id: string }) =>
   descriptor.defaultMessage ?? descriptor.id) as IntlShape["formatMessage"];
 
 const eligibleGarden = {
-  id: "garden-1",
+  id: "0x0000000000000000000000000000000000000aaa",
   name: "Chakra Farm",
   location: "Quito",
-  tokenAddress: "0x0000000000000000000000000000000000000aaa",
+  tokenAddress: "0x9990000000000000000000000000000000000999",
 } as Garden;
 
 function assessment(id: string, gardenAddress: string, title: string): GardenAssessment {

--- a/packages/admin/src/views/Actions/index.tsx
+++ b/packages/admin/src/views/Actions/index.tsx
@@ -72,6 +72,7 @@ export default function Actions() {
       formatMessage: intl.formatMessage,
     });
   }, [actions.actions, actions.isLoading, intl.formatMessage]);
+  const headerStatsLoading = actions.isLoading;
 
   const handleRefresh = useCallback(() => {
     void actions.refetch();
@@ -97,7 +98,14 @@ export default function Actions() {
             "Scan the registry, review lifecycle status, and maintain submission requirements.",
         })}
         metadata={
-          headerStats.length > 0 ? <MetaStrip items={headerStats} density="inline" /> : undefined
+          headerStatsLoading || headerStats.length > 0 ? (
+            <MetaStrip
+              items={headerStats}
+              density="inline"
+              loading={headerStatsLoading}
+              loadingItemCount={2}
+            />
+          ) : undefined
         }
         variant="canvas"
         sticky

--- a/packages/admin/src/views/Community/index.tsx
+++ b/packages/admin/src/views/Community/index.tsx
@@ -57,6 +57,7 @@ export default function CommunityView() {
       formatMessage,
     ]
   );
+  const headerStatsLoading = Boolean(community.selectedGarden) && community.allocationsLoading;
 
   return (
     <CanvasRouteFrame
@@ -79,7 +80,14 @@ export default function CommunityView() {
           defaultMessage: "Treasury, governance, payouts, and the people around the garden.",
         })}
         metadata={
-          headerStats.length > 0 ? <MetaStrip items={headerStats} density="inline" /> : undefined
+          headerStatsLoading || headerStats.length > 0 ? (
+            <MetaStrip
+              items={headerStats}
+              density="inline"
+              loading={headerStatsLoading}
+              loadingItemCount={2}
+            />
+          ) : undefined
         }
         actions={
           isDesktop && community.desktopActions.length > 0 ? (

--- a/packages/admin/src/views/Garden/HypercertDetail.tsx
+++ b/packages/admin/src/views/Garden/HypercertDetail.tsx
@@ -3,6 +3,7 @@ import {
   Alert,
   DEFAULT_CHAIN_ID,
   adminRoutes,
+  compareAddresses,
   formatDate,
   getNetworkConfig,
   ImageWithFallback,
@@ -94,7 +95,7 @@ export default function HypercertDetail({
   const location = useLocation();
   const { selectedGarden } = useAdminGardenWorkspaceSelection();
   const { data: gardens = [] } = useGardens();
-  const garden = gardens.find((item) => item.id === selectedGarden?.id);
+  const garden = gardens.find((item) => compareAddresses(item.id, selectedGarden?.id));
   const gardenRouteContext = { gardenAddress: garden?.tokenAddress ?? garden?.id };
   const permissions = useGardenPermissions();
   const canManage = garden ? permissions.canManageGarden(garden) : false;

--- a/packages/admin/src/views/Garden/HypercertDetail.tsx
+++ b/packages/admin/src/views/Garden/HypercertDetail.tsx
@@ -96,7 +96,7 @@ export default function HypercertDetail({
   const { selectedGarden } = useAdminGardenWorkspaceSelection();
   const { data: gardens = [] } = useGardens();
   const garden = gardens.find((item) => compareAddresses(item.id, selectedGarden?.id));
-  const gardenRouteContext = { gardenAddress: garden?.tokenAddress ?? garden?.id };
+  const gardenRouteContext = { gardenAddress: garden?.id };
   const permissions = useGardenPermissions();
   const canManage = garden ? permissions.canManageGarden(garden) : false;
   const [listingDialogOpen, setListingDialogOpen] = useState(false);

--- a/packages/admin/src/views/Garden/SignalPool.tsx
+++ b/packages/admin/src/views/Garden/SignalPool.tsx
@@ -2,6 +2,7 @@ import {
   type Address,
   Alert,
   adminRoutes,
+  compareAddresses,
   PoolType,
   useAdminGardenWorkspaceSelection,
   useDeregisterHypercert,
@@ -56,7 +57,7 @@ export default function GardenSignalPoolView({ layout = "page" }: GardenSignalPo
   const targetPoolType = isActionPool ? PoolType.Action : PoolType.Hypercert;
 
   const { data: gardens = [], isLoading: gardensLoading } = useGardens();
-  const garden = gardens.find((item) => item.id === gardenId);
+  const garden = gardens.find((item) => compareAddresses(item.id, gardenId));
   const gardenRouteContext = { gardenAddress: garden?.tokenAddress ?? garden?.id ?? gardenId };
   const permissions = useGardenPermissions();
 

--- a/packages/admin/src/views/Garden/SignalPool.tsx
+++ b/packages/admin/src/views/Garden/SignalPool.tsx
@@ -58,7 +58,7 @@ export default function GardenSignalPoolView({ layout = "page" }: GardenSignalPo
 
   const { data: gardens = [], isLoading: gardensLoading } = useGardens();
   const garden = gardens.find((item) => compareAddresses(item.id, gardenId));
-  const gardenRouteContext = { gardenAddress: garden?.tokenAddress ?? garden?.id ?? gardenId };
+  const gardenRouteContext = { gardenAddress: garden?.id ?? gardenId };
   const permissions = useGardenPermissions();
 
   // Load pools from GardensModule — typed with PoolType

--- a/packages/admin/src/views/Garden/Strategies.tsx
+++ b/packages/admin/src/views/Garden/Strategies.tsx
@@ -37,7 +37,7 @@ export default function GardenStrategiesView({ layout = "page" }: GardenStrategi
 
   const { data: gardens = [], isLoading: gardensLoading } = useGardens();
   const garden = gardens.find((item) => compareAddresses(item.id, gardenId));
-  const gardenRouteContext = { gardenAddress: garden?.tokenAddress ?? garden?.id ?? gardenId };
+  const gardenRouteContext = { gardenAddress: garden?.id ?? gardenId };
   const permissions = useGardenPermissions();
 
   const {

--- a/packages/admin/src/views/Garden/Strategies.tsx
+++ b/packages/admin/src/views/Garden/Strategies.tsx
@@ -3,6 +3,7 @@ import {
   AddressDisplay,
   Alert,
   adminRoutes,
+  compareAddresses,
   useAdminGardenWorkspaceSelection,
   useConvictionStrategies,
   useGardenPermissions,
@@ -35,7 +36,7 @@ export default function GardenStrategiesView({ layout = "page" }: GardenStrategi
   const gardenId = selectedGarden?.id ?? null;
 
   const { data: gardens = [], isLoading: gardensLoading } = useGardens();
-  const garden = gardens.find((item) => item.id === gardenId);
+  const garden = gardens.find((item) => compareAddresses(item.id, gardenId));
   const gardenRouteContext = { gardenAddress: garden?.tokenAddress ?? garden?.id ?? gardenId };
   const permissions = useGardenPermissions();
 

--- a/packages/admin/src/views/Garden/SubmitWork.submit.test.tsx
+++ b/packages/admin/src/views/Garden/SubmitWork.submit.test.tsx
@@ -109,6 +109,8 @@ vi.mock("@green-goods/shared", async () => {
         children,
         action
       ),
+    compareAddresses: (a: string | null | undefined, b: string | null | undefined) =>
+      Boolean(a && b && a.toLowerCase() === b.toLowerCase()),
     adminRoutes: {
       gardenSettings: () => "/garden/settings",
       hub: () => "/hub",

--- a/packages/admin/src/views/Garden/SubmitWork.tsx
+++ b/packages/admin/src/views/Garden/SubmitWork.tsx
@@ -4,6 +4,7 @@ import {
   Alert,
   adminRoutes,
   Card,
+  compareAddresses,
   type Domain,
   expandDomainMask,
   FileUploadField,
@@ -305,7 +306,7 @@ function SubmitWorkPanelContent({
   const { canManageGarden } = useGardenPermissions();
 
   const garden = useMemo(
-    () => gardens.find((candidate) => candidate.id === gardenId),
+    () => gardens.find((candidate) => compareAddresses(candidate.id, gardenId)),
     [gardens, gardenId]
   );
   const gardenDomains = useMemo<Set<Domain>>(

--- a/packages/admin/src/views/Garden/Vault.tsx
+++ b/packages/admin/src/views/Garden/Vault.tsx
@@ -83,8 +83,7 @@ export default function GardenVaultView({ layout = "page" }: GardenVaultViewProp
     gardens.find((item) => item.id.toLowerCase() === normalizedResolvedGardenId) ??
     selectedGardenFallback;
   const gardenRouteContext = {
-    gardenAddress:
-      garden?.tokenAddress ?? garden?.id ?? selectedGarden?.tokenAddress ?? resolvedGardenId,
+    gardenAddress: garden?.id ?? selectedGarden?.id ?? resolvedGardenId,
   };
   const permissions = useGardenPermissions();
   const { primaryAddress } = useUser();

--- a/packages/admin/src/views/Garden/WorkTab.tsx
+++ b/packages/admin/src/views/Garden/WorkTab.tsx
@@ -173,7 +173,7 @@ export function WorkTab({
               lastUpdatedAt={lastWorkRefreshAt}
               initialFilter={section === "history" ? "all" : "pending"}
               highlightWorkId={selectedItem}
-              hubContext={{ gardenAddress: garden.tokenAddress ?? garden.id }}
+              hubContext={{ gardenAddress: garden.id }}
             />
           )}
         </div>

--- a/packages/admin/src/views/Garden/components/ImpactTab.tsx
+++ b/packages/admin/src/views/Garden/components/ImpactTab.tsx
@@ -55,7 +55,7 @@ export function ImpactTab({
 
   const recentAssessments = assessments.slice(0, 5);
   const recentHypercerts = hypercerts.slice(0, 4);
-  const gardenRouteContext = { gardenAddress: garden.tokenAddress ?? garden.id };
+  const gardenRouteContext = { gardenAddress: garden.id };
 
   return (
     <div className="garden-tab-shell">

--- a/packages/admin/src/views/Garden/index.tsx
+++ b/packages/admin/src/views/Garden/index.tsx
@@ -38,6 +38,7 @@ export default function GardenView() {
       formatMessage,
     ]
   );
+  const headerStatsLoading = Boolean(garden.selectedGarden) && garden.hypercertsLoading;
 
   return (
     <CanvasRouteFrame
@@ -61,7 +62,14 @@ export default function GardenView() {
             "What's growing in this garden — overview, activity, gardeners, and settings.",
         })}
         metadata={
-          headerStats.length > 0 ? <MetaStrip items={headerStats} density="inline" /> : undefined
+          headerStatsLoading || headerStats.length > 0 ? (
+            <MetaStrip
+              items={headerStats}
+              density="inline"
+              loading={headerStatsLoading}
+              loadingItemCount={2}
+            />
+          ) : undefined
         }
         actions={
           isDesktop && garden.desktopActions.length > 0 ? (

--- a/packages/admin/src/views/Hub/index.tsx
+++ b/packages/admin/src/views/Hub/index.tsx
@@ -44,6 +44,7 @@ export default function HubView() {
     hub.pendingWarningCount,
     formatMessage,
   ]);
+  const headerStatsLoading = Boolean(hub.selectedGarden) && hub.worksLoading;
 
   return (
     <CanvasRouteFrame
@@ -95,8 +96,13 @@ export default function HubView() {
                 "Review submitted work, run assessments, and certify impact across your gardens.",
             })}
             metadata={
-              headerStats.length > 0 ? (
-                <MetaStrip items={headerStats} density="inline" />
+              headerStatsLoading || headerStats.length > 0 ? (
+                <MetaStrip
+                  items={headerStats}
+                  density="inline"
+                  loading={headerStatsLoading}
+                  loadingItemCount={2}
+                />
               ) : undefined
             }
             variant="canvas"

--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -178,6 +178,8 @@ export function loadConfig(): Config {
   };
 }
 
+export const getConfig = loadConfig;
+
 function parsePositiveInteger(value: string | undefined): number | undefined {
   if (!value?.trim()) return undefined;
   const parsed = Number(value);

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -10,7 +10,7 @@
 
 import { createServer, startServer } from "./api/server";
 import { parseAllowedOrigins } from "./api/public-protection";
-import { getConfig } from "./config";
+import { loadConfig } from "./config";
 import { createGroupCaptureHandler, handleMessage, setHandlerContext } from "./handlers";
 import {
   createNotifier,
@@ -40,7 +40,7 @@ import { createShutdownHandler } from "./runtime/shutdown";
 // ============================================================================
 
 async function main(): Promise<void> {
-  const config = getConfig();
+  const config = loadConfig();
   initAgentSentry({
     dsn: config.sentryDsn,
     enabled: config.sentryEnabled,
@@ -110,7 +110,7 @@ async function main(): Promise<void> {
     allowedOrigins: parseAllowedOrigins(config.publicAllowedOrigins),
     trustedProxy: {
       hops: config.trustedProxyHops,
-      cidrs: config.trustedProxyCidrs?.split(",").map((cidr) => cidr.trim()),
+      cidrs: config.trustedProxyCidrs?.split(",").map((cidr: string) => cidr.trim()),
     },
     uploadSigning: {
       pinataJwt: config.pinataJwt,
@@ -183,13 +183,17 @@ async function main(): Promise<void> {
 
   const shutdown = createShutdownHandler({
     bot,
-    stopRateLimiter: () => rateLimiter.stop(),
-    closeDatabase: closeDB,
-    clearBlockchainCache,
-    shutdownAnalytics: shutdownAgentAnalytics,
-    shutdownSentry: shutdownAgentSentry,
-    captureException: captureAgentException,
+    botMode: config.telegramRuntimeDisabled ? "webhook" : config.mode,
+    cleanupTasks: [
+      () => rateLimiter.destroy(),
+      closeDB,
+      clearBlockchainCache,
+      shutdownAgentAnalytics,
+      shutdownAgentSentry,
+    ],
+    exit: (code) => process.exit(code),
     logger,
+    server,
   });
 
   process.once("SIGINT", () => {
@@ -201,7 +205,7 @@ async function main(): Promise<void> {
 }
 
 main().catch(async (error) => {
-  captureAgentException(error, { phase: "startup" });
+  captureAgentException(error, { source: "startup" });
   logger.error({ error }, "❌ Failed to start agent");
   await shutdownAgentAnalytics().catch(() => undefined);
   await shutdownAgentSentry().catch(() => undefined);

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -10,7 +10,7 @@
 
 import { createServer, startServer } from "./api/server";
 import { parseAllowedOrigins } from "./api/public-protection";
-import { loadConfig } from "./config";
+import { getConfig } from "./config";
 import { createGroupCaptureHandler, handleMessage, setHandlerContext } from "./handlers";
 import {
   createNotifier,
@@ -40,7 +40,7 @@ import { createShutdownHandler } from "./runtime/shutdown";
 // ============================================================================
 
 async function main(): Promise<void> {
-  const config = loadConfig();
+  const config = getConfig();
   initAgentSentry({
     dsn: config.sentryDsn,
     enabled: config.sentryEnabled,
@@ -205,7 +205,7 @@ async function main(): Promise<void> {
 }
 
 main().catch(async (error) => {
-  captureAgentException(error, { source: "startup" });
+  captureAgentException(error, { source: "startup", surface: "runtime" });
   logger.error({ error }, "❌ Failed to start agent");
   await shutdownAgentAnalytics().catch(() => undefined);
   await shutdownAgentSentry().catch(() => undefined);

--- a/packages/shared/src/__tests__/components/Canvas/MetaStrip.test.tsx
+++ b/packages/shared/src/__tests__/components/Canvas/MetaStrip.test.tsx
@@ -1,0 +1,50 @@
+/**
+ * MetaStrip Tests
+ * @vitest-environment jsdom
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { MetaStrip } from "../../../components/Canvas/MetaStrip";
+
+describe("MetaStrip", () => {
+  it("renders inline metadata items", () => {
+    render(
+      <MetaStrip
+        density="inline"
+        items={[
+          { id: "total", value: "12", label: "total" },
+          { id: "domains", value: "3", label: "domains" },
+        ]}
+      />
+    );
+
+    const strip = screen.getByText("total").closest('[data-component="MetaStrip"]');
+    expect(strip).toHaveAttribute("data-density", "inline");
+    expect(strip).not.toHaveAttribute("data-state", "loading");
+  });
+
+  it("renders an inline loading row with the same density hook and item count", () => {
+    const { container } = render(
+      <MetaStrip density="inline" items={[]} loading loadingItemCount={2} />
+    );
+
+    const strip = container.querySelector('[data-component="MetaStrip"]');
+    expect(strip).toHaveAttribute("data-density", "inline");
+    expect(strip).toHaveAttribute("data-state", "loading");
+    expect(strip).toHaveAttribute("aria-hidden", "true");
+    expect(container.querySelectorAll('[data-slot="skeleton-item"]')).toHaveLength(2);
+  });
+
+  it("renders a pill loading row with the same density hook and item count", () => {
+    const { container } = render(
+      <MetaStrip density="pill" items={[]} loading loadingItemCount={3} />
+    );
+
+    const strip = container.querySelector('[data-component="MetaStrip"]');
+    expect(strip).toHaveAttribute("data-density", "pill");
+    expect(strip).toHaveAttribute("data-state", "loading");
+    expect(container.querySelectorAll('[data-slot="skeleton-item"]')).toHaveLength(3);
+  });
+});

--- a/packages/shared/src/__tests__/components/GardenChip.test.tsx
+++ b/packages/shared/src/__tests__/components/GardenChip.test.tsx
@@ -3,7 +3,7 @@
  *
  * Verifies the GardenChip renders a static label for single gardens,
  * opens a popover dropdown for multi-garden selection, and handles
- * "All Gardens" and "Create Garden" interactions.
+ * garden and "Create Garden" interactions.
  *
  * @vitest-environment jsdom
  */
@@ -17,7 +17,7 @@ vi.mock("react-intl", () => ({
   useIntl: () => ({
     formatMessage: ({ id }: { id: string }) => {
       const messages: Record<string, string> = {
-        "cockpit.gardenChip.allGardens": "All Gardens",
+        "app.assessment.selectGarden": "Select a garden",
         "cockpit.gardenChip.createGarden": "Create Garden",
       };
       return messages[id] ?? id;
@@ -82,16 +82,17 @@ describe("GardenChip", () => {
     expect(trigger).toHaveAttribute("data-slot", "trigger");
   });
 
-  it("shows 'All Gardens' when selectedGarden is null", () => {
+  it("shows a selection prompt when selectedGarden is null", () => {
     render(
       <GardenChip gardens={[GARDEN_A, GARDEN_B]} selectedGarden={null} onSelectGarden={() => {}} />
     );
 
     const trigger = screen.getByRole("button");
-    expect(trigger.textContent).toContain("All Gardens");
+    expect(trigger.textContent).toContain("Select a garden");
+    expect(trigger).toHaveAttribute("data-selection-state", "empty");
   });
 
-  it("opens dropdown on click and shows all options", async () => {
+  it("opens dropdown on click and shows only garden options and create action", async () => {
     render(
       <GardenChip
         gardens={[GARDEN_A, GARDEN_B]}
@@ -103,35 +104,15 @@ describe("GardenChip", () => {
 
     await user.click(screen.getByRole("button"));
 
-    // Should see "All Gardens", both garden names, and "Create Garden"
+    // Should see both garden names and "Create Garden", but no aggregate scope option.
     // "Wildflower Meadow" appears in both the trigger chip and the dropdown list
-    expect(screen.getByText("All Gardens")).toBeTruthy();
+    expect(screen.queryByText("All Gardens")).toBeNull();
     expect(screen.getAllByText("Wildflower Meadow").length).toBeGreaterThanOrEqual(2);
     expect(screen.getByText("Urban Composting")).toBeTruthy();
     expect(screen.getByText("Create Garden")).toBeTruthy();
-    expect(screen.getByText("All Gardens").closest("button")).toHaveAttribute(
-      "data-slot",
-      "option"
-    );
-  });
-
-  it("calls onSelectGarden(null) when 'All Gardens' is clicked", async () => {
-    const onSelectGarden = vi.fn();
-    render(
-      <GardenChip
-        gardens={[GARDEN_A, GARDEN_B]}
-        selectedGarden={GARDEN_A}
-        onSelectGarden={onSelectGarden}
-      />
-    );
-
-    await user.click(screen.getByRole("button"));
-
-    // The dropdown "All Gardens" button
-    const allGardensBtn = screen.getByText("All Gardens").closest("button")!;
-    await user.click(allGardensBtn);
-
-    expect(onSelectGarden).toHaveBeenCalledWith(null);
+    expect(
+      document.body.querySelectorAll('[data-component="GardenChip"][data-slot="option"]')
+    ).toHaveLength(2);
   });
 
   it("calls onSelectGarden with the garden when a garden option is clicked", async () => {

--- a/packages/shared/src/__tests__/hooks/cookie-jar/useAccessibleCookieJars.test.ts
+++ b/packages/shared/src/__tests__/hooks/cookie-jar/useAccessibleCookieJars.test.ts
@@ -15,12 +15,13 @@ const TEST_MODULE = "0xModule111111111111111111111111111111111111";
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const TEST_USER = "0x1234567890123456789012345678901234567890";
 
-const GARDENER_GARDEN = "0xGarden1111111111111111111111111111111111";
-const OPERATOR_GARDEN = "0xGarden2222222222222222222222222222222222";
-const OWNER_GARDEN = "0xGarden3333333333333333333333333333333333";
-const EVALUATOR_GARDEN = "0xGarden4444444444444444444444444444444444";
-const FUNDER_GARDEN = "0xGarden5555555555555555555555555555555555";
-const COMMUNITY_GARDEN = "0xGarden6666666666666666666666666666666666";
+const SHARED_GARDEN_TOKEN = "0x9999999999999999999999999999999999999999";
+const GARDENER_GARDEN = "0x1111111111111111111111111111111111111111";
+const OPERATOR_GARDEN = "0x2222222222222222222222222222222222222222";
+const OWNER_GARDEN = "0x3333333333333333333333333333333333333333";
+const EVALUATOR_GARDEN = "0x4444444444444444444444444444444444444444";
+const FUNDER_GARDEN = "0x5555555555555555555555555555555555555555";
+const COMMUNITY_GARDEN = "0x6666666666666666666666666666666666666666";
 
 const TEST_JAR_1 = "0xJar1111111111111111111111111111111111111";
 const TEST_JAR_2 = "0xJar2222222222222222222222222222222222222";
@@ -29,8 +30,8 @@ const TEST_CURRENCY = "0xCurr111111111111111111111111111111111111";
 
 const mockGardens = [
   {
-    id: "gardener",
-    tokenAddress: GARDENER_GARDEN,
+    id: GARDENER_GARDEN,
+    tokenAddress: SHARED_GARDEN_TOKEN,
     gardeners: [TEST_USER],
     operators: [],
     owners: [],
@@ -39,8 +40,8 @@ const mockGardens = [
     communities: [],
   },
   {
-    id: "operator",
-    tokenAddress: OPERATOR_GARDEN,
+    id: OPERATOR_GARDEN,
+    tokenAddress: SHARED_GARDEN_TOKEN,
     gardeners: [],
     operators: [TEST_USER],
     owners: [],
@@ -49,8 +50,8 @@ const mockGardens = [
     communities: [],
   },
   {
-    id: "owner",
-    tokenAddress: OWNER_GARDEN,
+    id: OWNER_GARDEN,
+    tokenAddress: SHARED_GARDEN_TOKEN,
     gardeners: [],
     operators: [],
     owners: [TEST_USER],
@@ -59,8 +60,8 @@ const mockGardens = [
     communities: [],
   },
   {
-    id: "evaluator",
-    tokenAddress: EVALUATOR_GARDEN,
+    id: EVALUATOR_GARDEN,
+    tokenAddress: SHARED_GARDEN_TOKEN,
     gardeners: [],
     operators: [],
     owners: [],
@@ -69,8 +70,8 @@ const mockGardens = [
     communities: [],
   },
   {
-    id: "funder",
-    tokenAddress: FUNDER_GARDEN,
+    id: FUNDER_GARDEN,
+    tokenAddress: SHARED_GARDEN_TOKEN,
     gardeners: [],
     operators: [],
     owners: [],
@@ -79,8 +80,8 @@ const mockGardens = [
     communities: [],
   },
   {
-    id: "community",
-    tokenAddress: COMMUNITY_GARDEN,
+    id: COMMUNITY_GARDEN,
+    tokenAddress: SHARED_GARDEN_TOKEN,
     gardeners: [],
     operators: [],
     owners: [],

--- a/packages/shared/src/__tests__/hooks/cookie-jar/useUserCookieJars.test.ts
+++ b/packages/shared/src/__tests__/hooks/cookie-jar/useUserCookieJars.test.ts
@@ -16,8 +16,9 @@ const TEST_CHAIN_ID = 11155111;
 const TEST_MODULE = "0xModule111111111111111111111111111111111111";
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-const TEST_GARDEN_1 = "0xGarden1111111111111111111111111111111111";
-const TEST_GARDEN_2 = "0xGarden2222222222222222222222222222222222";
+const TEST_GARDEN_1 = "0x1111111111111111111111111111111111111111";
+const TEST_GARDEN_2 = "0x2222222222222222222222222222222222222222";
+const SHARED_GARDEN_TOKEN = "0x9999999999999999999999999999999999999999";
 const TEST_JAR_1 = "0xJar1111111111111111111111111111111111111";
 const TEST_JAR_2 = "0xJar2222222222222222222222222222222222222";
 const TEST_CURRENCY = "0xCurr111111111111111111111111111111111111";
@@ -105,11 +106,11 @@ describe("hooks/cookie-jar/useUserCookieJars", () => {
   });
 
   it("filters gardens to only those where user is operator", () => {
-    const nonOperatorGarden = "0xNonOp111111111111111111111111111111111";
+    const nonOperatorGarden = "0x3333333333333333333333333333333333333333";
     mockOperatorGardens.push({ id: TEST_GARDEN_1.toLowerCase(), name: "Garden 1" });
     mockGardens.push(
-      { tokenAddress: TEST_GARDEN_1, id: "garden-1" },
-      { tokenAddress: nonOperatorGarden, id: "garden-non-op" }
+      { id: TEST_GARDEN_1, tokenAddress: SHARED_GARDEN_TOKEN },
+      { id: nonOperatorGarden, tokenAddress: SHARED_GARDEN_TOKEN }
     );
 
     // Step 1: jar addresses — only 1 garden should be queried
@@ -151,8 +152,8 @@ describe("hooks/cookie-jar/useUserCookieJars", () => {
       { id: TEST_GARDEN_2.toLowerCase(), name: "Garden 2" }
     );
     mockGardens.push(
-      { tokenAddress: TEST_GARDEN_1, id: "garden-1" },
-      { tokenAddress: TEST_GARDEN_2, id: "garden-2" }
+      { id: TEST_GARDEN_1, tokenAddress: SHARED_GARDEN_TOKEN },
+      { id: TEST_GARDEN_2, tokenAddress: SHARED_GARDEN_TOKEN }
     );
 
     // Step 1: jar addresses for both gardens
@@ -214,7 +215,7 @@ describe("hooks/cookie-jar/useUserCookieJars", () => {
 
   it("filters out zero-address jars across all gardens", () => {
     mockOperatorGardens.push({ id: TEST_GARDEN_1.toLowerCase(), name: "Garden 1" });
-    mockGardens.push({ tokenAddress: TEST_GARDEN_1, id: "garden-1" });
+    mockGardens.push({ id: TEST_GARDEN_1, tokenAddress: SHARED_GARDEN_TOKEN });
 
     // Jar addresses include a zero address
     mockReadContractsResults.push({
@@ -250,7 +251,7 @@ describe("hooks/cookie-jar/useUserCookieJars", () => {
 
   it("falls back to 18 decimals on failure", () => {
     mockOperatorGardens.push({ id: TEST_GARDEN_1.toLowerCase(), name: "Garden 1" });
-    mockGardens.push({ tokenAddress: TEST_GARDEN_1, id: "garden-1" });
+    mockGardens.push({ id: TEST_GARDEN_1, tokenAddress: SHARED_GARDEN_TOKEN });
 
     mockReadContractsResults.push({
       data: [{ result: [TEST_JAR_1], status: "success" }],
@@ -287,7 +288,7 @@ describe("hooks/cookie-jar/useUserCookieJars", () => {
 
   it("sets loading state correctly across all steps", () => {
     mockOperatorGardens.push({ id: TEST_GARDEN_1.toLowerCase(), name: "Garden 1" });
-    mockGardens.push({ tokenAddress: TEST_GARDEN_1, id: "garden-1" });
+    mockGardens.push({ id: TEST_GARDEN_1, tokenAddress: SHARED_GARDEN_TOKEN });
 
     // First step is loading
     mockReadContractsResults.push({ data: undefined, isLoading: true });

--- a/packages/shared/src/__tests__/hooks/garden/adminGardenSwitching.render.test.tsx
+++ b/packages/shared/src/__tests__/hooks/garden/adminGardenSwitching.render.test.tsx
@@ -50,7 +50,16 @@ function GardenSwitchingHarness() {
       <h1 data-testid="garden-heading">{selectedGarden?.name ?? "No garden"}</h1>
       <p>{renderedContent}</p>
       {gardenOptions.map((garden) => (
-        <button key={garden.id} type="button" onClick={() => handleSelectGarden(garden)}>
+        <button
+          key={garden.id}
+          type="button"
+          onClick={() =>
+            handleSelectGarden({
+              id: garden.name === "Beta Garden" ? garden.id.toUpperCase() : garden.id,
+              name: garden.name,
+            })
+          }
+        >
           Switch to {garden.name}
         </button>
       ))}

--- a/packages/shared/src/__tests__/hooks/garden/adminGardenSwitching.render.test.tsx
+++ b/packages/shared/src/__tests__/hooks/garden/adminGardenSwitching.render.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, useLocation } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAdminGardenWorkspaceSelection } from "../../../hooks/garden/useAdminGardenWorkspaceSelection";
+import { ADMIN_GARDEN_PREFERENCES_STORAGE_KEY, useAdminStore } from "../../../stores/useAdminStore";
+import type { Garden } from "../../../types/domain";
+import { createMockGarden } from "../../test-utils";
+
+const mockEligibleState = vi.hoisted(() => ({
+  current: {
+    eligibleGardens: [] as Garden[],
+    resolvedDefaultGarden: null as Garden | null,
+    persistedGardenId: null as string | null,
+    scopeKey: "11155111:0x1111111111111111111111111111111111111111",
+    canCreateGarden: false,
+    isLoaded: true,
+    isError: false,
+    hasStaleBaseList: false,
+  },
+}));
+
+vi.mock("../../../hooks/garden/useEligibleAdminGardens", () => ({
+  useEligibleAdminGardens: () => mockEligibleState.current,
+}));
+
+function LocationProbe() {
+  const location = useLocation();
+  return <output data-testid="location-search">{location.search}</output>;
+}
+
+function GardenSwitchingHarness() {
+  const { selectedGarden, gardenOptions, handleSelectGarden } = useAdminGardenWorkspaceSelection({
+    autoSelectFirstGarden: true,
+  });
+  const activeGardenId = selectedGarden?.id.toLowerCase() ?? "";
+  const renderedContent =
+    activeGardenId === "0xaaa0000000000000000000000000000000000aaa"
+      ? "Alpha settings and work queue"
+      : activeGardenId === "0xbbb0000000000000000000000000000000000bbb"
+        ? "Beta members and treasury"
+        : "No garden selected";
+
+  return (
+    <section>
+      <h1 data-testid="garden-heading">{selectedGarden?.name ?? "No garden"}</h1>
+      <p>{renderedContent}</p>
+      {gardenOptions.map((garden) => (
+        <button key={garden.id} type="button" onClick={() => handleSelectGarden(garden)}>
+          Switch to {garden.name}
+        </button>
+      ))}
+      <LocationProbe />
+    </section>
+  );
+}
+
+describe("admin garden switching rendered context", () => {
+  beforeEach(() => {
+    localStorage.removeItem(ADMIN_GARDEN_PREFERENCES_STORAGE_KEY);
+    useAdminStore.setState({ selectedGarden: null, lastGardenIdsByScope: {} });
+  });
+
+  it("updates URL and rendered admin content after switching between two eligible gardens", async () => {
+    const gardenA = createMockGarden({
+      id: "0xaaa0000000000000000000000000000000000aaa",
+      tokenAddress: "0xaaa0000000000000000000000000000000000aaa",
+      name: "Alpha Garden",
+      location: "Quito",
+    });
+    const gardenB = createMockGarden({
+      id: "0xbbb0000000000000000000000000000000000bbb",
+      tokenAddress: "0xbbb0000000000000000000000000000000000bbb",
+      name: "Beta Garden",
+      location: "Bogota",
+    });
+    mockEligibleState.current = {
+      ...mockEligibleState.current,
+      eligibleGardens: [gardenA, gardenB],
+      resolvedDefaultGarden: gardenA,
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/hub"]}>
+        <GardenSwitchingHarness />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("garden-heading")).toHaveTextContent("Alpha Garden");
+    });
+    expect(screen.getByText("Alpha settings and work queue")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Switch to Beta Garden" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("garden-heading")).toHaveTextContent("Beta Garden");
+    });
+    expect(screen.queryByText("Alpha settings and work queue")).not.toBeInTheDocument();
+    expect(screen.getByText("Beta members and treasury")).toBeInTheDocument();
+    expect(screen.getByTestId("location-search")).toHaveTextContent(
+      "gardenAddress=0xbbb0000000000000000000000000000000000bbb"
+    );
+  });
+});

--- a/packages/shared/src/__tests__/hooks/garden/adminGardenSwitching.render.test.tsx
+++ b/packages/shared/src/__tests__/hooks/garden/adminGardenSwitching.render.test.tsx
@@ -68,13 +68,13 @@ describe("admin garden switching rendered context", () => {
   it("updates URL and rendered admin content after switching between two eligible gardens", async () => {
     const gardenA = createMockGarden({
       id: "0xaaa0000000000000000000000000000000000aaa",
-      tokenAddress: "0xaaa0000000000000000000000000000000000aaa",
+      tokenAddress: "0x9990000000000000000000000000000000000999",
       name: "Alpha Garden",
       location: "Quito",
     });
     const gardenB = createMockGarden({
       id: "0xbbb0000000000000000000000000000000000bbb",
-      tokenAddress: "0xbbb0000000000000000000000000000000000bbb",
+      tokenAddress: "0x9990000000000000000000000000000000000999",
       name: "Beta Garden",
       location: "Bogota",
     });

--- a/packages/shared/src/__tests__/hooks/garden/useEligibleAdminGardens.test.ts
+++ b/packages/shared/src/__tests__/hooks/garden/useEligibleAdminGardens.test.ts
@@ -77,7 +77,7 @@ describe("hooks/garden/useEligibleAdminGardens", () => {
     );
   });
 
-  it("filters gardens to operator, owner, and evaluator memberships", () => {
+  it("filters gardens to operator and owner memberships", () => {
     mockUseGardens.mockReturnValue({
       data: [
         makeGarden("garden-operator", "Operator Garden", { operators: [ADDR_USER] }),
@@ -92,7 +92,6 @@ describe("hooks/garden/useEligibleAdminGardens", () => {
     const { result } = renderHook(() => useEligibleAdminGardens());
 
     expect(result.current.eligibleGardens.map((garden) => garden.id)).toEqual([
-      "garden-evaluator",
       "garden-operator",
       "garden-owner",
     ]);
@@ -104,7 +103,7 @@ describe("hooks/garden/useEligibleAdminGardens", () => {
     mockUseGardens.mockReturnValue({
       data: [
         makeGarden("garden-b", "Beta Garden", { operators: [ADDR_USER] }),
-        makeGarden("garden-a", "Alpha Garden", { evaluators: [ADDR_USER] }),
+        makeGarden("garden-a", "Alpha Garden", { owners: [ADDR_USER] }),
       ],
       isFetched: true,
       isError: false,
@@ -128,7 +127,7 @@ describe("hooks/garden/useEligibleAdminGardens", () => {
     mockUseGardens.mockReturnValue({
       data: [
         makeGarden("garden-z", "Zeta Garden", { operators: [ADDR_USER] }),
-        makeGarden("garden-a", "Alpha Garden", { evaluators: [ADDR_USER] }),
+        makeGarden("garden-a", "Alpha Garden", { owners: [ADDR_USER] }),
       ],
       isFetched: true,
       isError: false,

--- a/packages/shared/src/__tests__/hooks/garden/useEligibleAdminGardens.test.ts
+++ b/packages/shared/src/__tests__/hooks/garden/useEligibleAdminGardens.test.ts
@@ -77,7 +77,7 @@ describe("hooks/garden/useEligibleAdminGardens", () => {
     );
   });
 
-  it("filters gardens to operator and owner memberships", () => {
+  it("filters gardens to operator, owner, and evaluator memberships", () => {
     mockUseGardens.mockReturnValue({
       data: [
         makeGarden("garden-operator", "Operator Garden", { operators: [ADDR_USER] }),
@@ -92,6 +92,7 @@ describe("hooks/garden/useEligibleAdminGardens", () => {
     const { result } = renderHook(() => useEligibleAdminGardens());
 
     expect(result.current.eligibleGardens.map((garden) => garden.id)).toEqual([
+      "garden-evaluator",
       "garden-operator",
       "garden-owner",
     ]);
@@ -103,7 +104,7 @@ describe("hooks/garden/useEligibleAdminGardens", () => {
     mockUseGardens.mockReturnValue({
       data: [
         makeGarden("garden-b", "Beta Garden", { operators: [ADDR_USER] }),
-        makeGarden("garden-a", "Alpha Garden", { owners: [ADDR_USER] }),
+        makeGarden("garden-a", "Alpha Garden", { evaluators: [ADDR_USER] }),
       ],
       isFetched: true,
       isError: false,
@@ -127,7 +128,7 @@ describe("hooks/garden/useEligibleAdminGardens", () => {
     mockUseGardens.mockReturnValue({
       data: [
         makeGarden("garden-z", "Zeta Garden", { operators: [ADDR_USER] }),
-        makeGarden("garden-a", "Alpha Garden", { owners: [ADDR_USER] }),
+        makeGarden("garden-a", "Alpha Garden", { evaluators: [ADDR_USER] }),
       ],
       isFetched: true,
       isError: false,

--- a/packages/shared/src/__tests__/hooks/navigation/useGardenUrlSync.search-options.test.ts
+++ b/packages/shared/src/__tests__/hooks/navigation/useGardenUrlSync.search-options.test.ts
@@ -97,20 +97,21 @@ describe("useGardenUrlSync search options", () => {
   });
 
   it("does not let a second hook instance restore the previous URL garden while a switch is pending", () => {
+    const sharedGardenToken = "0x9990000000000000000000000000000000000999";
     const gardenA = {
       id: "garden-a",
       name: "Alpha",
-      tokenAddress: "0xaaa0000000000000000000000000000000000aaa",
+      tokenAddress: sharedGardenToken,
     };
     const gardenB = {
       id: "garden-b",
       name: "Beta",
-      tokenAddress: "0xbbb0000000000000000000000000000000000bbb",
+      tokenAddress: sharedGardenToken,
     };
     mockEligibleGardens.current = [gardenA, gardenB];
     mockSelectedGarden.current = gardenA;
     mockSelectedGardenId.current = gardenA.id;
-    mockSearchParams.current = new URLSearchParams(`gardenAddress=${gardenA.tokenAddress}`);
+    mockSearchParams.current = new URLSearchParams(`gardenAddress=${gardenA.id}`);
 
     const { result, rerender } = renderHook(() => ({
       shell: useGardenUrlSync(),

--- a/packages/shared/src/__tests__/hooks/navigation/useGardenUrlSync.search-options.test.ts
+++ b/packages/shared/src/__tests__/hooks/navigation/useGardenUrlSync.search-options.test.ts
@@ -6,14 +6,17 @@ import { renderHook, act } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSetSearchParams = vi.fn();
-const mockSearchParams = new URLSearchParams();
+const mockSearchParams = { current: new URLSearchParams() };
 const mockSetSelectedGarden = vi.fn();
 const mockSetPersistedGardenId = vi.fn();
 const mockSelectedGardenId = { current: null as string | null };
 const mockSelectedGarden = { current: null as any };
+const mockEligibleGardens = { current: [] as any[] };
+const mockResolvedDefaultGarden = { current: null as any };
+const mockIsLoaded = { current: true };
 
 vi.mock("react-router-dom", () => ({
-  useSearchParams: () => [mockSearchParams, mockSetSearchParams],
+  useSearchParams: () => [mockSearchParams.current, mockSetSearchParams],
 }));
 
 vi.mock("../../../stores/useAdminStore", () => ({
@@ -29,12 +32,12 @@ vi.mock("../../../stores/useAdminStore", () => ({
 
 vi.mock("../../../hooks/garden/useEligibleAdminGardens", () => ({
   useEligibleAdminGardens: () => ({
-    eligibleGardens: [],
-    resolvedDefaultGarden: null,
+    eligibleGardens: mockEligibleGardens.current,
+    resolvedDefaultGarden: mockResolvedDefaultGarden.current,
     persistedGardenId: null,
     scopeKey: "11155111:0x1111111111111111111111111111111111111111",
     canCreateGarden: false,
-    isLoaded: true,
+    isLoaded: mockIsLoaded.current,
   }),
 }));
 
@@ -43,8 +46,16 @@ import { useGardenUrlSync } from "../../../hooks/navigation/useGardenUrlSync";
 describe("useGardenUrlSync search options", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSetSelectedGarden.mockImplementation((garden) => {
+      mockSelectedGarden.current = garden;
+      mockSelectedGardenId.current = garden?.id ?? null;
+    });
+    mockSearchParams.current = new URLSearchParams();
     mockSelectedGardenId.current = null;
     mockSelectedGarden.current = null;
+    mockEligibleGardens.current = [];
+    mockResolvedDefaultGarden.current = null;
+    mockIsLoaded.current = true;
   });
 
   it("preserves scroll when opening and closing route-backed item sheets", () => {
@@ -83,5 +94,36 @@ describe("useGardenUrlSync search options", () => {
     });
 
     expect(mockSetSearchParams).toHaveBeenLastCalledWith(expect.any(Function), { replace: true });
+  });
+
+  it("does not let a second hook instance restore the previous URL garden while a switch is pending", () => {
+    const gardenA = {
+      id: "garden-a",
+      name: "Alpha",
+      tokenAddress: "0xaaa0000000000000000000000000000000000aaa",
+    };
+    const gardenB = {
+      id: "garden-b",
+      name: "Beta",
+      tokenAddress: "0xbbb0000000000000000000000000000000000bbb",
+    };
+    mockEligibleGardens.current = [gardenA, gardenB];
+    mockSelectedGarden.current = gardenA;
+    mockSelectedGardenId.current = gardenA.id;
+    mockSearchParams.current = new URLSearchParams(`gardenAddress=${gardenA.tokenAddress}`);
+
+    const { result, rerender } = renderHook(() => ({
+      shell: useGardenUrlSync(),
+      route: useGardenUrlSync(),
+    }));
+
+    act(() => {
+      result.current.shell.setGarden(gardenB);
+    });
+
+    rerender();
+
+    expect(mockSelectedGarden.current).toEqual(gardenB);
+    expect(mockSetSelectedGarden).not.toHaveBeenLastCalledWith(gardenA);
   });
 });

--- a/packages/shared/src/__tests__/hooks/navigation/useGardenUrlSync.test.ts
+++ b/packages/shared/src/__tests__/hooks/navigation/useGardenUrlSync.test.ts
@@ -139,12 +139,12 @@ describe("useGardenUrlSync", () => {
     const greenGarden = createMockGarden({
       id: "garden-green",
       name: "Green Goods Community Garden",
-      tokenAddress: "0xaaa0000000000000000000000000000000000aaa",
+      tokenAddress: "0x9990000000000000000000000000000000000999",
     });
     const growGarden = createMockGarden({
       id: "garden-grow",
       name: "Grow Ecosystem",
-      tokenAddress: "0xbbb0000000000000000000000000000000000bbb",
+      tokenAddress: "0x9990000000000000000000000000000000000999",
     });
     mockEligibleGardens.current = [greenGarden, growGarden];
     mockSelectedGarden.current = greenGarden;
@@ -164,7 +164,7 @@ describe("useGardenUrlSync", () => {
     });
 
     expect(mockSetSelectedGarden).toHaveBeenLastCalledWith(growGarden);
-    expect(mockLocationSearch.current).toContain(`gardenAddress=${growGarden.tokenAddress}`);
+    expect(mockLocationSearch.current).toContain(`gardenAddress=${growGarden.id}`);
     expect(mockLocationSearch.current).toContain("sort=oldest");
   });
 
@@ -237,19 +237,17 @@ describe("useGardenUrlSync", () => {
   it("reports the URL garden as active even when the store still has the previous garden", () => {
     const previousGarden = createMockGarden({
       id: "garden-previous",
-      tokenAddress: "0x1110000000000000000000000000000000000111",
+      tokenAddress: "0x9990000000000000000000000000000000000999",
     });
     const urlGarden = createMockGarden({
       id: "garden-url",
-      tokenAddress: "0x7890000000000000000000000000000000000789",
+      tokenAddress: "0x9990000000000000000000000000000000000999",
     });
     mockEligibleGardens.current = [previousGarden, urlGarden];
     mockSelectedGarden.current = previousGarden;
     mockSelectedGardenId.current = previousGarden.id;
 
-    const wrapper = createRouterWrapper([
-      "/hub?gardenAddress=0x7890000000000000000000000000000000000789",
-    ]);
+    const wrapper = createRouterWrapper(["/hub?gardenAddress=garden-url"]);
 
     const { result } = renderHook(() => useGardenUrlSync(), { wrapper });
 
@@ -257,6 +255,28 @@ describe("useGardenUrlSync", () => {
     expect(mockSetSelectedGarden).toHaveBeenCalledWith(
       expect.objectContaining({ id: urlGarden.id })
     );
+  });
+
+  it("prefers garden id over shared tokenAddress when resolving URL garden", () => {
+    const sharedGardenToken = "0x9990000000000000000000000000000000000999";
+    const gardenA = createMockGarden({
+      id: "garden-a",
+      tokenAddress: sharedGardenToken,
+    });
+    const gardenB = createMockGarden({
+      id: "garden-b",
+      tokenAddress: sharedGardenToken,
+    });
+    mockEligibleGardens.current = [gardenA, gardenB];
+    mockSelectedGarden.current = gardenA;
+    mockSelectedGardenId.current = gardenA.id;
+
+    const wrapper = createRouterWrapper(["/hub?gardenAddress=garden-b"]);
+
+    const { result } = renderHook(() => useGardenUrlSync(), { wrapper });
+
+    expect(result.current.gardenId).toBe(gardenB.id);
+    expect(mockSetSelectedGarden).toHaveBeenCalledWith(expect.objectContaining({ id: gardenB.id }));
   });
 
   it("falls back to the resolved default garden when the URL has no garden param", () => {

--- a/packages/shared/src/__tests__/hooks/navigation/useGardenUrlSync.test.ts
+++ b/packages/shared/src/__tests__/hooks/navigation/useGardenUrlSync.test.ts
@@ -234,6 +234,31 @@ describe("useGardenUrlSync", () => {
     );
   });
 
+  it("reports the URL garden as active even when the store still has the previous garden", () => {
+    const previousGarden = createMockGarden({
+      id: "garden-previous",
+      tokenAddress: "0x1110000000000000000000000000000000000111",
+    });
+    const urlGarden = createMockGarden({
+      id: "garden-url",
+      tokenAddress: "0x7890000000000000000000000000000000000789",
+    });
+    mockEligibleGardens.current = [previousGarden, urlGarden];
+    mockSelectedGarden.current = previousGarden;
+    mockSelectedGardenId.current = previousGarden.id;
+
+    const wrapper = createRouterWrapper([
+      "/hub?gardenAddress=0x7890000000000000000000000000000000000789",
+    ]);
+
+    const { result } = renderHook(() => useGardenUrlSync(), { wrapper });
+
+    expect(result.current.gardenId).toBe(urlGarden.id);
+    expect(mockSetSelectedGarden).toHaveBeenCalledWith(
+      expect.objectContaining({ id: urlGarden.id })
+    );
+  });
+
   it("falls back to the resolved default garden when the URL has no garden param", () => {
     const defaultGarden = createMockGarden({ id: "garden-default" });
     mockEligibleGardens.current = [defaultGarden];

--- a/packages/shared/src/components/Canvas/GardenChip.stories.tsx
+++ b/packages/shared/src/components/Canvas/GardenChip.stories.tsx
@@ -65,11 +65,10 @@ const meta = {
     },
     selectedGarden: {
       control: "object",
-      description: "The currently selected garden, or null for All Gardens.",
+      description: "The currently selected garden, or null while selection is loading.",
     },
     onSelectGarden: {
-      description:
-        "Callback when a garden is selected. Receives the garden object or null for All Gardens.",
+      description: "Callback when a garden is selected. Receives the garden object.",
     },
     onCreateGarden: {
       description:
@@ -114,8 +113,8 @@ export const MultiGarden: Story = {
   },
 };
 
-/** No garden selected — shows "All Gardens" label. */
-export const AllGardens: Story = {
+/** No garden selected yet — prompts the user to choose an eligible garden. */
+export const SelectionRequired: Story = {
   args: {
     gardens: multipleGardens,
     selectedGarden: null,
@@ -191,7 +190,9 @@ export const StateCatalog: Story = {
       </section>
 
       <section>
-        <h3 className="mb-3 text-sm font-semibold text-text-sub">Multi Garden — All Gardens</h3>
+        <h3 className="mb-3 text-sm font-semibold text-text-sub">
+          Multi Garden - selection required
+        </h3>
         <GardenChip
           gardens={multipleGardens}
           selectedGarden={null}

--- a/packages/shared/src/components/Canvas/GardenChip.tsx
+++ b/packages/shared/src/components/Canvas/GardenChip.tsx
@@ -11,7 +11,7 @@ import { cn } from "../../utils/styles/cn";
 export interface GardenChipProps {
   gardens: Array<{ id: string; name: string }>;
   selectedGarden: { id: string; name: string } | null;
-  onSelectGarden: (garden: { id: string; name: string } | null) => void;
+  onSelectGarden: (garden: { id: string; name: string }) => void;
   onCreateGarden?: () => void;
 }
 
@@ -22,12 +22,12 @@ export interface GardenChipProps {
 /**
  * Compact pill/chip showing the active garden name.
  *
- * - 1 garden: Static label (no dropdown, no "All Gardens")
+ * - 1 garden: Static label (no dropdown)
  * - 2+ gardens: Click to open a Radix Popover dropdown with
- *   "All Gardens" at top, garden list, divider, "Create Garden" at bottom
+ *   garden list, divider, "Create Garden" at bottom
  *
  * Decision D47: single-garden users never see a switcher.
- * Decision D50: dropdown contains only gardens + All Gardens + Create Garden.
+ * Decision D50: dropdown contains only eligible gardens + Create Garden.
  */
 export function GardenChip({
   gardens,
@@ -39,7 +39,7 @@ export function GardenChip({
   const [open, setOpen] = useState(false);
 
   const displayName =
-    selectedGarden?.name ?? formatMessage({ id: "cockpit.gardenChip.allGardens" });
+    selectedGarden?.name ?? formatMessage({ id: "app.assessment.selectGarden" });
 
   const hasMultiple = gardens.length >= 2;
 
@@ -107,7 +107,7 @@ export function GardenChip({
           }}
           data-component="GardenChip"
           data-slot="trigger"
-          data-selection-state={selectedGarden ? "selected" : "all-gardens"}
+          data-selection-state={selectedGarden ? "selected" : "empty"}
         >
           {selectedGarden ? (
             <span className="relative flex h-4 w-4 shrink-0 items-center justify-center">
@@ -155,16 +155,6 @@ export function GardenChip({
           data-component="GardenChip"
           data-slot="menu"
         >
-          {/* All Gardens option */}
-          <GardenDropdownItem
-            label={formatMessage({ id: "cockpit.gardenChip.allGardens" })}
-            isSelected={selectedGarden === null}
-            onClick={() => {
-              onSelectGarden(null);
-              setOpen(false);
-            }}
-          />
-
           {/* Garden list */}
           {gardens.map((garden) => (
             <GardenDropdownItem

--- a/packages/shared/src/components/Canvas/GardenChip.tsx
+++ b/packages/shared/src/components/Canvas/GardenChip.tsx
@@ -38,8 +38,7 @@ export function GardenChip({
   const { formatMessage } = useIntl();
   const [open, setOpen] = useState(false);
 
-  const displayName =
-    selectedGarden?.name ?? formatMessage({ id: "app.assessment.selectGarden" });
+  const displayName = selectedGarden?.name ?? formatMessage({ id: "app.assessment.selectGarden" });
 
   const hasMultiple = gardens.length >= 2;
 

--- a/packages/shared/src/components/Canvas/MetaStrip.stories.tsx
+++ b/packages/shared/src/components/Canvas/MetaStrip.stories.tsx
@@ -44,3 +44,11 @@ export const Empty: Story = {
     items: [],
   },
 };
+
+export const LoadingInline: Story = {
+  render: () => <MetaStrip density="inline" items={[]} loading loadingItemCount={2} />,
+};
+
+export const LoadingPill: Story = {
+  render: () => <MetaStrip density="pill" items={[]} loading loadingItemCount={3} />,
+};

--- a/packages/shared/src/components/Canvas/MetaStrip.tsx
+++ b/packages/shared/src/components/Canvas/MetaStrip.tsx
@@ -49,11 +49,7 @@ export function MetaStrip({
 }: MetaStripProps) {
   if (loading) {
     return (
-      <MetaStripSkeleton
-        className={className}
-        density={density}
-        itemCount={loadingItemCount}
-      />
+      <MetaStripSkeleton className={className} density={density} itemCount={loadingItemCount} />
     );
   }
 
@@ -107,11 +103,7 @@ export function MetaStrip({
   );
 }
 
-function MetaStripSkeleton({
-  className,
-  density = "pill",
-  itemCount = 2,
-}: MetaStripSkeletonProps) {
+function MetaStripSkeleton({ className, density = "pill", itemCount = 2 }: MetaStripSkeletonProps) {
   if (itemCount <= 0) return null;
 
   const widths = density === "inline" ? INLINE_SKELETON_WIDTHS : PILL_SKELETON_WIDTHS;

--- a/packages/shared/src/components/Canvas/MetaStrip.tsx
+++ b/packages/shared/src/components/Canvas/MetaStrip.tsx
@@ -10,6 +10,8 @@ export interface MetaStripItem {
 export interface MetaStripProps {
   items: MetaStripItem[];
   className?: string;
+  loading?: boolean;
+  loadingItemCount?: number;
   /**
    * Render density. Default `pill` shows each item as a soft pill with shadow
    * (the original anatomy). `inline` renders items as plain text separated by
@@ -20,7 +22,41 @@ export interface MetaStripProps {
   density?: "pill" | "inline";
 }
 
-export function MetaStrip({ items, className, density = "pill" }: MetaStripProps) {
+export interface MetaStripSkeletonProps {
+  className?: string;
+  density?: MetaStripProps["density"];
+  itemCount?: number;
+}
+
+const INLINE_SKELETON_WIDTHS = [
+  { value: "1.75rem", label: "4.5rem" },
+  { value: "1.5rem", label: "5.25rem" },
+  { value: "2rem", label: "4rem" },
+] as const;
+
+const PILL_SKELETON_WIDTHS = [
+  { value: "1.75rem", label: "4.75rem" },
+  { value: "1.5rem", label: "5.5rem" },
+  { value: "2rem", label: "4.25rem" },
+] as const;
+
+export function MetaStrip({
+  items,
+  className,
+  density = "pill",
+  loading = false,
+  loadingItemCount = 2,
+}: MetaStripProps) {
+  if (loading) {
+    return (
+      <MetaStripSkeleton
+        className={className}
+        density={density}
+        itemCount={loadingItemCount}
+      />
+    );
+  }
+
   if (items.length === 0) return null;
 
   if (density === "inline") {
@@ -65,6 +101,86 @@ export function MetaStrip({ items, className, density = "pill" }: MetaStripProps
         >
           {item.value ? <span className="font-bold text-text-strong">{item.value}</span> : null}
           <span>{item.label}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function MetaStripSkeleton({
+  className,
+  density = "pill",
+  itemCount = 2,
+}: MetaStripSkeletonProps) {
+  if (itemCount <= 0) return null;
+
+  const widths = density === "inline" ? INLINE_SKELETON_WIDTHS : PILL_SKELETON_WIDTHS;
+  const items = Array.from({ length: itemCount }, (_, index) => ({
+    id: `meta-skeleton-${index}`,
+    widths: widths[index % widths.length] ?? widths[0],
+  }));
+
+  if (density === "inline") {
+    return (
+      <div
+        data-component="MetaStrip"
+        data-density="inline"
+        data-state="loading"
+        aria-hidden="true"
+        className={cn(
+          "flex flex-wrap items-center gap-x-2 gap-y-1 text-label-sm font-medium text-text-sub",
+          className
+        )}
+      >
+        {items.map((item, index) => (
+          <Fragment key={item.id}>
+            {index > 0 ? (
+              <span aria-hidden="true" className="text-text-soft">
+                ·
+              </span>
+            ) : null}
+            <span className="inline-flex items-center gap-1" data-slot="skeleton-item">
+              <span
+                className="rounded skeleton-shimmer"
+                data-slot="skeleton-value"
+                style={{ width: item.widths.value, height: "1em" }}
+              />
+              <span
+                className="rounded skeleton-shimmer"
+                data-slot="skeleton-label"
+                style={{ width: item.widths.label, height: "1em" }}
+              />
+            </span>
+          </Fragment>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-component="MetaStrip"
+      data-density="pill"
+      data-state="loading"
+      aria-hidden="true"
+      className={cn("flex flex-wrap items-center gap-2 max-[599px]:gap-1.5", className)}
+    >
+      {items.map((item) => (
+        <span
+          key={item.id}
+          className="inline-flex items-center gap-1.5 rounded-full bg-bg-soft px-3 py-2 text-label-sm font-semibold text-text-sub shadow-[var(--edge-rest)]"
+          data-slot="skeleton-item"
+        >
+          <span
+            className="rounded skeleton-shimmer"
+            data-slot="skeleton-value"
+            style={{ width: item.widths.value, height: "1rem" }}
+          />
+          <span
+            className="rounded skeleton-shimmer"
+            data-slot="skeleton-label"
+            style={{ width: item.widths.label, height: "1rem" }}
+          />
         </span>
       ))}
     </div>

--- a/packages/shared/src/hooks/admin-ui/community/useCommunityWorkspaceController.ts
+++ b/packages/shared/src/hooks/admin-ui/community/useCommunityWorkspaceController.ts
@@ -58,7 +58,7 @@ export function useCommunityWorkspaceController() {
   const { searchParams } = useCanvasSearchParams();
   const { containerRef } = useSheetWidth();
   const gardenStateKey = selectedGarden?.id ?? "";
-  const selectedGardenAddress = selectedGarden?.tokenAddress ?? selectedGarden?.id;
+  const selectedGardenAddress = selectedGarden?.id;
   const getGardenWorkspaceState = useGardenStateStore((state) => state.getGardenWorkspaceState);
   const setGardenWorkspaceState = useGardenStateStore((state) => state.setGardenWorkspaceState);
   const lastHydratedGardenStateKeyRef = useRef<string | null>(null);

--- a/packages/shared/src/hooks/admin-ui/garden/useGardenWorkspaceController.ts
+++ b/packages/shared/src/hooks/admin-ui/garden/useGardenWorkspaceController.ts
@@ -36,7 +36,7 @@ export function useGardenWorkspaceController() {
   const { selectedGarden, gardenOptions, handleSelectGarden } = useAdminGardenWorkspaceSelection();
   const { containerRef } = useSheetWidth();
   const gardenStateKey = selectedGarden?.id ?? "";
-  const selectedGardenAddress = selectedGarden?.tokenAddress ?? selectedGarden?.id;
+  const selectedGardenAddress = selectedGarden?.id;
   const getGardenWorkspaceState = useGardenStateStore((state) => state.getGardenWorkspaceState);
   const setGardenWorkspaceState = useGardenStateStore((state) => state.setGardenWorkspaceState);
   const lastHydratedGardenStateKeyRef = useRef<string | null>(null);

--- a/packages/shared/src/hooks/admin-ui/garden/useResolvedWorkDetail.ts
+++ b/packages/shared/src/hooks/admin-ui/garden/useResolvedWorkDetail.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_CHAIN_ID,
+  compareAddresses,
   useActions,
   useAdminGardenWorkspaceSelection,
   useGardenPermissions,
@@ -35,7 +36,8 @@ export function useResolvedWorkDetail(workId: string | undefined) {
   );
   const gardenId = matchedGarden?.id ?? selectedGardenId;
   const garden =
-    gardens.find((candidateGarden) => candidateGarden.id === gardenId) ?? matchedGarden;
+    gardens.find((candidateGarden) => compareAddresses(candidateGarden.id, gardenId)) ??
+    matchedGarden;
 
   const { works, isLoading: worksLoading } = useWorks(gardenId ?? "");
   const work =
@@ -55,7 +57,7 @@ export function useResolvedWorkDetail(workId: string | undefined) {
   const isReviewed = work?.status === "approved" || work?.status === "rejected";
 
   useEffect(() => {
-    if (matchedGarden && matchedGarden.id !== selectedGardenId) {
+    if (matchedGarden && !compareAddresses(matchedGarden.id, selectedGardenId)) {
       setSelectedGarden(matchedGarden);
     }
   }, [matchedGarden, selectedGardenId, setSelectedGarden]);

--- a/packages/shared/src/hooks/admin-ui/hub/useCreateAssessmentController.ts
+++ b/packages/shared/src/hooks/admin-ui/hub/useCreateAssessmentController.ts
@@ -2,6 +2,7 @@ import {
   type Address,
   adminRoutes,
   assessmentStepFields,
+  compareAddresses,
   type CreateAssessmentFormData,
   type Step,
   toastService,
@@ -95,7 +96,10 @@ export function useCreateAssessmentController() {
   const { data: gardens = [] } = useGardens();
   const permissions = useGardenPermissions();
   const gardenId = selectedGarden?.id ?? null;
-  const garden = useMemo(() => gardens.find((item) => item.id === gardenId), [gardens, gardenId]);
+  const garden = useMemo(
+    () => gardens.find((item) => compareAddresses(item.id, gardenId)),
+    [gardens, gardenId]
+  );
   const gardenRouteContext = useMemo(
     () => ({ gardenAddress: garden?.tokenAddress ?? garden?.id }),
     [garden?.id, garden?.tokenAddress]

--- a/packages/shared/src/hooks/admin-ui/hub/useCreateAssessmentController.ts
+++ b/packages/shared/src/hooks/admin-ui/hub/useCreateAssessmentController.ts
@@ -100,10 +100,7 @@ export function useCreateAssessmentController() {
     () => gardens.find((item) => compareAddresses(item.id, gardenId)),
     [gardens, gardenId]
   );
-  const gardenRouteContext = useMemo(
-    () => ({ gardenAddress: garden?.tokenAddress ?? garden?.id }),
-    [garden?.id, garden?.tokenAddress]
-  );
+  const gardenRouteContext = useMemo(() => ({ gardenAddress: garden?.id }), [garden?.id]);
   const canReview = garden ? permissions.canReviewGarden(garden) : false;
 
   const form = useCreateAssessmentStore(useShallow((state) => state.form));

--- a/packages/shared/src/hooks/admin-ui/hub/useCreateHypercertController.ts
+++ b/packages/shared/src/hooks/admin-ui/hub/useCreateHypercertController.ts
@@ -17,10 +17,7 @@ export function useCreateHypercertController() {
     () => gardens.find((item) => compareAddresses(item.id, selectedGarden?.id)),
     [gardens, selectedGarden?.id]
   );
-  const gardenRouteContext = useMemo(
-    () => ({ gardenAddress: garden?.tokenAddress ?? garden?.id }),
-    [garden?.id, garden?.tokenAddress]
-  );
+  const gardenRouteContext = useMemo(() => ({ gardenAddress: garden?.id }), [garden?.id]);
   const permissions = useGardenPermissions();
   const canManage = garden ? permissions.canManageGarden(garden) : false;
 

--- a/packages/shared/src/hooks/admin-ui/hub/useCreateHypercertController.ts
+++ b/packages/shared/src/hooks/admin-ui/hub/useCreateHypercertController.ts
@@ -1,4 +1,10 @@
-import { adminRoutes, useAdminStore, useGardenPermissions, useGardens } from "@green-goods/shared";
+import {
+  adminRoutes,
+  compareAddresses,
+  useAdminStore,
+  useGardenPermissions,
+  useGardens,
+} from "@green-goods/shared";
 import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import type { HypercertCompletionData } from "../hypercerts/types";
@@ -8,7 +14,7 @@ export function useCreateHypercertController() {
   const selectedGarden = useAdminStore((state) => state.selectedGarden);
   const { data: gardens = [] } = useGardens();
   const garden = useMemo(
-    () => gardens.find((item) => item.id === selectedGarden?.id),
+    () => gardens.find((item) => compareAddresses(item.id, selectedGarden?.id)),
     [gardens, selectedGarden?.id]
   );
   const gardenRouteContext = useMemo(

--- a/packages/shared/src/hooks/admin-ui/hub/useHubWorkbenchController.ts
+++ b/packages/shared/src/hooks/admin-ui/hub/useHubWorkbenchController.ts
@@ -92,10 +92,10 @@ export function useHubWorkbenchController() {
   const isDesktop = useMediaQuery("(min-width: 600px)");
   const hubContext = useMemo<AdminHubRouteContext>(
     () => ({
-      gardenAddress: selectedGarden?.tokenAddress ?? selectedGarden?.id,
+      gardenAddress: selectedGarden?.id,
       sort: sortDirection,
     }),
-    [selectedGarden?.id, selectedGarden?.tokenAddress, sortDirection]
+    [selectedGarden?.id, sortDirection]
   );
 
   useEffect(() => {

--- a/packages/shared/src/hooks/admin-ui/layout/commandPalette.results.ts
+++ b/packages/shared/src/hooks/admin-ui/layout/commandPalette.results.ts
@@ -164,7 +164,7 @@ export function buildCommandPaletteResults({
       {
         id: `garden-${garden.id}`,
         label: garden.name,
-        href: adminRoutes.garden({ gardenAddress: garden.tokenAddress ?? garden.id }),
+        href: adminRoutes.garden({ gardenAddress: garden.id }),
         onSelect: () => selectGarden(garden),
         category: "gardens",
         subtitle: garden.location || undefined,
@@ -193,12 +193,11 @@ export function buildCommandPaletteResults({
   for (const assessment of assessments) {
     const title = assessment.title || `Assessment ${assessment.id.slice(0, 8)}`;
     const matchedGarden = eligibleGardens.find(
-      (garden) =>
-        (garden.tokenAddress ?? garden.id).toLowerCase() === assessment.gardenAddress.toLowerCase()
+      (garden) => garden.id.toLowerCase() === assessment.gardenAddress.toLowerCase()
     );
     if (!matchedGarden) continue;
 
-    const gardenAddress = matchedGarden.tokenAddress ?? matchedGarden.id;
+    const gardenAddress = matchedGarden.id;
     const gardenName = matchedGarden.name;
     pushIfMatches(
       {

--- a/packages/shared/src/hooks/admin-ui/layout/useAdminRightSheetDescriptor.tsx
+++ b/packages/shared/src/hooks/admin-ui/layout/useAdminRightSheetDescriptor.tsx
@@ -43,7 +43,7 @@ function AdminNotificationPanel() {
   const navigate = useNavigate();
   const closeSheet = useSheetOrchestratorStore((state) => state.closeSheet);
   const { selectedGarden } = useAdminGardenWorkspaceSelection();
-  const selectedGardenAddress = selectedGarden?.tokenAddress ?? selectedGarden?.id;
+  const selectedGardenAddress = selectedGarden?.id;
   const workspace = useGardenDetailData(selectedGarden?.id);
 
   const navigateFromNotification = useCallback(

--- a/packages/shared/src/hooks/cookie-jar/useAccessibleCookieJars.ts
+++ b/packages/shared/src/hooks/cookie-jar/useAccessibleCookieJars.ts
@@ -39,7 +39,7 @@ export function useAccessibleCookieJars() {
     () =>
       primaryAddress
         ? gardens.map((garden) => ({
-            address: garden.tokenAddress.toLowerCase() as Address,
+            address: garden.id.toLowerCase() as Address,
             abi: GARDEN_ACCOUNT_ROLE_ABI,
             functionName: "isGardener" as const,
             args: [primaryAddress] as const,
@@ -88,7 +88,7 @@ export function useAccessibleCookieJars() {
         address: moduleAddress as Address,
         abi: COOKIE_JAR_MODULE_ABI,
         functionName: "getGardenJars" as const,
-        args: [garden.tokenAddress.toLowerCase() as Address] as const,
+        args: [garden.id.toLowerCase() as Address] as const,
       })),
     [eligibleGardens, moduleAddress]
   );
@@ -115,7 +115,7 @@ export function useAccessibleCookieJars() {
         if (address.toLowerCase() !== ZERO_ADDRESS) {
           pairs.push({
             jarAddress: address,
-            gardenAddress: eligibleGardens[index].tokenAddress.toLowerCase() as Address,
+            gardenAddress: eligibleGardens[index].id.toLowerCase() as Address,
           });
         }
       }

--- a/packages/shared/src/hooks/cookie-jar/useUserCookieJars.ts
+++ b/packages/shared/src/hooks/cookie-jar/useUserCookieJars.ts
@@ -31,7 +31,7 @@ export function useUserCookieJars() {
   const operatorGardens = useMemo(() => {
     if (!gardens || !roleOperatorGardens?.length) return [];
     const opSet = new Set(roleOperatorGardens.map((g) => g.id.toLowerCase()));
-    return gardens.filter((g) => opSet.has(g.tokenAddress.toLowerCase()));
+    return gardens.filter((g) => opSet.has(g.id.toLowerCase()));
   }, [gardens, roleOperatorGardens]);
 
   // Step 1: Batch-read jar addresses for each operator garden
@@ -41,7 +41,7 @@ export function useUserCookieJars() {
         address: moduleAddress as Address,
         abi: COOKIE_JAR_MODULE_ABI,
         functionName: "getGardenJars" as const,
-        args: [garden.tokenAddress.toLowerCase() as Address] as const,
+        args: [garden.id.toLowerCase() as Address] as const,
       })),
     [operatorGardens, moduleAddress]
   );
@@ -65,7 +65,7 @@ export function useUserCookieJars() {
         if (addr.toLowerCase() !== ZERO_ADDRESS) {
           pairs.push({
             jarAddress: addr,
-            gardenAddress: operatorGardens[i].tokenAddress.toLowerCase() as Address,
+            gardenAddress: operatorGardens[i].id.toLowerCase() as Address,
           });
         }
       }

--- a/packages/shared/src/hooks/garden/useAdminGardenWorkspaceSelection.ts
+++ b/packages/shared/src/hooks/garden/useAdminGardenWorkspaceSelection.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo } from "react";
 import { useAdminStore, type Garden } from "../../stores/useAdminStore";
+import { compareAddresses } from "../../utils/blockchain/address";
 import { useGardenUrlSync } from "../navigation/useGardenUrlSync";
 import { useEligibleAdminGardens } from "./useEligibleAdminGardens";
 
@@ -43,7 +44,7 @@ export function useAdminGardenWorkspaceSelection({
 
   const handleSelectGarden = useCallback(
     (garden: Pick<AdminGardenWorkspaceOption, "id">) => {
-      const fullGarden = eligibleGardens.find((entry) => entry.id === garden.id);
+      const fullGarden = eligibleGardens.find((entry) => compareAddresses(entry.id, garden.id));
       setGarden(fullGarden ?? null);
     },
     [eligibleGardens, setGarden]

--- a/packages/shared/src/hooks/garden/useEligibleAdminGardens.ts
+++ b/packages/shared/src/hooks/garden/useEligibleAdminGardens.ts
@@ -94,7 +94,8 @@ export function useEligibleAdminGardens(): EligibleAdminGardensResult {
       .filter((garden) => {
         return (
           isAddressInList(address, garden.operators) ||
-          isAddressInList(address, garden.owners)
+          isAddressInList(address, garden.owners) ||
+          isAddressInList(address, garden.evaluators)
         );
       })
       .slice()

--- a/packages/shared/src/hooks/garden/useEligibleAdminGardens.ts
+++ b/packages/shared/src/hooks/garden/useEligibleAdminGardens.ts
@@ -94,8 +94,7 @@ export function useEligibleAdminGardens(): EligibleAdminGardensResult {
       .filter((garden) => {
         return (
           isAddressInList(address, garden.operators) ||
-          isAddressInList(address, garden.owners) ||
-          isAddressInList(address, garden.evaluators)
+          isAddressInList(address, garden.owners)
         );
       })
       .slice()

--- a/packages/shared/src/hooks/garden/useEligibleAdminGardens.ts
+++ b/packages/shared/src/hooks/garden/useEligibleAdminGardens.ts
@@ -5,7 +5,7 @@ import { usePrimaryAddress } from "../auth/usePrimaryAddress";
 import { useRole } from "../gardener/useRole";
 import { getAdminGardenScopeKey, useAdminStore } from "../../stores/useAdminStore";
 import type { Address, Garden } from "../../types/domain";
-import { isAddressInList } from "../../utils/blockchain/address";
+import { compareAddresses, isAddressInList } from "../../utils/blockchain/address";
 
 export interface EligibleAdminGardensResult {
   eligibleGardens: Garden[];
@@ -127,7 +127,7 @@ export function useEligibleAdminGardens(): EligibleAdminGardensResult {
 
     const persistedGarden =
       (persistedGardenId
-        ? (eligibleGardens.find((garden) => garden.id === persistedGardenId) ?? null)
+        ? (eligibleGardens.find((garden) => compareAddresses(garden.id, persistedGardenId)) ?? null)
         : null) ?? null;
 
     return persistedGarden ?? eligibleGardens[0] ?? null;

--- a/packages/shared/src/hooks/garden/useGardenDetailData.ts
+++ b/packages/shared/src/hooks/garden/useGardenDetailData.ts
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { DEFAULT_CHAIN_ID } from "../../config/blockchain";
 import type { Address } from "../../types/domain";
 import { WeightScheme } from "../../types/gardens-community";
+import { compareAddresses } from "../../utils/blockchain/address";
 import type { GardenRole } from "../../utils/blockchain/garden-roles";
 import { getNetDeposited } from "../../utils/blockchain/vaults";
 import { useGardenAssessments } from "../assessment/useGardenAssessments";
@@ -32,8 +33,8 @@ export function useGardenDetailData(id: string | undefined) {
     hasStaleBaseList,
     isError: eligibleGardenBaseListError,
   } = useEligibleAdminGardens();
-  const baseGarden = gardens.find((g) => g.id === id) ?? null;
-  const recoveredEligibleGarden = eligibleGardens.find((g) => g.id === id) ?? null;
+  const baseGarden = gardens.find((g) => compareAddresses(g.id, id)) ?? null;
+  const recoveredEligibleGarden = eligibleGardens.find((g) => compareAddresses(g.id, id)) ?? null;
   const garden = baseGarden ?? recoveredEligibleGarden ?? undefined;
   const isRecoveredEligibleGarden = baseGarden === null && recoveredEligibleGarden !== null;
 

--- a/packages/shared/src/hooks/navigation/useGardenUrlSync.ts
+++ b/packages/shared/src/hooks/navigation/useGardenUrlSync.ts
@@ -102,7 +102,9 @@ export function useGardenUrlSync(): GardenUrlSyncResult {
     }
 
     const nextGarden = matchingUrlGarden ?? matchingSelectedGarden ?? resolvedDefaultGarden ?? null;
-    if (!compareAddresses(nextGarden?.id, selectedGardenId)) {
+    const nextGardenId = nextGarden?.id ?? null;
+    const currentGardenId = selectedGardenId ?? null;
+    if (nextGardenId !== currentGardenId && !compareAddresses(nextGardenId, currentGardenId)) {
       setSelectedGarden(nextGarden);
     }
   }, [

--- a/packages/shared/src/hooks/navigation/useGardenUrlSync.ts
+++ b/packages/shared/src/hooks/navigation/useGardenUrlSync.ts
@@ -21,6 +21,10 @@ const ROUTE_BACKED_ITEM_URL_OPTIONS = {
 // the old URL garden while the shell is replacing the gardenAddress param.
 let pendingGardenAddress: string | null | undefined;
 
+function getGardenShareAddress(garden: Garden): string {
+  return garden.id;
+}
+
 export interface GardenUrlSyncResult {
   gardenId: string | null;
   tab: string | null;
@@ -76,11 +80,11 @@ export function useGardenUrlSync(): GardenUrlSyncResult {
 
   const matchingUrlGarden =
     requestedGardenAddress !== null
-      ? (eligibleGardens.find(
-          (garden) =>
-            compareAddresses(garden.tokenAddress, requestedGardenAddress) ||
-            compareAddresses(garden.id, requestedGardenAddress)
-        ) ?? null)
+      ? (eligibleGardens.find((garden) => compareAddresses(garden.id, requestedGardenAddress)) ??
+        eligibleGardens.find((garden) =>
+          compareAddresses(garden.tokenAddress, requestedGardenAddress)
+        ) ??
+        null)
       : null;
 
   // URL -> store sync with default resolution.
@@ -118,7 +122,7 @@ export function useGardenUrlSync(): GardenUrlSyncResult {
 
   const setGarden = useCallback(
     (garden: Garden | null) => {
-      const nextGardenAddress = garden ? (garden.tokenAddress ?? garden.id) : null;
+      const nextGardenAddress = garden ? getGardenShareAddress(garden) : null;
       pendingGardenAddress = nextGardenAddress;
       updateParams({ [ADMIN_GARDEN_SHARE_PARAM]: nextGardenAddress }, REPLACE_URL_PARAMS_OPTIONS);
       setSelectedGarden(garden);

--- a/packages/shared/src/hooks/navigation/useGardenUrlSync.ts
+++ b/packages/shared/src/hooks/navigation/useGardenUrlSync.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useEligibleAdminGardens } from "../garden/useEligibleAdminGardens";
 import { useAdminStore, type Garden } from "../../stores/useAdminStore";
@@ -17,6 +17,9 @@ const ROUTE_BACKED_ITEM_URL_OPTIONS = {
   replace: false,
   preventScrollReset: true,
 } satisfies UpdateParamsOptions;
+// Shared across mounted hook instances so route-level effects cannot restore
+// the old URL garden while the shell is replacing the gardenAddress param.
+let pendingGardenAddress: string | null | undefined;
 
 export interface GardenUrlSyncResult {
   gardenId: string | null;
@@ -44,7 +47,6 @@ export function useGardenUrlSync(): GardenUrlSyncResult {
   const setSelectedGarden = useAdminStore((s) => s.setSelectedGarden);
   const setPersistedGardenId = useAdminStore((s) => s.setPersistedGardenId);
   const { eligibleGardens, resolvedDefaultGarden, scopeKey, isLoaded } = useEligibleAdminGardens();
-  const pendingGardenAddressRef = useRef<string | null | undefined>(undefined);
 
   const requestedGardenAddress = searchParams.get(ADMIN_GARDEN_SHARE_PARAM);
   const tab = searchParams.get("tab");
@@ -70,7 +72,7 @@ export function useGardenUrlSync(): GardenUrlSyncResult {
   const matchingSelectedGarden =
     selectedGardenId === null
       ? null
-      : (eligibleGardens.find((garden) => garden.id === selectedGardenId) ?? null);
+      : (eligibleGardens.find((garden) => compareAddresses(garden.id, selectedGardenId)) ?? null);
 
   const matchingUrlGarden =
     requestedGardenAddress !== null
@@ -85,7 +87,6 @@ export function useGardenUrlSync(): GardenUrlSyncResult {
   useEffect(() => {
     if (!isLoaded) return;
 
-    const pendingGardenAddress = pendingGardenAddressRef.current;
     if (pendingGardenAddress !== undefined) {
       const urlMatchesPending =
         pendingGardenAddress === null
@@ -93,11 +94,11 @@ export function useGardenUrlSync(): GardenUrlSyncResult {
           : compareAddresses(requestedGardenAddress, pendingGardenAddress);
 
       if (!urlMatchesPending) return;
-      pendingGardenAddressRef.current = undefined;
+      pendingGardenAddress = undefined;
     }
 
     const nextGarden = matchingUrlGarden ?? matchingSelectedGarden ?? resolvedDefaultGarden ?? null;
-    if (nextGarden?.id !== selectedGardenId) {
+    if (!compareAddresses(nextGarden?.id, selectedGardenId)) {
       setSelectedGarden(nextGarden);
     }
   }, [
@@ -118,7 +119,7 @@ export function useGardenUrlSync(): GardenUrlSyncResult {
   const setGarden = useCallback(
     (garden: Garden | null) => {
       const nextGardenAddress = garden ? (garden.tokenAddress ?? garden.id) : null;
-      pendingGardenAddressRef.current = nextGardenAddress;
+      pendingGardenAddress = nextGardenAddress;
       updateParams({ [ADMIN_GARDEN_SHARE_PARAM]: nextGardenAddress }, REPLACE_URL_PARAMS_OPTIONS);
       setSelectedGarden(garden);
     },
@@ -151,7 +152,7 @@ export function useGardenUrlSync(): GardenUrlSyncResult {
   }, [updateParams]);
 
   return {
-    gardenId: selectedGardenId ?? matchingUrlGarden?.id ?? null,
+    gardenId: matchingUrlGarden?.id ?? selectedGardenId ?? null,
     tab,
     item,
     setGarden,

--- a/packages/shared/src/hooks/roles/useEffectiveToolbarPermissions.ts
+++ b/packages/shared/src/hooks/roles/useEffectiveToolbarPermissions.ts
@@ -9,7 +9,7 @@
  */
 
 import { useMemo } from "react";
-import { isAddressInList } from "../../utils/blockchain/address";
+import { compareAddresses, isAddressInList } from "../../utils/blockchain/address";
 import { useAdminStore } from "../../stores/useAdminStore";
 import { usePrimaryAddress } from "../auth/usePrimaryAddress";
 import { useRole } from "../gardener/useRole";
@@ -53,13 +53,12 @@ export function useEffectiveToolbarPermissions(): ToolbarPermissions {
 
     // Determine which gardens to check
     const scope = selectedGarden
-      ? eligibleGardens.filter((g) => g.id === selectedGarden.id)
+      ? eligibleGardens.filter((g) => compareAddresses(g.id, selectedGarden.id))
       : eligibleGardens;
 
     // Compute aggregated roles across the scope
     let hasAnyRole = false;
     let isOperatorOrOwner = false;
-    let isOwner = false;
 
     for (const garden of scope) {
       const inOperators = isAddressInList(address, garden.operators);
@@ -75,9 +74,6 @@ export function useEffectiveToolbarPermissions(): ToolbarPermissions {
 
       if (inOperators || inOwners) {
         isOperatorOrOwner = true;
-      }
-      if (inOwners) {
-        isOwner = true;
       }
     }
 

--- a/tests/specs/admin.production-flows.ci.spec.ts
+++ b/tests/specs/admin.production-flows.ci.spec.ts
@@ -17,9 +17,10 @@ const ADMIN_URL = TEST_URLS.admin;
 const ROUTE_SMOKE_TEST_TIMEOUT_MS = 90_000;
 const MOCK_DEPLOYER_ADDRESS = "0x2aa64E6d80390F5C017F0313cB908051BE2FD35e";
 const MOCK_OPERATOR_ADDRESS = "0x04D60647836bcA09c37B379550038BdaaFD82503";
-const TEST_GARDEN_ADDRESS = "0xabcd1234567890123456789012345678901234ef";
-const TEST_GARDEN_ID = "0x1234567890123456789012345678901234567890";
-const TEST_GARDEN_CONTEXT = `gardenAddress=${encodeURIComponent(TEST_GARDEN_ADDRESS)}`;
+const SHARED_GARDEN_TOKEN = "0xabcd1234567890123456789012345678901234ef";
+const ALPHA_GARDEN_ID = "0x1234567890123456789012345678901234567890";
+const BETA_GARDEN_ID = "0x4567890123456789012345678901234567890123";
+const TEST_GARDEN_CONTEXT = `gardenAddress=${encodeURIComponent(ALPHA_GARDEN_ID)}`;
 
 const GRAPHQL_HEADERS = {
   "access-control-allow-origin": "*",
@@ -28,12 +29,12 @@ const GRAPHQL_HEADERS = {
   "content-type": "application/json",
 };
 
-const MOCK_GARDEN = {
-  id: TEST_GARDEN_ID,
+const MOCK_ALPHA_GARDEN = {
+  id: ALPHA_GARDEN_ID,
   chainId: 11155111,
-  tokenAddress: TEST_GARDEN_ADDRESS,
+  tokenAddress: SHARED_GARDEN_TOKEN,
   tokenID: "1",
-  name: "Mock CI Garden",
+  name: "Alpha CI Garden",
   description: "Fixture garden for admin production-flow route smoke",
   location: "Nairobi",
   bannerImage: "",
@@ -46,6 +47,17 @@ const MOCK_GARDEN = {
   openJoining: false,
   createdAt: 1710000000,
 };
+const MOCK_BETA_GARDEN = {
+  ...MOCK_ALPHA_GARDEN,
+  id: BETA_GARDEN_ID,
+  tokenID: "2",
+  name: "Beta CI Garden",
+  description: "Second fixture garden for admin switching verification",
+  location: "Bogota",
+  gardeners: [MOCK_OPERATOR_ADDRESS, MOCK_DEPLOYER_ADDRESS],
+  createdAt: 1710000100,
+};
+const MOCK_GARDENS = [MOCK_ALPHA_GARDEN, MOCK_BETA_GARDEN];
 
 function getGraphQLQueryText(route: Route): string {
   const body = route.request().postData();
@@ -109,7 +121,7 @@ async function setupAdminRouteBackend(page: Page) {
         headers: GRAPHQL_HEADERS,
         body: JSON.stringify({
           data: {
-            Garden: [{ id: MOCK_GARDEN.id, name: MOCK_GARDEN.name }],
+            Garden: MOCK_GARDENS.map(({ id, name }) => ({ id, name })),
           },
         }),
       });
@@ -121,8 +133,11 @@ async function setupAdminRouteBackend(page: Page) {
         headers: GRAPHQL_HEADERS,
         body: JSON.stringify({
           data: {
-            Garden: [MOCK_GARDEN],
-            GardenDomains: [{ garden: MOCK_GARDEN.id, domainMask: 1 }],
+            Garden: MOCK_GARDENS,
+            GardenDomains: MOCK_GARDENS.map((garden) => ({
+              garden: garden.id,
+              domainMask: 1,
+            })),
           },
         }),
       });
@@ -230,5 +245,38 @@ test.describe("Admin Production Flows CI", () => {
         }
       });
     }
+  });
+
+  test("garden switcher rebinds the rendered garden workspace", async ({ page }) => {
+    test.setTimeout(ROUTE_SMOKE_TEST_TIMEOUT_MS);
+    const helper = await setupAuthenticatedAdmin(page);
+
+    await expectNoCrashOnRoute(page, helper, `/garden/settings?${TEST_GARDEN_CONTEXT}`);
+
+    const gardenSwitcher = page.locator('[data-component="GardenChip"][data-slot="trigger"]');
+    await expect(gardenSwitcher).toContainText(MOCK_ALPHA_GARDEN.name);
+    await expect(page.getByRole("heading", { name: MOCK_ALPHA_GARDEN.name })).toBeVisible();
+    await expect(page.getByText(MOCK_ALPHA_GARDEN.location, { exact: true })).toBeVisible();
+
+    await gardenSwitcher.click();
+    await page
+      .locator('[data-component="GardenChip"][data-slot="option"]')
+      .filter({ hasText: MOCK_BETA_GARDEN.name })
+      .click();
+
+    await expect
+      .poll(() => new URL(page.url()).searchParams.get("gardenAddress"))
+      .toBe(MOCK_BETA_GARDEN.id);
+    await expect(gardenSwitcher).toContainText(MOCK_BETA_GARDEN.name);
+    await expect(page.getByRole("heading", { name: MOCK_BETA_GARDEN.name })).toBeVisible();
+    await expect(page.getByText(MOCK_BETA_GARDEN.location, { exact: true })).toBeVisible();
+    await expect(page.getByText(MOCK_ALPHA_GARDEN.location, { exact: true })).toHaveCount(0);
+
+    const screenshotPath = test.info().outputPath("admin-garden-switching-beta.png");
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    await test.info().attach("admin garden switch beta selected", {
+      path: screenshotPath,
+      contentType: "image/png",
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Share pending admin garden URL changes across mounted `useGardenUrlSync` hook instances so route-level effects cannot restore the previous garden while the shell replaces `gardenAddress`.
- Normalize selected-garden lookups across admin shell, vault-adjacent settings/work/community surfaces, and admin UI controllers so casing differences do not fall back to stale/default garden data.
- Remove the Admin Dashboard aggregate `All Gardens` switcher option while keeping concrete operator, owner, and evaluator gardens eligible for admin access.
- Reserve the admin header stats footprint with a `MetaStrip` loading state so Hub, Garden, Community, and Actions do not shift when stats finish loading.
- Add two-garden regression coverage proving URL priority, the multi-hook race, rendered Alpha -> Beta content changes after a switch, evaluator eligibility, and header stats loading strip behavior.

## Validation
- [x] `bun run --filter @green-goods/shared test -- src/__tests__/hooks/navigation/useGardenUrlSync.test.ts src/__tests__/hooks/navigation/useGardenUrlSync.search-options.test.ts src/__tests__/hooks/garden/adminGardenSwitching.render.test.tsx` (15 tests pass)
- [x] `bun run --filter @green-goods/admin test:hub` (99 tests pass)
- [x] `bun run --filter @green-goods/shared typecheck`
- [x] `bun run --filter @green-goods/shared lint` (passes with existing warnings)
- [x] `bun run --filter @green-goods/admin lint` (passes with existing story warnings)
- [x] `bun run --filter @green-goods/admin build` (passes with existing CSS/Rollup/chunk warnings)
- [x] `git diff --check`
- [x] Focused local Vitest via Node: `useEligibleAdminGardens`, `GardenChip`, and `MetaStrip` (24 tests pass)
- [x] Focused local Vitest via Node: admin `CanvasLayout` and `IndexRoute` (33 tests pass)
- [x] Direct TypeScript checks via Node: shared `tsc --noEmit`, admin `tsc --noEmit -p packages/admin/tsconfig.json`, agent `tsc --noEmit`
- [x] Local browser proof: switch from Alpha content to Beta content updates URL to `?gardenAddress=0xbbb0000000000000000000000000000000000bbb`; screenshots at `output/playwright/admin-switch-before.png` and `output/playwright/admin-switch-after.png`
- [ ] Header stats browser screenshot proof is blocked in this sandbox: Bun cannot read the worktree cwd, Playwright Chromium fails on missing `icudtl.dat`, WebKit cache execution is denied, and headless Brave aborts before opening a page even with escalation.
- [ ] `node scripts/dev/ci-local.js --quick` previously failed on agent typecheck drift that is now resolved by aligning this PR branch with `develop`; targeted local agent typecheck passes on the final branch content.

Refs PRD-509, PRD-510, PRD-531