### PR TITLE
fix(shared): time-box IPFS uploads so stalled work-media uploads fail retryably

### DIFF
--- a/packages/shared/src/__tests__/modules/ipfs.module.test.ts
+++ b/packages/shared/src/__tests__/modules/ipfs.module.test.ts
@@ -240,4 +240,41 @@ describe("modules/data/ipfs", () => {
 
     expect(result).toEqual({ cid: validCid });
   });
+
+  it("aborts a stalled Pinata upload once the timeout elapses", async () => {
+    vi.useFakeTimers();
+    try {
+      await initializeIpfsFromEnv({
+        MODE: "test",
+        PINATA_JWT: "pinata-server-token",
+        PINATA_GATEWAY_URL: "https://pinata.example",
+        PINATA_API_URL: "https://uploads.pinata.test/v3",
+      });
+
+      // A fetch that never resolves on its own — it only settles when its
+      // AbortSignal fires, mimicking a connection that stalls mid-upload.
+      const fetchMock = vi.fn<typeof fetch>(
+        (_input, init) =>
+          new Promise<Response>((_resolve, reject) => {
+            (init as RequestInit | undefined)?.signal?.addEventListener("abort", () => {
+              reject(new DOMException("The operation was aborted.", "AbortError"));
+            });
+          })
+      );
+      globalThis.fetch = fetchMock;
+
+      const uploadPromise = uploadFileToIPFS(
+        new File(["content"], "proof.txt", { type: "text/plain" })
+      );
+      const expectation = expect(uploadPromise).rejects.toThrow(/timed out/i);
+
+      // Advance past the 60s upload ceiling so the AbortController fires.
+      await vi.advanceTimersByTimeAsync(60_000);
+      await expectation;
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/packages/shared/src/i18n/en.json
+++ b/packages/shared/src/i18n/en.json
@@ -3384,7 +3384,6 @@
   "public.impact.hero.season": "Season One",
   "public.impact.heroLede": "Green Goods turns documented regenerative Work into evidence the public can read. Assessments come first, then Work, and when ready, an Impact Certificate that sources every claim.",
   "public.impact.heroTitle": "See how Garden work becomes <accent>evidence</accent>.",
-  "public.impact.hypercertsPlaceholder": "Hypercert gallery coming soon",
   "public.impact.kicker": "Public evidence ledger",
   "public.impact.kind.all": "All",
   "public.impact.kind.assessment": "Assessment",

--- a/packages/shared/src/i18n/es.json
+++ b/packages/shared/src/i18n/es.json
@@ -3384,7 +3384,6 @@
   "public.impact.hero.season": "Temporada Uno",
   "public.impact.heroLede": "Green Goods convierte el Trabajo regenerativo documentado en evidencia que el público puede leer. Primero las Evaluaciones, luego el Trabajo, y cuando esté listo, un Certificado de Impacto que respalda cada afirmación.",
   "public.impact.heroTitle": "Mira cómo el trabajo de un Jardín se vuelve <accent>evidencia</accent>.",
-  "public.impact.hypercertsPlaceholder": "Galería de Hypercerts próximamente",
   "public.impact.kicker": "Registro público de evidencia",
   "public.impact.kind.all": "Todo",
   "public.impact.kind.assessment": "Evaluación",

--- a/packages/shared/src/i18n/pt.json
+++ b/packages/shared/src/i18n/pt.json
@@ -3384,7 +3384,6 @@
   "public.impact.hero.season": "Temporada Um",
   "public.impact.heroLede": "A Green Goods transforma o Trabalho regenerativo documentado em evidência que o público pode ler. Primeiro as Avaliações, depois o Trabalho, e quando pronto, um Certificado de Impacto que fundamenta cada afirmação.",
   "public.impact.heroTitle": "Veja como o trabalho de um Jardim se torna <accent>evidência</accent>.",
-  "public.impact.hypercertsPlaceholder": "Galeria de Hypercerts em breve",
   "public.impact.kicker": "Registro público de evidência",
   "public.impact.kind.all": "Tudo",
   "public.impact.kind.assessment": "Avaliação",

--- a/packages/shared/src/modules/data/ipfs/client.ts
+++ b/packages/shared/src/modules/data/ipfs/client.ts
@@ -36,6 +36,11 @@ export const DEFAULT_PINATA_UPLOADS_API_BASE_URL = "https://uploads.pinata.cloud
 export const IPFS_FALLBACK_GATEWAYS = ["https://gateway.pinata.cloud", "https://ipfs.io"];
 export const PROVIDER_VERIFICATION_ATTEMPTS = 3;
 export const PROVIDER_VERIFICATION_TIMEOUT_MS = 5_000;
+// Uploads send file bodies, so they get a longer ceiling than the gateway HEAD
+// checks above — generous enough not to abort a legitimately slow mobile upload,
+// but bounded so a stalled connection fails retryably instead of hanging forever.
+export const PINATA_UPLOAD_TIMEOUT_MS = 60_000;
+export const PINATA_UPLOAD_SIGN_TIMEOUT_MS = 15_000;
 export const DEFAULT_AVATAR = "/images/avatar.png";
 
 // ============================================================================

--- a/packages/shared/src/modules/data/ipfs/pinata.ts
+++ b/packages/shared/src/modules/data/ipfs/pinata.ts
@@ -5,6 +5,8 @@ import {
   getPinataJwt,
   getPinataUploadSignUrl,
   getPinataUploadsApiBaseUrl,
+  PINATA_UPLOAD_SIGN_TIMEOUT_MS,
+  PINATA_UPLOAD_TIMEOUT_MS,
   PROVIDER_VERIFICATION_ATTEMPTS,
   PROVIDER_VERIFICATION_TIMEOUT_MS,
   trimTrailingSlashes,
@@ -30,6 +32,43 @@ type UploadSignResponse =
 
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
+}
+
+/**
+ * Issues a fetch that aborts after `timeoutMs`, converting the abort into a
+ * clear, retryable error. Without this, a stalled upload connection (common on
+ * weak mobile networks) hangs forever with no surfaced error — the work-media
+ * "Uploading…" spinner never resolves. Mirrors the AbortController idiom used by
+ * `verifyGatewayAvailability` below.
+ */
+async function fetchWithTimeout(
+  input: string,
+  init: RequestInit,
+  timeoutMs: number,
+  timeoutMessage: string
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (isAbortError(error)) {
+      throw new Error(timeoutMessage);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 function buildPinataMetadata(
@@ -92,18 +131,23 @@ async function requestSignedUploadUrl(
     throw new Error("IPFS upload signer endpoint is not configured");
   }
 
-  const response = await fetch(signUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      filename: options.name ?? file.name,
-      mimeType: file.type,
-      size: file.size,
-      category: options.category,
-      source: options.source,
-      gardenAddress: options.gardenAddress,
-    }),
-  });
+  const response = await fetchWithTimeout(
+    signUrl,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        filename: options.name ?? file.name,
+        mimeType: file.type,
+        size: file.size,
+        category: options.category,
+        source: options.source,
+        gardenAddress: options.gardenAddress,
+      }),
+    },
+    PINATA_UPLOAD_SIGN_TIMEOUT_MS,
+    "Upload signing timed out. Check your connection and try again."
+  );
 
   let payload: UploadSignResponse | null = null;
   try {
@@ -138,10 +182,15 @@ async function uploadFileWithSignedPinataUrl(
   formData.append("network", "public");
   formData.append("file", file);
 
-  const response = await fetch(signedUrl, {
-    method: "POST",
-    body: formData,
-  });
+  const response = await fetchWithTimeout(
+    signedUrl,
+    {
+      method: "POST",
+      body: formData,
+    },
+    PINATA_UPLOAD_TIMEOUT_MS,
+    "Media upload timed out. Check your connection and try again."
+  );
 
   return parsePinataUploadResponse(response, file.name);
 }
@@ -180,13 +229,18 @@ export async function uploadFileWithPinata(
     formData.append("keyvalues", JSON.stringify(keyvalues));
   }
 
-  const response = await fetch(`${getPinataUploadsApiBaseUrl()}/files`, {
-    method: "POST",
-    headers: {
-      Authorization: `Bearer ${jwt}`,
+  const response = await fetchWithTimeout(
+    `${getPinataUploadsApiBaseUrl()}/files`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${jwt}`,
+      },
+      body: formData,
     },
-    body: formData,
-  });
+    PINATA_UPLOAD_TIMEOUT_MS,
+    "Media upload timed out. Check your connection and try again."
+  );
 
   return parsePinataUploadResponse(response, file.name);
 }


### PR DESCRIPTION
## What

The three Pinata IPFS upload requests had no timeout, so a stalled connection on a weak mobile network hangs the upload forever with **no surfaced error** — the work-media "Uploading…" spinner never resolves. This is a leading suspect for the gardener photo-upload report in PRD-607, and a real bug regardless of that report.

## Fix

- Add `fetchWithTimeout` in `pinata.ts` and wrap the three upload `fetch` calls (sign request, signed-URL upload, JWT upload). On abort it throws a clear, **retryable** error instead of hanging.
- Mirrors the `AbortController` idiom already used by `verifyGatewayAvailability` in the same file.
- New constants in `client.ts`: `PINATA_UPLOAD_TIMEOUT_MS` = 60s (generous — won't abort a legitimately slow upload) and `PINATA_UPLOAD_SIGN_TIMEOUT_MS` = 15s.
- The thrown message surfaces through the existing `executeUpload` error path (already `recoverable: true` + tracked), so the work stays retryable.

## Also

- Removes the unused `public.impact.hypercertsPlaceholder` i18n key (en/es/pt) — no code references, surfaced by the PRD-534 editorial audit.

## Test

- Adds a fake-timer Vitest case in `ipfs.module.test.ts`: a fetch that only settles on abort, advanced past the 60s ceiling, asserting the upload rejects with a timeout message and that fetch was called once.

## Validation

- i18n JSON valid (en/es/pt parse clean); `git diff --check` clean; Biome clean on the changed TS.
- ⚠️ Local Vitest/tsc could not run in this worktree (no `packages/shared/node_modules` — the known fresh-worktree dependency gate). **CI Gate is the validation path** for the test, typecheck, and build.

## Behavior note

60s is a deliberate ceiling: long enough not to abort a slow-but-progressing upload over poor signal, short enough that a truly stalled connection fails (retryably) instead of spinning indefinitely.

Refs PRD-607, PRD-534

🤖 Generated with [Claude Code](https://claude.com/claude-code)