### PR TITLE
fix(shared,client): recover stalled PWA updates

### DIFF
--- a/packages/client/src/__tests__/components/PwaUpdateNotifier.test.tsx
+++ b/packages/client/src/__tests__/components/PwaUpdateNotifier.test.tsx
@@ -4,11 +4,18 @@
 
 import { render } from "@testing-library/react";
 import { createElement } from "react";
+import { IntlProvider } from "react-intl";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const sharedMocks = vi.hoisted(() => ({
   applyUpdate: vi.fn(),
+  createUpdateToasts: vi.fn(() => ({
+    available: vi.fn(),
+    stalled: vi.fn(),
+    updating: vi.fn(),
+  })),
   dismissUpdate: vi.fn(),
+  stalled: vi.fn(),
   updateAvailable: vi.fn(),
   updating: vi.fn(),
   useApp: vi.fn(),
@@ -16,23 +23,36 @@ const sharedMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@green-goods/shared", () => ({
-  updateToasts: {
-    available: sharedMocks.updateAvailable,
-    updating: sharedMocks.updating,
-  },
+  createUpdateToasts: sharedMocks.createUpdateToasts,
   useApp: sharedMocks.useApp,
   useServiceWorkerUpdate: sharedMocks.useServiceWorkerUpdate,
 }));
 
 import { PwaUpdateNotifier } from "../../components/Communication/PwaUpdateNotifier";
 
