### PR TITLE
fix(client): proxy public subscribe through Vercel

### DIFF
--- a/packages/client/src/__tests__/components/PublicGetInTouch.test.tsx
+++ b/packages/client/src/__tests__/components/PublicGetInTouch.test.tsx
@@ -37,7 +37,10 @@ vi.mock("@/content/publicCuration", () => ({
   },
 }));
 
-import { PublicGetInTouch } from "../../components/Public/PublicGetInTouch";
+import {
+  getPublicSubscribeUrl,
+  PublicGetInTouch,
+} from "../../components/Public/PublicGetInTouch";
 
 const messages: Record<string, string> = {
   "public.home.getInTouch.consent":
@@ -114,6 +117,22 @@ describe("PublicGetInTouch", () => {
         }),
       })
     );
+  });
+
+  it("uses the same-origin Vercel proxy for the production public agent", () => {
+    expect(
+      getPublicSubscribeUrl("/public/subscribe", "https://agent.greengoods.app", true)
+    ).toBe("/api/agent/public/subscribe");
+    expect(
+      getPublicSubscribeUrl("/public/subscribe", "https://agent.greengoods.app", false)
+    ).toBe("https://agent.greengoods.app/public/subscribe");
+    expect(getPublicSubscribeUrl("/public/subscribe", "", true)).toBe("/public/subscribe");
+  });
+
+  it("normalizes subscribe routes without changing custom API bases", () => {
+    expect(
+      getPublicSubscribeUrl("public/subscribe", "https://api.example.test/root", true)
+    ).toBe("https://api.example.test/root/public/subscribe");
   });
 
   it("links schedule-a-call to the configured appointment URL", () => {

--- a/packages/client/src/__tests__/components/PublicGetInTouch.test.tsx
+++ b/packages/client/src/__tests__/components/PublicGetInTouch.test.tsx
@@ -37,10 +37,7 @@ vi.mock("@/content/publicCuration", () => ({
   },
 }));
 
-import {
-  getPublicSubscribeUrl,
-  PublicGetInTouch,
-} from "../../components/Public/PublicGetInTouch";
+import { getPublicSubscribeUrl, PublicGetInTouch } from "../../components/Public/PublicGetInTouch";
 
 const messages: Record<string, string> = {
   "public.home.getInTouch.consent":
@@ -120,19 +117,19 @@ describe("PublicGetInTouch", () => {
   });
 
   it("uses the same-origin Vercel proxy for the production public agent", () => {
-    expect(
-      getPublicSubscribeUrl("/public/subscribe", "https://agent.greengoods.app", true)
-    ).toBe("/api/agent/public/subscribe");
-    expect(
-      getPublicSubscribeUrl("/public/subscribe", "https://agent.greengoods.app", false)
-    ).toBe("https://agent.greengoods.app/public/subscribe");
+    expect(getPublicSubscribeUrl("/public/subscribe", "https://agent.greengoods.app", true)).toBe(
+      "/api/agent/public/subscribe"
+    );
+    expect(getPublicSubscribeUrl("/public/subscribe", "https://agent.greengoods.app", false)).toBe(
+      "https://agent.greengoods.app/public/subscribe"
+    );
     expect(getPublicSubscribeUrl("/public/subscribe", "", true)).toBe("/public/subscribe");
   });
 
   it("normalizes subscribe routes without changing custom API bases", () => {
-    expect(
-      getPublicSubscribeUrl("public/subscribe", "https://api.example.test/root", true)
-    ).toBe("https://api.example.test/root/public/subscribe");
+    expect(getPublicSubscribeUrl("public/subscribe", "https://api.example.test/root", true)).toBe(
+      "https://api.example.test/root/public/subscribe"
+    );
   });
 
   it("links schedule-a-call to the configured appointment URL", () => {

--- a/packages/client/src/__tests__/manifest/vercel-routing.test.ts
+++ b/packages/client/src/__tests__/manifest/vercel-routing.test.ts
@@ -19,6 +19,7 @@ describe("client Vercel public social shell routing", () => {
       { source: "/gardens", destination: "/gardens/index.html" },
       { source: "/gardens/:path*", destination: "/gardens/index.html" },
       { source: "/cookies", destination: "/cookies/index.html" },
+      { source: "/api/agent/:path*", destination: "https://agent.greengoods.app/:path*" },
     ]);
   });
 

--- a/packages/client/src/components/Public/PublicGetInTouch.tsx
+++ b/packages/client/src/components/Public/PublicGetInTouch.tsx
@@ -16,7 +16,21 @@ import {
 
 type SubmitState = "idle" | "loading" | "ok" | "error";
 
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || "";
+const PUBLIC_AGENT_API_ORIGIN = "https://agent.greengoods.app";
+const PUBLIC_AGENT_PROXY_BASE_URL = "/api/agent";
+const CONFIGURED_API_BASE_URL = (import.meta.env.VITE_API_BASE_URL || "").replace(/\/+$/, "");
+
+export function getPublicSubscribeUrl(
+  route: string,
+  apiBaseUrl = CONFIGURED_API_BASE_URL,
+  isProduction = import.meta.env.PROD
+) {
+  const normalizedRoute = route.startsWith("/") ? route : `/${route}`;
+  if (isProduction && apiBaseUrl === PUBLIC_AGENT_API_ORIGIN) {
+    return `${PUBLIC_AGENT_PROXY_BASE_URL}${normalizedRoute}`;
+  }
+  return `${apiBaseUrl}${normalizedRoute}`;
+}
 
 /**
  * PublicGetInTouch — closing module on the editorial homepage.
@@ -56,7 +70,7 @@ export function PublicGetInTouch() {
       setSubmitState("loading");
       setErrorMessageId(null);
       try {
-        const response = await fetch(`${API_BASE_URL}${publicCuration.subscribeRoute}`, {
+        const response = await fetch(getPublicSubscribeUrl(publicCuration.subscribeRoute), {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),

--- a/packages/client/vercel.json
+++ b/packages/client/vercel.json
@@ -213,6 +213,15 @@
       ]
     },
     {
+      "source": "/api/agent/:path*",
+      "headers": [
+        {
+          "key": "x-vercel-enable-rewrite-caching",
+          "value": "0"
+        }
+      ]
+    },
+    {
       "source": "/assets/:path*",
       "headers": [
         {
@@ -246,6 +255,10 @@
     {
       "source": "/cookies",
       "destination": "/cookies/index.html"
+    },
+    {
+      "source": "/api/agent/:path*",
+      "destination": "https://agent.greengoods.app/:path*"
     },
     {
       "source": "/(.*)",


### PR DESCRIPTION
## Summary
- Route production public subscribe calls through a same-origin `/api/agent/*` Vercel rewrite when the configured API origin is `https://agent.greengoods.app`.
- Add the Vercel external rewrite to proxy `/api/agent/:path*` to the Fly agent.
- Cover the production proxy URL and Vercel rewrite contract in client tests while preserving local/test `/public/subscribe` behavior.

## Validation
- [x] `bun run --filter @green-goods/client test -- PublicGetInTouch`
- [x] `bun run --filter @green-goods/client test -- PublicGetInTouch vercel-routing`
- [x] `bun run --filter @green-goods/client format:check`
- [x] `bun run --filter @green-goods/agent test -- resend public-api config`
- [x] `bun run --filter @green-goods/shared test -- public-contracts`
- [x] `bun run lint:vocab`
- [x] Vercel preview build passed for `green-goods` at commit `f51f15b1c5ab350f3b85c9540d126a92726f90a1`
- [x] GitHub Actions passed: Client, Shared, Design, CI Gate
- [ ] `bun run --filter @green-goods/client build` blocked locally in the isolated checkout because the reused local `node_modules` does not include declared `@sentry/vite-plugin`; Vercel installed dependencies and built successfully.

## Live evidence
- Staging bundle at `https://staging.greengoods.app/` is built with `VITE_API_BASE_URL:"https://agent.greengoods.app"` and release `green-goods-client@eb6caf7ff3f3`.
- Browser pass on staging rendered the homepage, email input, and Subscribe button, but submitting a unique QA email surfaced `We couldn't reach the server. Please try again.` and logged `[PublicGetInTouch] subscribe failed`.
- Direct Codex shell/browser access to `https://agent.greengoods.app` is blocked in this environment before reaching the app (`blocked-by-allowlist`, `ERR_BLOCKED_BY_CLIENT`, or DNS failure).
- Final preview proxy health check passed: `https://green-goods-hacmewv4d-greenpilldevguild.vercel.app/api/agent/health` returned HTTP 200 with `{ "status": "ok" }`, `fly-request-id: 01KVH226RN0JYC0T2CXRAGQG3B-ord`, proving Vercel can reach the live Fly agent through the same-origin proxy.
- POST validation from this environment remains blocked outside Vercel/browser GET: shell POST is denied by the Codex proxy method policy, direct no-proxy DNS fails, the in-app browser click path timed out, and standalone Playwright could not launch an installed browser here. The code path is covered by unit tests and the Vercel rewrite is proven for live Fly health.