### PR TITLE
ci(contracts): split fork readiness into sequential runner

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -187,7 +187,7 @@ jobs:
           path: output/contracts-test-audit/
           retention-days: 14
 
-  fork-readiness:
+  fork-readiness-core:
     name: Fork Readiness / ${{ matrix.label }}
     if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.operation == 'fork-readiness' || inputs.operation == 'all')
     runs-on: ubuntu-latest
@@ -196,21 +196,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - shard: arbitrum
-            label: Arbitrum
-            script: test:fork:arbitrum:ci
           - shard: sepolia
             label: Sepolia
             script: test:fork:sepolia:ci
           - shard: ethereum
             label: Ethereum ENS
             script: test:fork:ethereum:ci
-          - shard: gardens
-            label: Gardens And Deployment
-            script: test:fork:gardens:ci
-          - shard: octant
-            label: Octant Readiness
-            script: test:fork:octant:ci
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -294,6 +285,126 @@ jobs:
       - name: Run ${{ matrix.label }} fork shard
         working-directory: packages/contracts
         run: bun run ${{ matrix.script }}
+        env:
+          COOKIE_JAR_FACTORY_ADDRESS: ${{ secrets.COOKIE_JAR_FACTORY_ADDRESS }}
+          CI: true
+
+  fork-readiness-arbitrum:
+    name: Fork Readiness / Arbitrum Sequential
+    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_dispatch' || inputs.operation == 'fork-readiness' || inputs.operation == 'all')
+    runs-on: ubuntu-latest
+    timeout-minutes: 75
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Resolve fork RPCs and block pins
+        env:
+          ARBITRUM_RPC_URL: ${{ secrets.ARBITRUM_RPC_URL }}
+          ARBITRUM_FORK_BLOCK_NUMBER: ${{ vars.ARBITRUM_FORK_BLOCK_NUMBER || '466388412' }}
+          SEPOLIA_RPC_URL: ${{ secrets.SEPOLIA_RPC_URL }}
+          SEPOLIA_FORK_BLOCK_NUMBER: ${{ vars.SEPOLIA_FORK_BLOCK_NUMBER || '10917257' }}
+          ETHEREUM_RPC_URL: ${{ secrets.ETHEREUM_RPC_URL }}
+          ETHEREUM_FORK_BLOCK_NUMBER: ${{ vars.ETHEREUM_FORK_BLOCK_NUMBER || '25170563' }}
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+          ALCHEMY_KEY: ${{ secrets.ALCHEMY_KEY }}
+          VITE_ALCHEMY_API_KEY: ${{ secrets.VITE_ALCHEMY_API_KEY }}
+          PUBLIC_ARBITRUM_RPC_URL: https://arbitrum-one.public.blastapi.io
+          PUBLIC_SEPOLIA_RPC_URL: https://sepolia.drpc.org
+          PUBLIC_ETHEREUM_RPC_URL: https://ethereum.drpc.org
+        run: |
+          set -euo pipefail
+
+          ALCHEMY_KEY_VALUE="${ALCHEMY_API_KEY:-$ALCHEMY_KEY}"
+          ALCHEMY_KEY_VALUE="${ALCHEMY_KEY_VALUE:-$VITE_ALCHEMY_API_KEY}"
+
+          if [[ -z "$ARBITRUM_RPC_URL" ]]; then
+            if [[ -n "$ALCHEMY_KEY_VALUE" ]]; then
+              ARBITRUM_RPC_URL="https://arb-mainnet.g.alchemy.com/v2/$ALCHEMY_KEY_VALUE"
+              echo "::notice::ARBITRUM_RPC_URL secret is not configured; using derived Alchemy Arbitrum RPC from existing key secret."
+            else
+              ARBITRUM_RPC_URL="$PUBLIC_ARBITRUM_RPC_URL"
+              echo "::warning::ARBITRUM_RPC_URL secret is not configured; using public Arbitrum RPC fallback."
+            fi
+          fi
+
+          if [[ -z "$SEPOLIA_RPC_URL" ]]; then
+            SEPOLIA_RPC_URL="$PUBLIC_SEPOLIA_RPC_URL"
+            echo "::warning::SEPOLIA_RPC_URL secret is not configured; using public Sepolia RPC fallback."
+          fi
+
+          if [[ -z "$ETHEREUM_RPC_URL" ]]; then
+            ETHEREUM_RPC_URL="$PUBLIC_ETHEREUM_RPC_URL"
+            echo "::warning::ETHEREUM_RPC_URL secret is not configured; using public Ethereum RPC fallback."
+          fi
+
+          echo "::add-mask::$ARBITRUM_RPC_URL"
+          echo "::add-mask::$SEPOLIA_RPC_URL"
+          echo "::add-mask::$ETHEREUM_RPC_URL"
+          echo "ARBITRUM_RPC_URL=$ARBITRUM_RPC_URL" >> "$GITHUB_ENV"
+          echo "ARBITRUM_FORK_RPC_URL=$ARBITRUM_RPC_URL" >> "$GITHUB_ENV"
+          echo "ARBITRUM_FORK_BLOCK_NUMBER=$ARBITRUM_FORK_BLOCK_NUMBER" >> "$GITHUB_ENV"
+          echo "SEPOLIA_RPC_URL=$SEPOLIA_RPC_URL" >> "$GITHUB_ENV"
+          echo "SEPOLIA_FORK_RPC_URL=$SEPOLIA_RPC_URL" >> "$GITHUB_ENV"
+          echo "SEPOLIA_FORK_BLOCK_NUMBER=$SEPOLIA_FORK_BLOCK_NUMBER" >> "$GITHUB_ENV"
+          echo "ETHEREUM_RPC_URL=$ETHEREUM_RPC_URL" >> "$GITHUB_ENV"
+          echo "ETHEREUM_FORK_RPC_URL=$ETHEREUM_RPC_URL" >> "$GITHUB_ENV"
+          echo "MAINNET_RPC_URL=$ETHEREUM_RPC_URL" >> "$GITHUB_ENV"
+          echo "ETHEREUM_FORK_BLOCK_NUMBER=$ETHEREUM_FORK_BLOCK_NUMBER" >> "$GITHUB_ENV"
+          echo "MAINNET_FORK_BLOCK_NUMBER=$ETHEREUM_FORK_BLOCK_NUMBER" >> "$GITHUB_ENV"
+          echo "::notice::Arbitrum sequential fork shards blocks: arbitrum=$ARBITRUM_FORK_BLOCK_NUMBER sepolia=$SEPOLIA_FORK_BLOCK_NUMBER ethereum=$ETHEREUM_FORK_BLOCK_NUMBER"
+
+      - name: Run Arbitrum fork shards sequentially
+        working-directory: packages/contracts
+        run: |
+          set +e
+
+          bun run test:fork:arbitrum:ci
+          arbitrum_status=$?
+
+          bun run test:fork:gardens:ci
+          gardens_status=$?
+
+          bun run test:fork:octant:ci
+          octant_status=$?
+
+          set -e
+
+          failed=0
+          if [[ "$arbitrum_status" -ne 0 ]]; then
+            echo "::error::Arbitrum fork shard failed with exit code $arbitrum_status"
+            failed=1
+          fi
+          if [[ "$gardens_status" -ne 0 ]]; then
+            echo "::error::Gardens fork shard failed with exit code $gardens_status"
+            failed=1
+          fi
+          if [[ "$octant_status" -ne 0 ]]; then
+            echo "::error::Octant fork shard failed with exit code $octant_status"
+            failed=1
+          fi
+
+          exit "$failed"
         env:
           COOKIE_JAR_FACTORY_ADDRESS: ${{ secrets.COOKIE_JAR_FACTORY_ADDRESS }}
           CI: true