+function renderNotifier() {
+  return render(
+    createElement(
+      IntlProvider,
+      { locale: "en", messages: {} },
+      createElement(PwaUpdateNotifier)
+    )
+  );
+}
+
 describe("PwaUpdateNotifier", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sharedMocks.createUpdateToasts.mockReturnValue({
+      available: sharedMocks.updateAvailable,
+      stalled: sharedMocks.stalled,
+      updating: sharedMocks.updating,
+    });
     sharedMocks.useApp.mockReturnValue({ isPwaPresentation: true });
     sharedMocks.useServiceWorkerUpdate.mockReturnValue({
       updateAvailable: false,
       isUpdating: false,
+      applyTimedOut: false,
       applyUpdate: sharedMocks.applyUpdate,
       dismissUpdate: sharedMocks.dismissUpdate,
     });
@@ -41,10 +61,11 @@ describe("PwaUpdateNotifier", () => {
   it("does not subscribe to service worker updates in browser presentation", () => {
     sharedMocks.useApp.mockReturnValue({ isPwaPresentation: false });
 
-    render(createElement(PwaUpdateNotifier));
+    renderNotifier();
 
     expect(sharedMocks.useServiceWorkerUpdate).not.toHaveBeenCalled();
     expect(sharedMocks.updateAvailable).not.toHaveBeenCalled();
+    expect(sharedMocks.stalled).not.toHaveBeenCalled();
     expect(sharedMocks.updating).not.toHaveBeenCalled();
   });
 
@@ -52,11 +73,12 @@ describe("PwaUpdateNotifier", () => {
     sharedMocks.useServiceWorkerUpdate.mockReturnValue({
       updateAvailable: true,
       isUpdating: false,
+      applyTimedOut: false,
       applyUpdate: sharedMocks.applyUpdate,
       dismissUpdate: sharedMocks.dismissUpdate,
     });
 
-    render(createElement(PwaUpdateNotifier));
+    renderNotifier();
 
     expect(sharedMocks.useServiceWorkerUpdate).toHaveBeenCalledTimes(1);
     expect(sharedMocks.updateAvailable).toHaveBeenCalledWith(
@@ -69,12 +91,31 @@ describe("PwaUpdateNotifier", () => {
     sharedMocks.useServiceWorkerUpdate.mockReturnValue({
       updateAvailable: false,
       isUpdating: true,
+      applyTimedOut: false,
       applyUpdate: sharedMocks.applyUpdate,
       dismissUpdate: sharedMocks.dismissUpdate,
     });
 
-    render(createElement(PwaUpdateNotifier));
+    renderNotifier();
 
     expect(sharedMocks.updating).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the stalled toast when an update apply times out", () => {
+    sharedMocks.useServiceWorkerUpdate.mockReturnValue({
+      updateAvailable: true,
+      isUpdating: false,
+      applyTimedOut: true,
+      applyUpdate: sharedMocks.applyUpdate,
+      dismissUpdate: sharedMocks.dismissUpdate,
+    });
+
+    renderNotifier();
+
+    expect(sharedMocks.stalled).toHaveBeenCalledWith(
+      sharedMocks.applyUpdate,
+      sharedMocks.dismissUpdate
+    );
+    expect(sharedMocks.updateAvailable).not.toHaveBeenCalled();
   });
 });

--- a/packages/client/src/__tests__/components/PwaUpdateNotifier.test.tsx
+++ b/packages/client/src/__tests__/components/PwaUpdateNotifier.test.tsx
@@ -32,11 +32,7 @@ import { PwaUpdateNotifier } from "../../components/Communication/PwaUpdateNotif
 
 function renderNotifier() {
   return render(
-    createElement(
-      IntlProvider,
-      { locale: "en", messages: {} },
-      createElement(PwaUpdateNotifier)
-    )
+    createElement(IntlProvider, { locale: "en", messages: {} }, createElement(PwaUpdateNotifier))
   );
 }
 

--- a/packages/client/src/__tests__/components/PwaUpdateNotifier.test.tsx
+++ b/packages/client/src/__tests__/components/PwaUpdateNotifier.test.tsx
@@ -23,9 +23,12 @@ const sharedMocks = vi.hoisted(() => ({
 }));
 
 vi.mock("@green-goods/shared", () => ({
-  createUpdateToasts: sharedMocks.createUpdateToasts,
   useApp: sharedMocks.useApp,
   useServiceWorkerUpdate: sharedMocks.useServiceWorkerUpdate,
+}));
+
+vi.mock("@green-goods/shared/components", () => ({
+  createUpdateToasts: sharedMocks.createUpdateToasts,
 }));
 
 import { PwaUpdateNotifier } from "../../components/Communication/PwaUpdateNotifier";

--- a/packages/client/src/components/Communication/PwaUpdateNotifier.tsx
+++ b/packages/client/src/components/Communication/PwaUpdateNotifier.tsx
@@ -1,4 +1,5 @@
-import { createUpdateToasts, useApp, useServiceWorkerUpdate } from "@green-goods/shared";
+import { useApp, useServiceWorkerUpdate } from "@green-goods/shared";
+import { createUpdateToasts } from "@green-goods/shared/components";
 import { useEffect } from "react";
 import { useIntl } from "react-intl";
 

--- a/packages/client/src/components/Communication/PwaUpdateNotifier.tsx
+++ b/packages/client/src/components/Communication/PwaUpdateNotifier.tsx
@@ -1,17 +1,29 @@
-import { updateToasts, useApp, useServiceWorkerUpdate } from "@green-goods/shared";
+import { createUpdateToasts, useApp, useServiceWorkerUpdate } from "@green-goods/shared";
 import { useEffect } from "react";
+import { useIntl } from "react-intl";
 
 function ServiceWorkerUpdateNotifier() {
-  const { updateAvailable, isUpdating, applyUpdate, dismissUpdate } = useServiceWorkerUpdate();
+  const { formatMessage } = useIntl();
+  const { updateAvailable, isUpdating, applyTimedOut, applyUpdate, dismissUpdate } =
+    useServiceWorkerUpdate();
 
   useEffect(() => {
+    const updateToasts = createUpdateToasts(formatMessage);
+
+    if (isUpdating) {
+      updateToasts.updating();
+      return;
+    }
+
+    if (applyTimedOut) {
+      updateToasts.stalled(applyUpdate, dismissUpdate);
+      return;
+    }
+
     if (updateAvailable) {
       updateToasts.available(applyUpdate, dismissUpdate);
     }
-    if (isUpdating) {
-      updateToasts.updating();
-    }
-  }, [updateAvailable, isUpdating, applyUpdate, dismissUpdate]);
+  }, [applyTimedOut, updateAvailable, isUpdating, applyUpdate, dismissUpdate, formatMessage]);
 
   return null;
 }

--- a/packages/shared/src/__tests__/hooks/app/useServiceWorkerUpdate.test.ts
+++ b/packages/shared/src/__tests__/hooks/app/useServiceWorkerUpdate.test.ts
@@ -30,6 +30,7 @@ import {
   APPLY_UPDATE_TIMEOUT_MS,
   useServiceWorkerUpdate,
 } from "../../../hooks/app/useServiceWorkerUpdate";
+import { logger } from "../../../modules/app/logger";
 import { track } from "../../../modules/app/posthog";
 
 function createMockRegistration(
@@ -73,6 +74,7 @@ describe("hooks/app/useServiceWorkerUpdate", () => {
 
       expect(result.current.updateAvailable).toBe(false);
       expect(result.current.isUpdating).toBe(false);
+      expect(result.current.applyTimedOut).toBe(false);
       expect(result.current.waitingWorker).toBeNull();
       expect(typeof result.current.applyUpdate).toBe("function");
       expect(typeof result.current.dismissUpdate).toBe("function");
@@ -101,6 +103,7 @@ describe("hooks/app/useServiceWorkerUpdate", () => {
 
       // Should not set isUpdating since there's no waiting worker
       expect(result.current.isUpdating).toBe(false);
+      expect(result.current.applyTimedOut).toBe(false);
     });
   });
 
@@ -117,6 +120,7 @@ describe("hooks/app/useServiceWorkerUpdate", () => {
       });
 
       expect(result.current.updateAvailable).toBe(false);
+      expect(result.current.applyTimedOut).toBe(false);
       expect(result.current.waitingWorker).toBeNull();
     });
 
@@ -198,6 +202,10 @@ describe("hooks/app/useServiceWorkerUpdate", () => {
 
       expect(result.current.isUpdating).toBe(false);
       expect(result.current.applyTimedOut).toBe(true);
+      expect(logger.warn).toHaveBeenCalledWith(
+        "Service worker update did not activate before timeout",
+        expect.objectContaining({ timeoutMs: APPLY_UPDATE_TIMEOUT_MS })
+      );
       expect(track).toHaveBeenCalledWith("sw_update_apply_timeout", {});
       expect(navigator.serviceWorker.removeEventListener).toHaveBeenCalledWith(
         "controllerchange",
@@ -233,6 +241,37 @@ describe("hooks/app/useServiceWorkerUpdate", () => {
 
       expect(result.current.applyTimedOut).toBe(false);
       expect(result.current.isUpdating).toBe(true);
+    });
+
+    it("clears the timed-out flag when the user dismisses the stalled update", async () => {
+      vi.stubEnv("VITE_ENABLE_SW_DEV", "true");
+      const waitingWorker = { postMessage: vi.fn() } as unknown as ServiceWorker;
+      const registration = createMockRegistration({ waiting: waitingWorker });
+      installServiceWorkerMock(registration);
+
+      const { result } = renderHook(() => useServiceWorkerUpdate());
+
+      await waitFor(() => {
+        expect(result.current.updateAvailable).toBe(true);
+      });
+
+      vi.useFakeTimers();
+
+      act(() => {
+        result.current.applyUpdate();
+      });
+      act(() => {
+        vi.advanceTimersByTime(APPLY_UPDATE_TIMEOUT_MS);
+      });
+      expect(result.current.applyTimedOut).toBe(true);
+
+      act(() => {
+        result.current.dismissUpdate();
+      });
+
+      expect(result.current.applyTimedOut).toBe(false);
+      expect(result.current.updateAvailable).toBe(false);
+      expect(track).toHaveBeenCalledWith("sw_update_dismissed", {});
     });
   });
 });

--- a/packages/shared/src/components/Toast/presets/types.ts
+++ b/packages/shared/src/components/Toast/presets/types.ts
@@ -154,4 +154,8 @@ export const toastMessageIdsUpdate = {
     title: "app.toast.update.updating.title",
     message: "app.toast.update.updating.message",
   },
+  stalled: {
+    title: "app.update.title",
+    message: "app.update.timeout",
+  },
 } as const;

--- a/packages/shared/src/components/Toast/presets/update.ts
+++ b/packages/shared/src/components/Toast/presets/update.ts
@@ -11,11 +11,15 @@ const updateDefaults = {
     title: "Updating...",
     message: "Refreshing to the latest version.",
   },
+  stalled: {
+    title: "Update app",
+    message: "The update didn't finish. Close all app tabs and try again.",
+  },
 };
 
 export const updateToasts = {
   /** Show info when an update is available with action to refresh */
-  available: (onUpdate: () => void) =>
+  available: (onUpdate: () => void, onDismiss?: () => void) =>
     toastService.info({
       id: "app-update",
       title: updateDefaults.available.title,
@@ -28,6 +32,8 @@ export const updateToasts = {
         dismissOnClick: false,
         testId: "update-now-button",
       },
+      closable: true,
+      onDismiss,
       suppressLogging: true,
     }),
 
@@ -38,6 +44,25 @@ export const updateToasts = {
       title: updateDefaults.updating.title,
       message: updateDefaults.updating.message,
       context: "app update",
+      suppressLogging: true,
+    }),
+
+  /** Show recoverable state when an update activation times out */
+  stalled: (onUpdate: () => void, onDismiss?: () => void) =>
+    toastService.info({
+      id: "app-update",
+      title: updateDefaults.stalled.title,
+      message: updateDefaults.stalled.message,
+      context: "app update",
+      duration: Infinity,
+      action: {
+        label: "Update now",
+        onClick: onUpdate,
+        dismissOnClick: false,
+        testId: "update-now-button",
+      },
+      closable: true,
+      onDismiss,
       suppressLogging: true,
     }),
 