--- a/packages/contracts/script/utils/fork-shards.mjs
+++ b/packages/contracts/script/utils/fork-shards.mjs
@@ -18,11 +18,13 @@ const DEFAULTS = {
 
 const SHARDS = {
   arbitrum: {
+    chain: "ARBITRUM",
     description: "Arbitrum core, ENS, Gardens module, EAS, Hypercerts, Karma GAP, and full-protocol fork coverage",
     glob:
       "test/fork/{ArbitrumActionRegistry,ArbitrumConvictionVoting,ArbitrumENS,ArbitrumGardenAccount,ArbitrumGardenAccountConfig,ArbitrumGardenAccountMembership,ArbitrumGardenAccountMetadata,ArbitrumGardenToken,ArbitrumGardensModule,ArbitrumGardensNegativePaths,ArbitrumGoodsToken,ArbitrumHats,ArbitrumHypercerts,ArbitrumKarmaGAP,ArbitrumLiveGardenSignalPoolRepair,ArbitrumMultiGardenIsolation,ArbitrumNegativePaths,ArbitrumRoleRevocation,e2e/ArbitrumFullProtocolE2E,eas/ArbitrumEASAttestationLifecycle}.t.sol",
   },
   sepolia: {
+    chain: "SEPOLIA",
     description: "Sepolia protocol, EAS, ENS, Karma GAP, CookieJar, and full-protocol fork coverage",
     glob:
       "test/fork/{SepoliaActionRegistry,SepoliaConvictionVoting,SepoliaCookieJar,SepoliaENS,SepoliaGardenAccount,SepoliaGardenAccountConfig,SepoliaGardenAccountMembership,SepoliaGardenAccountMetadata,SepoliaGardenToken,SepoliaGardensModule,SepoliaGoodsToken,SepoliaHats,SepoliaKarmaGAP,SepoliaNegativePaths,e2e/FullProtocolE2E,e2e/SepoliaExtendedE2E,eas/EASAttestationLifecycle}.t.sol",
@@ -36,6 +38,7 @@ const SHARDS = {
     glob: "test/fork/{DeploymentRegistryFork,gardens/GardensCommunityGovernance,gardens/GardensV2Community}.t.sol",
   },
   octant: {
+    chain: "ARBITRUM",
     description: "Arbitrum Octant, Aave strategy, vault, yield splitter, CookieJar, and GreenWill readiness coverage",
     glob:
       "test/fork/{ArbitrumAaveStrategy,ArbitrumCookieJar,ArbitrumGreenWillSupport,ArbitrumOctantVault,ArbitrumVaultYieldE2E,ArbitrumYieldSplitterCore,e2e/ArbitrumExtendedE2E}.t.sol",
@@ -108,6 +111,19 @@ function commonArgs() {
   return args;
 }
 
+function forkArgsForChain(chain, profile = "fork") {
+  if (!chain) return [];
+
+  const env = forgeEnv(profile);
+  const rpc = env[`${chain}_FORK_RPC_URL`] || env[`${chain}_RPC_URL`];
+  if (!rpc) return [];
+
+  const blockNumber = env[`${chain}_FORK_BLOCK_NUMBER`] || env[`${chain}_BLOCK_NUMBER`];
+  const args = ["--fork-url", rpc];
+  if (blockNumber) args.push("--fork-block-number", blockNumber);
+  return args;
+}
+
 function runShard(name) {
   const shard = SHARDS[name];
   if (!shard) {
@@ -117,11 +133,24 @@ function runShard(name) {
 
   console.log(`[fork-shard] ${name}: ${shard.description}`);
   console.log(`[fork-shard] match-path: ${shard.glob}`);
-  runForge(["test", "--match-path", shard.glob, ...commonArgs()]);
+  const forkArgs = forkArgsForChain(shard.chain);
+  if (forkArgs.length) {
+    console.log(`[fork-shard] ${name}: using pinned ${shard.chain.toLowerCase()} process fork`);
+  }
+  runForge(["test", "--match-path", shard.glob, ...forkArgs, ...commonArgs()]);
 
   for (const extraRun of shard.extraRuns || []) {
     console.log(`[fork-shard] ${name}: ${extraRun.description}`);
-    const args = ["test", "--match-path", extraRun.glob, "--match-test", extraRun.matchTest, ...commonArgs()];
+    const extraForkArgs = forkArgsForChain(extraRun.chain || shard.chain, extraRun.profile || "fork");
+    const args = [
+      "test",
+      "--match-path",
+      extraRun.glob,
+      "--match-test",
+      extraRun.matchTest,
+      ...extraForkArgs,
+      ...commonArgs(),
+    ];
     runForge(args, { profile: extraRun.profile });
   }
 }
@@ -132,6 +161,7 @@ function listShard(name) {
     console.error(`Unknown fork shard: ${name}`);
     usage(1);
   }
+  console.log(`[fork-shards] listing ${name}`);
   return listTests(shard.glob);
 }
 
@@ -156,6 +186,7 @@ function flattenTests(listing) {
 }
 
 function checkCoverage() {
+  console.log("[fork-shards] listing baseline");
   const baseline = flattenTests(listTests("test/fork/**"));
   const baselineSet = new Set(baseline);
   const seen = new Map();

--- a/packages/contracts/script/utils/fork-shards.mjs
+++ b/packages/contracts/script/utils/fork-shards.mjs
@@ -30,6 +30,7 @@ const SHARDS = {
       "test/fork/{SepoliaActionRegistry,SepoliaConvictionVoting,SepoliaCookieJar,SepoliaENS,SepoliaGardenAccount,SepoliaGardenAccountConfig,SepoliaGardenAccountMembership,SepoliaGardenAccountMetadata,SepoliaGardenToken,SepoliaGardensModule,SepoliaGoodsToken,SepoliaHats,SepoliaKarmaGAP,SepoliaNegativePaths,e2e/FullProtocolE2E,e2e/SepoliaExtendedE2E,eas/EASAttestationLifecycle}.t.sol",
   },
   ethereum: {
+    chain: "ETHEREUM",
     description: "Ethereum mainnet ENS receiver, NameWrapper, and cross-chain ENS fork coverage",
     glob: "test/fork/{CrossChainENS,EthereumENSNameWrapper,EthereumENSReceiver}.t.sol",
   },

--- a/packages/contracts/test/fork/ArbitrumAaveStrategy.t.sol
+++ b/packages/contracts/test/fork/ArbitrumAaveStrategy.t.sol
@@ -16,6 +16,8 @@ contract ArbitrumAaveStrategyForkTest is Test {
     address internal constant ADAI = 0x82E64f49Ed5EC1bC6e43DAD4FC8Af9bb3A2312EE;
 
     function _tryFork() internal returns (bool) {
+        if (block.chainid == 42_161) return true;
+
         string memory rpc;
         try vm.envString("ARBITRUM_FORK_RPC_URL") returns (string memory value) {
             rpc = value;

--- a/packages/contracts/test/fork/ArbitrumConvictionVoting.t.sol
+++ b/packages/contracts/test/fork/ArbitrumConvictionVoting.t.sol
@@ -33,6 +33,8 @@ contract ArbitrumConvictionVotingForkTest is Test {
     uint256 public communityHatId;
 
     function _tryFork() internal returns (bool) {
+        if (block.chainid == 42_161) return true;
+
         string memory rpc;
         try vm.envString("ARBITRUM_FORK_RPC_URL") returns (string memory value) {
             rpc = value;

--- a/packages/contracts/test/fork/ArbitrumENS.t.sol
+++ b/packages/contracts/test/fork/ArbitrumENS.t.sol
@@ -42,6 +42,8 @@ contract ArbitrumENSForkTest is Test {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function _tryFork() internal returns (bool) {
+        if (block.chainid == 42_161) return true;
+
         string memory rpc;
         try vm.envString("ARBITRUM_FORK_RPC_URL") returns (string memory value) {
             rpc = value;

--- a/packages/contracts/test/fork/ArbitrumHypercerts.t.sol
+++ b/packages/contracts/test/fork/ArbitrumHypercerts.t.sol
@@ -45,6 +45,8 @@ contract ArbitrumHypercertsForkTest is Test {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function _tryFork() internal returns (bool) {
+        if (block.chainid == 42_161) return true;
+
         string memory rpc;
         try vm.envString("ARBITRUM_FORK_RPC_URL") returns (string memory value) {
             rpc = value;

--- a/packages/contracts/test/fork/EthereumENSNameWrapper.t.sol
+++ b/packages/contracts/test/fork/EthereumENSNameWrapper.t.sol
@@ -40,6 +40,8 @@ contract EthereumENSNameWrapperForkTest is Test {
     // ═══════════════════════════════════════════════════════
 
     function _tryFork() internal returns (bool) {
+        if (block.chainid == 1) return true;
+
         string memory rpc;
         try vm.envString("ETHEREUM_RPC_URL") returns (string memory value) {
             rpc = value;

--- a/packages/contracts/test/fork/EthereumENSReceiver.t.sol
+++ b/packages/contracts/test/fork/EthereumENSReceiver.t.sol
@@ -39,6 +39,8 @@ contract EthereumENSReceiverForkTest is Test {
     // ═══════════════════════════════════════════════════════════════════════════
 
     function _tryFork() internal returns (bool) {
+        if (block.chainid == 1) return true;
+
         string memory rpc;
         try vm.envString("ETHEREUM_RPC_URL") returns (string memory value) {
             rpc = value;

--- a/packages/contracts/test/fork/SepoliaENS.t.sol
+++ b/packages/contracts/test/fork/SepoliaENS.t.sol
@@ -39,6 +39,8 @@ contract SepoliaENSForkTest is Test {
     uint256 public protocolHatId;
 
     function _tryFork() internal returns (bool) {
+        if (block.chainid == 11_155_111) return true;
+
         string memory rpc;
         try vm.envString("SEPOLIA_FORK_RPC_URL") returns (string memory value) {
             rpc = value;

--- a/packages/contracts/test/fork/helpers/ForkTestBase.sol
+++ b/packages/contracts/test/fork/helpers/ForkTestBase.sol
@@ -130,6 +130,12 @@ abstract contract ForkTestBase is DeploymentBase, ERC6551Helper {
     /// @param chainName One of: "sepolia", "arbitrum", "celo"
     /// @return success True if fork was created and selected
     function _tryChainFork(string memory chainName) internal returns (bool success) {
+        uint256 expectedChainId = _expectedForkChainId(chainName);
+        if (expectedChainId != 0 && block.chainid == expectedChainId) {
+            forkActive = true;
+            return true;
+        }
+
         string memory rpc = _resolveRpcUrl(chainName);
         if (bytes(rpc).length == 0) return false;
 
@@ -143,6 +149,15 @@ abstract contract ForkTestBase is DeploymentBase, ERC6551Helper {
     /// @notice Require a fork for the given chain and fail loudly when the RPC is missing.
     function _requireChainFork(string memory chainName) internal {
         if (!_tryChainFork(chainName)) revert ForkUnavailable(chainName);
+    }
+
+    /// @notice Resolve a canonical chain id so process-level Foundry forks can be reused.
+    function _expectedForkChainId(string memory chainName) internal pure returns (uint256) {
+        bytes32 chain = keccak256(bytes(chainName));
+        if (chain == keccak256(bytes("arbitrum"))) return 42_161;
+        if (chain == keccak256(bytes("sepolia"))) return 11_155_111;
+        if (chain == keccak256(bytes("celo"))) return 42_220;
+        return 0;
     }
 
     /// @notice Resolve RPC URL for a chain name from environment variables


### PR DESCRIPTION
## Summary
- Split contract fork readiness into a core matrix plus a sequential Arbitrum lane to avoid overlapping heavy fork shards
- Reuse pinned process forks in shard helpers and let fork tests short-circuit when the expected chain is already selected
- Keep the coverage script aligned with the new shard layout and chain-specific fork args

## Validation
- [x] `bun run format:check`
- [x] `bun lint`
- [x] `bun run --cwd packages/contracts build`
- [x] `bun run --cwd packages/contracts test`
- [x] `node scripts/dev/ci-local.js --quick`
- [x] `VITE_CHAIN_ID=11155111 bun run build`
- [x] GitHub PR checks pass, including Contracts Unit Tests and CI Gate

## Notes
- Current PR base is `develop`; current diff is 10 contracts/CI files.
- Heavy fork readiness jobs are intentionally skipped on `pull_request` and remain available on non-PR/workflow-dispatch runs.