@@ -87,6 +112,30 @@ export function createUpdateToasts(formatMessage: FormatMessageFn) {
           defaultMessage: updateDefaults.updating.message,
         }),
         context: "app update",
+        suppressLogging: true,
+      }),
+
+    stalled: (onUpdate: () => void, onDismiss?: () => void) =>
+      toastService.info({
+        id: "app-update",
+        title: formatMessage({
+          id: toastMessageIdsUpdate.stalled.title,
+          defaultMessage: updateDefaults.stalled.title,
+        }),
+        message: formatMessage({
+          id: toastMessageIdsUpdate.stalled.message,
+          defaultMessage: updateDefaults.stalled.message,
+        }),
+        context: "app update",
+        duration: Infinity,
+        action: {
+          label: "Update now",
+          onClick: onUpdate,
+          dismissOnClick: false,
+          testId: "update-now-button",
+        },
+        closable: true,
+        onDismiss,
         suppressLogging: true,
       }),
 

--- a/packages/shared/src/hooks/app/useServiceWorkerUpdate.ts
+++ b/packages/shared/src/hooks/app/useServiceWorkerUpdate.ts
@@ -320,6 +320,12 @@ export function useServiceWorkerUpdate(): ServiceWorkerUpdateState {
       waitingWorkerRef.current ?? waitingWorker ?? registrationRef.current?.waiting ?? null;
     if (!worker) return;
 
+    clearApplyTimeout();
+    if (controllerChangeListenerRef.current) {
+      navigator.serviceWorker.removeEventListener("controllerchange", handleControllerChange);
+      controllerChangeListenerRef.current = false;
+    }
+
     waitingWorkerRef.current = worker;
     setApplyTimedOut(false);
     setIsUpdating(true);
@@ -351,21 +357,23 @@ export function useServiceWorkerUpdate(): ServiceWorkerUpdateState {
       });
       track("sw_update_apply_timeout", {});
     }, APPLY_UPDATE_TIMEOUT_MS);
-  }, [waitingWorker, handleControllerChange, scheduleApplyTimeout]);
+  }, [waitingWorker, clearApplyTimeout, handleControllerChange, scheduleApplyTimeout]);
 
-  // Cleanup effect for controllerchange listener if component unmounts before it fires
+  // Cleanup effect for apply timeout and controllerchange listener if unmounted before activation
   useEffect(() => {
     return () => {
+      clearApplyTimeout();
       if (controllerChangeListenerRef.current) {
         navigator.serviceWorker?.removeEventListener("controllerchange", handleControllerChange);
         controllerChangeListenerRef.current = false;
       }
     };
-  }, [handleControllerChange]);
+  }, [clearApplyTimeout, handleControllerChange]);
 
   const dismissUpdate = useCallback(() => {
     setDismissed(true);
     setUpdateAvailable(false);
+    setApplyTimedOut(false);
     track("sw_update_dismissed", {});
   }, []);
 


### PR DESCRIPTION
## Summary
- Harden `useServiceWorkerUpdate` so stalled apply attempts clean up timeout/controller listeners and dismissals clear the timeout state.
- Surface `applyTimedOut` through the installed-PWA update toast with retry and dismiss actions using existing localized update strings.
- Add focused hook and notifier tests for the stalled update recovery path.

## Validation
- [x] GitHub Actions passed on head `2d831f8`: Client, Shared, Design, Agent, and CI Gate.
- [x] Vercel statuses passed on head `2d831f8`: `green-goods`, `green-goods-admin`, and `green-goods-design`.
- [x] CodeRabbit status passed.
- [ ] Local targeted tests not run here because the local Codex checkout cannot run repo tooling: `bun` fails with `CouldntReadCurrentDirectory`, and local git is blocked by the broken Xcode command-line tools path.
- [ ] Device/browser PWA QA still needed before closing PRD-500.

Linear: PRD-500

Related context: this is a scoped replacement for the still-useful PRD-500 slice from #582. PRD-499's Android install-policy work has already landed through #584; PRD-502 and PRD-503 still need their own device/browser QA before closure.