### PR TITLE
docs: reconcile impact-domain taxonomy + assessment lifecycle (RESR-6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,11 +89,11 @@ Superpowers plans save to `.plans/active/<feature-name>/plan.todo.md` (not the s
 
 The `docs/` directory contains a Docusaurus site with product documentation, user guides, and developer references. When investigating domain questions, architecture decisions, or user-facing behavior, consult:
 
-- System architecture (diagrams): `docs/docs/developers/architecture.mdx`
-- Domain glossary: `docs/docs/glossary.md`
-- Impact model (CIDS): `docs/docs/concepts/impact-model.mdx`
-- Strategy and goals: `docs/docs/concepts/strategy-and-goals.mdx`
-- Entity matrix: `docs/docs/developers/reference/entity-matrix.mdx`
+- System architecture (diagrams): `docs/docs/builders/architecture.mdx`
+- Domain glossary: `docs/docs/reference/glossary-community.md`
+- Impact model & Eight Forms of Capital: `docs/docs/reference/design-research.md`
+- Action domains, goals & schema registry: `docs/docs/builders/specs/v1-0.mdx`
+- Entity matrix: `docs/docs/builders/integrations/entity-matrix.mdx`
 
 Package-specific context files (`.claude/context/*.md`) include additional documentation references relevant to each package.
 

--- a/docs/docs/builders/architecture/erd.mdx
+++ b/docs/docs/builders/architecture/erd.mdx
@@ -38,7 +38,7 @@ erDiagram
     Action ||--o{ Work : "documents"
     Work ||--o| WorkApproval : "reviewed by"
     Work }o--|| Gardener : "submitted by"
-    WorkApproval }o--|| GardenAssessment : "aggregated into"
+    Garden ||--o{ GardenAssessment : "baselines per domain/period"
 
     GardenVault ||--o{ VaultDeposit : "tracks per depositor"
     GardenVault ||--o{ VaultEvent : "logs activity"
@@ -46,6 +46,7 @@ erDiagram
 
     Hypercert ||--o{ HypercertClaim : "fractionalized into"
     Hypercert }o--o{ Work : "bundles attestations"
+    Hypercert }o--o{ GardenAssessment : "bundles attestations"
 
     Garden {
         ID id "Garden TBA address"
@@ -186,7 +187,7 @@ erDiagram
 | --- | --- | --- |
 | **Work** | EAS GraphQL | An attestation that a gardener performed a specific action. Contains a title, media URI (IPFS), and reference to the action. Validated by the WorkResolver. |
 | **WorkApproval** | EAS GraphQL | An operator's review of a work submission. References the work UID with an approval boolean, confidence score, and method description. |
-| **GardenAssessment** | EAS GraphQL | An evaluator's holistic assessment of a garden's progress. Contains notes and supporting media. |
+| **GardenAssessment** | EAS GraphQL | A garden's baseline strategy for a domain and reporting period: diagnosis, SMART-outcome targets, and selected actions. Set up front; the Hypercert later bundles it with approved work as evidence. |
 
 ### Financial entities
 

--- a/docs/docs/builders/architecture/erd.mdx
+++ b/docs/docs/builders/architecture/erd.mdx
@@ -46,7 +46,6 @@ erDiagram
 
     Hypercert ||--o{ HypercertClaim : "fractionalized into"
     Hypercert }o--o{ Work : "bundles attestations"
-    Hypercert }o--o{ GardenAssessment : "bundles attestations"
 
     Garden {
         ID id "Garden TBA address"
@@ -187,7 +186,7 @@ erDiagram
 | --- | --- | --- |
 | **Work** | EAS GraphQL | An attestation that a gardener performed a specific action. Contains a title, media URI (IPFS), and reference to the action. Validated by the WorkResolver. |
 | **WorkApproval** | EAS GraphQL | An operator's review of a work submission. References the work UID with an approval boolean, confidence score, and method description. |
-| **GardenAssessment** | EAS GraphQL | A garden's baseline strategy for a domain and reporting period: diagnosis, SMART-outcome targets, and selected actions. Set up front; the Hypercert later bundles it with approved work as evidence. |
+| **GardenAssessment** | EAS GraphQL | A garden's baseline strategy for a domain and reporting period: diagnosis, SMART-outcome targets, and selected actions. Set up front; approved work is later certified against it (the Hypercert bundles the work, not the assessment). |
 
 ### Financial entities
 

--- a/docs/docs/builders/architecture/sequence-diagrams.mdx
+++ b/docs/docs/builders/architecture/sequence-diagrams.mdx
@@ -328,7 +328,7 @@ Withdrawals follow the reverse path: the funder specifies an amount of assets to
 
 ## Assessment flow
 
-Evaluators create garden-level assessments that provide a holistic view of a garden's progress. Unlike work approvals (which reference specific work submissions), assessments evaluate the garden as a whole.
+Evaluators create garden-level assessments — a garden's baseline strategy for a domain and reporting period (diagnosis, SMART-outcome targets, selected actions). Unlike work approvals (which reference specific work submissions), an assessment is garden-level and set up front; the work is later measured against its outcomes.
 
 ```mermaid
 sequenceDiagram

--- a/docs/docs/builders/journeys/evaluation.mdx
+++ b/docs/docs/builders/journeys/evaluation.mdx
@@ -25,30 +25,30 @@ import {StatusBadge} from "@site/src/components/docs";
 
 <StatusBadge status="Live" />
 
-How approved work is bundled and assessed by the people who can vouch for it. The authority boundary is on-chain: `AssessmentResolver` calls `HatsModule.isEvaluator(attester)` before permitting an EAS attestation. Operators draft and evaluators (hat-holders) attest from the **same admin Garden + Hub surfaces** — visibility and permission are role-permissioned per garden, not split into a separate workspace.
+How a garden's baseline assessment is drafted and attested by the people who can vouch for it. The authority boundary is on-chain: `AssessmentResolver` calls `HatsModule.isEvaluator(attester)` before permitting an EAS attestation. Operators draft and evaluators (hat-holders) attest from the **same admin Garden + Hub surfaces** — visibility and permission are role-permissioned per garden, not split into a separate workspace.
 
 ## Personas
 
-- **B: Operator** — drives the Hub Assess stage; bundles approved works into an assessment.
+- **B: Operator** — drives the Hub Assess stage; drafts the garden's baseline assessment (diagnosis, SMART-outcome targets, selected actions, reporting period).
 - **C: Evaluator** — domain expert who signs the assessment with the Evaluator hat. Currently has no dedicated UI; evaluators with the hat use the same admin surface as operators.
 
 ## State machine
 
 ```mermaid
 stateDiagram-v2
-    [*] --> ApprovedWorks
-    ApprovedWorks --> Drafting: Hub stage Assess + FAB Create Assessment
-    Drafting --> SelectingDomain: AssessmentForm.domain
-    SelectingDomain --> SelectingScope: pick approved works
-    SelectingScope --> AttachingMedia: optional sensor logs / photos
+    [*] --> Drafting: Hub stage Assess + FAB Create Assessment
+    Drafting --> DomainContext: title, description, location, domain
+    DomainContext --> StrategyKernel: diagnosis + SMART-outcome targets
+    StrategyKernel --> ActionsHarvest: select action templates + reporting period
+    ActionsHarvest --> AttachingMedia: optional sensor logs / photos
     AttachingMedia --> Reviewing: createAssessmentMachine handoff
     Reviewing --> Submitting: useCreateAssessmentWorkflow
     Submitting --> ResolverGate: EAS onAttest
     ResolverGate --> Attested: HatsModule.isEvaluator(attester) = true
     ResolverGate --> Rejected: hat check fails
-    Attested --> ReadyToCertify: Hub stage Certify shows it
+    Attested --> AvailableAtCertify: Hub Certify stage bundles it with approved work
     Rejected --> [*]
-    ReadyToCertify --> [*]
+    AvailableAtCertify --> [*]
 ```
 
 ## Entry points
@@ -63,16 +63,16 @@ stateDiagram-v2
 
 | # | State | Persona | Surface (package + view) | Hook / Service | Side effects | Status |
 | --- | --- | --- | --- | --- | --- | --- |
-| 1 | ApprovedWorks | B | `admin` / `views/Hub` (stage `assess`) | `useReviewerWorks`, `HubAssessmentQueue` | Read approved Works + WorkApprovals from EAS via `eas.ts` | shipped |
-| 2 | Drafting | B / C | `admin` / `views/Hub/CreateAssessment.tsx` | `useCreateAssessmentController`, `useCreateAssessmentForm` (RHF + Zod) | IndexedDB draft via `useAssessmentDraft` | shipped |
-| 3 | SelectingDomain | B / C | same | `useCreateAssessmentForm.domain` | Domain mapped to contract enum (`AssessmentSchema.domain` uint8) | shipped |
-| 4 | SelectingScope | B / C | same | `useCreateAssessmentForm.workSelection` | Pulls approved work UIDs via `useGardenDerivedState` | shipped |
+| 1 | Drafting | B / C | `admin` / `views/Hub/CreateAssessment.tsx` | `useCreateAssessmentController`, `useCreateAssessmentForm` (RHF + Zod) | IndexedDB draft via `useAssessmentDraft` | shipped |
+| 2 | Domain & Context | B / C | same | `useCreateAssessmentForm` (`domain`, title, description, location) | Domain mapped to contract enum (`AssessmentSchema.domain` uint8) | shipped |
+| 3 | Strategy Kernel | B / C | same | `useCreateAssessmentForm` (`diagnosis`, `smartOutcomes` — at least one required) | The SMART-outcome targets the work is later measured against | shipped |
+| 4 | Actions & Harvest | B / C | same | `useCreateAssessmentForm` (`selectedActionUIDs`, `reportingPeriodStart/End`) | Selects which action templates the assessment covers + the reporting window | shipped |
 | 5 | AttachingMedia | B / C | same | shared media upload | IPFS pin via Pinata | shipped |
 | 6 | Reviewing | B / C | same | `createAssessmentMachine` (xstate-style state) | UI handoff before submit | shipped |
-| 7 | Submitting | B / C | same | `useCreateAssessmentWorkflow` | EAS `attest(AssessmentSchema)` | shipped |
+| 7 | Submitting | B / C | same | `useCreateAssessmentWorkflow` | EAS `attest(AssessmentSchema)` — stores `domain` + `assessmentConfigCID` | shipped |
 | 8 | ResolverGate | (chain) | `AssessmentResolver` (contracts) | onchain | Calls `HatsModule.isEvaluator(attester)`. **The hat check is the actual evaluator gate, not a UI gate.** | shipped |
 | 9 | Attested | C | EAS | indexed via EAS GraphQL → `getGardenAssessments` | Available to Hub Certify stage | shipped |
-| 10 | ReadyToCertify | B | `admin` / `views/Hub` (stage `certify`) → `HubCertificationInspector` | `useGardenAssessments`, `useCreateHypercertWorkflow` | Inspector shows the assessment with "Ready to certify" badge when `canMint = true` | shipped |
+| 10 | AvailableAtCertify | B | `admin` / `views/Hub` (stage `certify`) → `HubCertificationInspector` | `useGardenAssessments`, `useCreateHypercertWorkflow` | The Hypercert bundles approved work **with** this assessment (`Hypercert.attestationUIDs`) | shipped |
 
 ## Evaluator surface: served by Garden workspace via role-permissioned visibility
 
@@ -89,13 +89,13 @@ In practice that means:
 ## Failure / recovery paths
 
 - **Operator without Evaluator hat tries to submit.** Resolver reverts at `HatsModule.isEvaluator(attester)`. UI surfaces user-friendly text via `parseContractError`. The form draft remains in IndexedDB.
-- **No approved works available.** Hub Assess queue renders empty state; FAB still appears but the assessment will fail Zod validation (no `workSelection` items).
+- **Required fields missing.** The form fails Zod validation if the title, location, diagnosis, the reporting period, or at least one SMART outcome is empty (`useCreateAssessmentForm`). The draft remains in IndexedDB.
 - **IPFS pin fails.** `useCreateAssessmentWorkflow` retries via the standard mutation pipeline. Job queue persists the draft.
 - **Assessment EAS GraphQL lag.** Newly attested assessments may not appear in `useGardenAssessments` immediately. UI uses delayed invalidation pattern (`useDelayedInvalidation`) — nominal lag is ~2s.
 
 ## Connections
 
-- Upstream: [Work Submission](./work-submission) — assessments bundle approved works.
+- Related: [Work Submission](./work-submission) — the assessment sets the baseline; gardeners' approved work is later measured against its SMART outcomes.
 - Downstream: [Harvest](./harvest) — Hub Certify stage takes attested assessments and mints hypercerts. Certification handoff is operator-driven today (`HubCertificationInspector` `canMint` boolean).
 - Sequence diagram: [Assessment flow](../architecture/sequence-diagrams#assessment-flow).
 

--- a/docs/docs/builders/journeys/evaluation.mdx
+++ b/docs/docs/builders/journeys/evaluation.mdx
@@ -46,7 +46,7 @@ stateDiagram-v2
     Submitting --> ResolverGate: EAS onAttest
     ResolverGate --> Attested: HatsModule.isEvaluator(attester) = true
     ResolverGate --> Rejected: hat check fails
-    Attested --> AvailableAtCertify: Hub Certify stage bundles it with approved work
+    Attested --> AvailableAtCertify: Hub Certify mints a Hypercert from approved work
     Rejected --> [*]
     AvailableAtCertify --> [*]
 ```
@@ -72,7 +72,7 @@ stateDiagram-v2
 | 7 | Submitting | B / C | same | `useCreateAssessmentWorkflow` | EAS `attest(AssessmentSchema)` — stores `domain` + `assessmentConfigCID` | shipped |
 | 8 | ResolverGate | (chain) | `AssessmentResolver` (contracts) | onchain | Calls `HatsModule.isEvaluator(attester)`. **The hat check is the actual evaluator gate, not a UI gate.** | shipped |
 | 9 | Attested | C | EAS | indexed via EAS GraphQL → `getGardenAssessments` | Available to Hub Certify stage | shipped |
-| 10 | AvailableAtCertify | B | `admin` / `views/Hub` (stage `certify`) → `HubCertificationInspector` | `useGardenAssessments`, `useCreateHypercertWorkflow` | The Hypercert bundles approved work **with** this assessment (`Hypercert.attestationUIDs`) | shipped |
+| 10 | AvailableAtCertify | B | `admin` / `views/Hub` (stage `certify`) → `HubCertificationInspector` | `useGardenAssessments`, `useCreateHypercertWorkflow` | The Hypercert bundles the approved work into `Hypercert.attestationUIDs`; this assessment drives certify-stage filtering and prefill (its UID is not bundled) | shipped |
 
 ## Evaluator surface: served by Garden workspace via role-permissioned visibility
 

--- a/docs/docs/builders/journeys/harvest.mdx
+++ b/docs/docs/builders/journeys/harvest.mdx
@@ -41,9 +41,9 @@ How a Season's accumulated impact gets converted into hypercerts, distributed yi
 ```mermaid
 stateDiagram-v2
     [*] --> SeasonOpen
-    SeasonOpen --> WorksAccumulating: gardeners submit + operators approve
-    WorksAccumulating --> AssessmentsAttested: evaluation journey runs
-    AssessmentsAttested --> ReadyToCertify: Hub Certify stage shows assessments
+    SeasonOpen --> BaselineAssessed: evaluator sets the garden baseline (Hub Assess stage)
+    BaselineAssessed --> WorksAccumulating: gardeners submit + operators approve
+    WorksAccumulating --> ReadyToCertify: Hub Certify bundles approved work + assessment
 
     state "Hypercert minting" as Mint {
         ReadyToCertify --> DraftingHypercert: useHypercertDraft

--- a/docs/docs/builders/journeys/harvest.mdx
+++ b/docs/docs/builders/journeys/harvest.mdx
@@ -43,7 +43,7 @@ stateDiagram-v2
     [*] --> SeasonOpen
     SeasonOpen --> BaselineAssessed: evaluator sets the garden baseline (Hub Assess stage)
     BaselineAssessed --> WorksAccumulating: gardeners submit + operators approve
-    WorksAccumulating --> ReadyToCertify: Hub Certify bundles approved work + assessment
+    WorksAccumulating --> ReadyToCertify: Hub Certify mints a Hypercert from approved work
 
     state "Hypercert minting" as Mint {
         ReadyToCertify --> DraftingHypercert: useHypercertDraft
@@ -81,7 +81,7 @@ stateDiagram-v2
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | ReadyToCertify | B | `admin` / `views/Hub` (stage `certify`) | `useGardenAssessments`, `HubCertificationQueue`, `HubCertificationInspector` | Reads attested assessments via EAS | shipped |
 | 2 | DraftingHypercert | B | `admin` / `views/Hub/CreateHypercert.tsx` | `useCreateHypercertController`, `useHypercertDraft`, `useCreateHypercertWorkflow` | IndexedDB draft persistence | shipped |
-| 3 | SelectingAttestations | B | same | `useHypercertAllowlist` | Bundles work + assessment attestation UIDs into `Hypercert.attestationUIDs` | shipped |
+| 3 | SelectingAttestations | B | same | `useHypercertAllowlist` | Bundles the selected approved-work attestation UIDs into `Hypercert.attestationUIDs` (the assessment drives filtering/prefill, not the bundle) | shipped |
 | 4 | AssigningWeights | B | same | `useHypercertContributorWeights` | Per-contributor unit allocation | shipped |
 | 5 | Minting | B | same | `useMintHypercert` | Mints hypercert via Hypercerts contract; emits Transfer event | shipped |
 | 6 | HypercertActive | (system) | Envio | event handlers | Creates `Hypercert` entity (status `ACTIVE`), tokenId, totalUnits | shipped |
@@ -123,6 +123,6 @@ stateDiagram-v2
 ## Notes for builders
 
 - The 3-way split (`cookieJarAmount` / `fractionsAmount` / `juiceboxAmount`) is per-garden and lives on the `YieldAllocation` indexer entity. Always read aggregated yield via `useGardenYieldSummary` and `useProtocolYieldSummary`, not by re-summing individual events client-side.
-- `Hypercert.attestationUIDs` is the canonical link from a hypercert back to its EAS work + assessment attestations. The hypercert is the bundle; the attestations are the evidence. Don't deep-link from hypercerts to individual works without going through this field.
+- `Hypercert.attestationUIDs` is the canonical link from a hypercert back to its EAS work attestations. The hypercert is the bundle; the work attestations are the evidence. Don't deep-link from hypercerts to individual works without going through this field.
 - Octant Vault auto-buy of listed hypercerts is described in spec § 3.3 but there is no automation in this codebase. If you build it, model it as an off-chain bot that watches `useHypercertListings` and submits buy transactions when funded — not as a contract change.
 - A "Season close" primitive does not exist in the contract surface today. If you scope the orchestration: define a public Season read model and a write path (operator-callable, gated by Owner hat) that snapshots the works + assessments + hypercerts set and emits a Season event the indexer can materialize.

--- a/docs/docs/builders/journeys/work-submission.mdx
+++ b/docs/docs/builders/journeys/work-submission.mdx
@@ -113,7 +113,7 @@ stateDiagram-v2
 ## Connections
 
 - Upstream: [Onboarding](./onboarding) — Persona A must have a gardener role + currentGarden before this journey runs.
-- Downstream: [Evaluation](./evaluation) — approved work is the input to garden-level assessments (Hub Assess stage).
+- Related: [Evaluation](./evaluation) — the garden's assessment sets the baseline (diagnosis + SMART targets) that approved work is later measured against; the assessment is not fed by work.
 - Downstream: [Harvest](./harvest) — bundled approved works become the basis for hypercert minting.
 - Storage: see [`packages/shared/src/modules/job-queue/`](https://github.com/greenpill-dev-guild/green-goods/tree/main/packages/shared/src/modules/job-queue) for the offline mechanic and [Local vs Global Balance](../architecture/local-vs-global) for design rationale.
 - Sequence diagram: [Work submission and approval](../architecture/sequence-diagrams#work-submission-and-approval).

--- a/docs/docs/builders/specs/v1-0.mdx
+++ b/docs/docs/builders/specs/v1-0.mdx
@@ -180,6 +180,10 @@ The product architecture serves a 5-sided marketplace, ensuring checks and balan
 
 ### 3.4 Action Domains and Target Outcomes
 
+:::note Current canonical domains (updated 2026-06)
+This v1.0 PRD specifies **five** action domains. Green Goods production implements **four**: **Solar (Hub Development)**, **Agroforestry**, **Education**, and **Waste Management** (the `Domain` enum `SOLAR · AGRO · EDU · WASTE`). **Domain 5 — Mutual Credit and Farmer Verification** was offered in Season-1 onboarding but never received an action set or an enum value; it remains a deferred *build-vs-drop* decision, not an implemented domain. The canonical domain vocabulary is the Impact-Claim Domain Taxonomy + Glossary v1 (Impact Framework v0.1 Refresh). The five-domain text below is retained as the original product record.
+:::
+
 Green Goods is not a generic impact tracking tool. It is purpose-built to capture and verify specific categories of regenerative work emerging from Greenpill Network chapters and aligned initiatives. The protocol optimizes for five core action domains that reflect where local communities are actively creating value.
 
 #### Domain 1: Solar Infrastructure (DePIN Pillar)

--- a/docs/docs/community/evaluator-guide/making-assessments.mdx
+++ b/docs/docs/community/evaluator-guide/making-assessments.mdx
@@ -38,8 +38,7 @@ Attestation chain verification is the core evaluator skill. Every approved piece
 graph LR
     Work["Work Attestation\nUID + media"] --> Match["Match UIDs\nwork → approval"]
     Match --> Approval["Approval Attestation\noperator signature"]
-    Approval --> Assess["Create Assessment\nEight Forms of Capital"]
-    Assess --> Chain["On-Chain\nAttestation"]
+    Approval --> Verified["Chain verified\nimpact backed by evidence"]
 ```
 
 ## How It Works

--- a/docs/docs/community/how-it-works.mdx
+++ b/docs/docs/community/how-it-works.mdx
@@ -155,7 +155,7 @@ The attestation chain creates an **unbroken trail** from field work to certified
 graph LR
     A["Assessment<br/>(Garden baseline and targets)"] -.->|frames and measures| WA
     W["Work Attestation<br/>(Gardener submits)"] -->|reviewed by| WA["Work Approval<br/>(Operator verifies)"]
-    WA -->|bundled and minted as| H["Hypercert<br/>(bundles work + assessment)"]
+    WA -->|bundled and minted as| H["Hypercert<br/>(bundles approved work)"]
 
     style A fill:#a855f7,stroke:#9333ea,color:#fff
     style W fill:#22c55e,stroke:#16a34a,color:#fff

--- a/docs/docs/community/how-it-works.mdx
+++ b/docs/docs/community/how-it-works.mdx
@@ -153,13 +153,13 @@ The attestation chain creates an **unbroken trail** from field work to certified
 
 ```mermaid
 graph LR
+    A["Assessment<br/>(Garden baseline and targets)"] -.->|frames and measures| WA
     W["Work Attestation<br/>(Gardener submits)"] -->|reviewed by| WA["Work Approval<br/>(Operator verifies)"]
-    WA -->|aggregated into| A["Assessment<br/>(Evaluator certifies)"]
-    A -->|minted as| H["Hypercert<br/>(Impact certificate)"]
+    WA -->|bundled and minted as| H["Hypercert<br/>(bundles work + assessment)"]
 
+    style A fill:#a855f7,stroke:#9333ea,color:#fff
     style W fill:#22c55e,stroke:#16a34a,color:#fff
     style WA fill:#3b82f6,stroke:#2563eb,color:#fff
-    style A fill:#a855f7,stroke:#9333ea,color:#fff
     style H fill:#f59e0b,stroke:#d97706,color:#fff
 ```
 

--- a/docs/docs/community/operator-guide/making-an-assessment.mdx
+++ b/docs/docs/community/operator-guide/making-an-assessment.mdx
@@ -63,7 +63,7 @@ Each assessment is single-domain. If a garden is reporting Agroforestry and Educ
 - You know the reporting window and the actions that belong in this assessment.
 
 :::tip
-An assessment can be an early baseline or a later evidence-backed report. It is useful before approvals, but it is not required before every work approval.
+An assessment is the garden's **baseline**: make it first, before the work it frames, so approvals and impact certificates have context to measure against. The app does not strictly enforce one before every approval, but assessment-first is the intended flow.
 :::
 
 ## Step-by-step flow

--- a/docs/docs/community/operator-guide/making-an-assessment.mdx
+++ b/docs/docs/community/operator-guide/making-an-assessment.mdx
@@ -39,7 +39,7 @@ import {GuideOpener, NextBestAction, OperatorPathNav, StatusBadge} from "@site/s
 
 <GuideOpener
   image="/img/social/making-an-assessment.webp"
-  alt="Operators organizing approved work evidence into an assessment packet"
+  alt="Operators setting a garden's assessment baseline — diagnosis, outcomes, and actions"
   label="Assessment chapter"
   roleAccent="assessment"
 >

--- a/docs/docs/reference/design-research.md
+++ b/docs/docs/reference/design-research.md
@@ -78,6 +78,8 @@ Green Goods uses a holistic framework for impact measurement:
 7. **Spiritual Capital**: Meaning, purpose
 8. **Cultural Capital**: Traditions, identity
 
+> The numbering above is presentational. The canonical machine ordering is the `Capital` enum — Social (0), Material (1), Financial (2), Living (3), Intellectual (4), Experiential (5), Spiritual (6), Cultural (7).
+
 **Origin**: From Ethan Roland and Gregory Landua's work in regenerative design.
 
 **Application in Green Goods**:
@@ -123,7 +125,7 @@ Green Goods uses a holistic framework for impact measurement:
 
 **Who she is**: Environmental researcher partnered with AgroforestDAO in Minas Gerais, Brazil. Evaluates garden impact seasonally, not daily. Comfortable with data queries and attestation chains. Needs structured rubrics that map to academic and compliance frameworks.
 
-**A day in her life**: At the end of the growing season, Dr. Chen logs into the evaluator view and reviews the past quarter's work submissions across 3 gardens. She creates an assessment using the Eight Forms of Capital rubric, scoring each capital dimension with evidence references. She exports the assessment data as CSV for her research paper and verifies the attestation chain to confirm nothing was tampered with since submission.
+**A day in her life**: At the end of the growing season, Dr. Chen logs into the evaluator view and reviews the past quarter's approved work across 3 gardens against each garden's assessment baseline. She scores the realized impact across the Eight Forms of Capital rubric with evidence references, exports the data as CSV for her research paper, and verifies the attestation chain to confirm nothing was tampered with since submission.
 
 **What success feels like**: "I have a publishable dataset with cryptographic provenance that I can cite in a peer-reviewed journal." The data export maps cleanly to her research methodology.
 

--- a/docs/docs/reference/glossary-community.md
+++ b/docs/docs/reference/glossary-community.md
@@ -48,7 +48,7 @@ The 10 entities the system tracks. Use the canonical form in code (types, hooks,
 | **Garden** | entity | admin · client · agent · public · docs | A community of gardeners doing regenerative work in a place. ERC-721 NFT bound to a Tokenbound Account that owns a Vault and operator/gardener Hats. |
 | **Action** | entity | admin · client · agent · public · docs | A documented activity a gardener can perform — the unit of work template (e.g. "Plant native species", "Remove invasive growth"). |
 | **Work** | entity | admin · client · agent · public · docs | A specific instance of an Action performed by a gardener, captured with photo + description + metadata, attested on-chain after operator approval. |
-| **Assessment** | entity | admin · client · public · docs | An evaluator's verification of submitted Work — confirms the Work happened, attaches confidence, links to evidence. Drives Hypercert minting. |
+| **Assessment** | entity | admin · client · public · docs | A garden's baseline and strategy, set up front (typically at onboarding): the domain, diagnosis, SMART-outcome targets, selected Actions, and reporting period that work is later measured against. It defines what success looks like *before* the work — it is **not** a review of submitted Work (that is Work Approval). |
 | **Hypercert** | entity | admin · client · public · docs | An on-chain claim of impact bundling approved Work into a fractional impact certificate. Funders hold fractions; gardeners hold contribution credit. |
 | **Vault** | entity | admin · client · public · docs | The garden's treasury. Funders deposit; the garden's Tokenbound Account holds; yield splits flow to operators / gardeners / community per configured ratios. |
 | **Cookie Jar** | entity | admin · client · public · docs | A garden-scoped emergency or discretionary fund with rate-limited withdrawals. Allowlisted members can claim within the configured cap. |
@@ -178,11 +178,17 @@ The structured tables above are the canonical vocabulary contract. The longer en
 ### Action
 A task or bounty available for gardeners to complete within a garden. Actions define specific regenerative activities (like planting trees, litter cleanup, or biodiversity surveys) with clear instructions, metrics, and optional time windows. Each action is registered on-chain and tracks completion statistics.
 
+### Assessment
+A garden's baseline and strategy, created up front (typically at onboarding): the domain, a diagnosis of the current situation, SMART-outcome targets, the selected actions, and the reporting period. It sets what success looks like *before* the work it frames, so that later work approvals and impact certificates have a baseline to measure against. It is not a review of submitted work — that is [Work Approval](#work-approval).
+
 ### Attestation
 An on-chain record created using the Ethereum Attestation Service (EAS). Green Goods uses three attestation types: work submissions, work approvals, and garden assessments. Attestations are permanent, cryptographically signed records that prove specific claims about impact work.
 
 ### Community Member
 Local residents living in the bioregion affected by a Garden's Work. Community Members use public signal and conviction flows to attest that Work exists and is healthy, hold the Garden accountable, and prioritize future Actions.
+
+### Domain
+The category of regenerative work a garden does — *where* the work happens. Green Goods recognizes four action domains: **Agroforestry**, **Waste Management**, **Solar (Hub Development)**, and **Education** (the on-chain `Domain` enum: `SOLAR`, `AGRO`, `EDU`, `WASTE`). A domain is neither an outcome nor a form of capital — carbon and biodiversity, for example, are [outcomes](#outcome), not domains.
 
 ### EAS (Ethereum Attestation Service)
 A protocol for making on-chain and off-chain attestations about any subject. Green Goods uses EAS to create verifiable records of gardener work, operator approvals, and garden assessments. Learn more at [attest.sh](https://attest.sh).
@@ -199,6 +205,8 @@ A holistic framework for measuring wealth and impact beyond money:
 8. **Cultural Capital**: Traditions and shared identity
 
 Green Goods assessments track impact across all eight capitals.
+
+> The numbering above is presentational. The canonical machine ordering is the `Capital` enum: Social (0), Material (1), Financial (2), Living (3), Intellectual (4), Experiential (5), Spiritual (6), Cultural (7).
 
 ### Evaluator
 Impact assessors who verify work quality, create garden assessments, and certify impact across the Eight Forms of Capital. Evaluators ensure that reported work meets quality standards and provide the trust layer between field operations and funding.
@@ -221,6 +229,9 @@ A semi-fungible token representing a claim of impact work. Hypercerts enable ret
 ### Impact Token
 A token representing verified impact work that can be traded, funded, or used to unlock benefits. Green Goods uses Karma GAP attestations as the foundation for impact tokenization. Impact Tokens are the broader concept; see [Hypercert](#hypercert) for the specific tokenized certificate implementation.
 
+### Indicator
+A measurable signal of progress toward an [outcome](#outcome) — the unit a metric is counted in (trees planted, kWh generated, kg diverted, participants verified).
+
 ### IPFS (InterPlanetary File System)
 A distributed file storage system. Green Goods stores work photos, metadata, and action instructions in IPFS through the Pinata-backed upload path, with content identifiers (CIDs) referenced in on-chain attestations.
 
@@ -238,6 +249,9 @@ This pattern ensures high-quality documentation and reduces submission errors.
 ### On-Chain
 Data or transactions permanently recorded on a blockchain. Green Goods stores attestations on-chain for verifiability, while larger data (photos, metadata) is stored off-chain in IPFS and referenced by on-chain records.
 
+### Outcome
+The change an impact claim asserts — what will change and by how much. In Green Goods, outcomes are the SMART targets set in an [assessment](#assessment) and filled by approved work over the reporting period. Outcomes accrue to the [Eight Forms of Capital](#eight-forms-of-capital); they are not [domains](#domain).
+
 ### Owner
 Administrators with full control over garden configuration, role assignments, and governance settings. Owners can promote gardeners to operators, configure actions, and manage the garden's on-chain infrastructure.
 
@@ -254,7 +268,7 @@ Smart contracts that execute custom logic when attestations are created. Green G
 A structured template that defines the format of an attestation. Green Goods uses three schemas:
 - **Work Submission Schema**: Captures gardener work with media and metadata
 - **Work Approval Schema**: Records operator validation decisions
-- **Assessment Schema**: Documents garden-level impact across 8 forms of capital
+- **Assessment Schema**: Records a garden's baseline strategy kernel — domain, diagnosis, SMART-outcome targets, selected actions, and reporting period — set up front, before the work it frames
 
 ### Smart Account (Account Abstraction)
 A smart contract-based wallet that enables gasless transactions, social recovery, and improved UX. Green Goods gardeners use Kernel smart accounts powered by Pimlico, allowing them to submit work without paying gas fees or managing seed phrases.


### PR DESCRIPTION
## What & why

Research for [RESR-6](https://linear.app/greenpill-dev-guild/issue/RESR-6) (the Impact-Claim Domain Taxonomy + Glossary v1) surfaced several places where the repo docs contradict production reality. This PR reconciles them. **Docs only — no code, schema, or product change.**

## The root cause (most important)

`docs/docs/reference/glossary-community.md` — the file that declares itself "the canonical vocabulary… every other doc, prompt contract, and lint rule references this file" — **defined Assessment as _"an evaluator's verification of submitted Work — confirms the Work happened, attaches confidence."_** That is **Work Approval's** job. Because everything grounds in this file, it propagated a wrong **assessment-after-work** order across the docs (and into agent output).

The actual lifecycle is **Assessment (baseline) → Work → Work Approval → Report**. The `assessment_v2` schema and `GardenAssessment` type carry `diagnosis`, `smartOutcomes` (forward-looking *targets*), `selectedActionUIDs`, and `reportingPeriod` — a strategy kernel set **up front at onboarding**, not a review of work.

## Changes

| File | Change |
|---|---|
| `docs/docs/reference/glossary-community.md` | Redefine **Assessment** entity as the up-front baseline & strategy; add a prose **Assessment** term entry; fix the **Assessment Schema** bullet; add canonical **Domain / Outcome / Indicator** entries; note the `Capital` enum order is the numbering authority. |
| `docs/docs/community/operator-guide/making-an-assessment.mdx` | Reword the tip to lead with assessment-first (baseline before the work it frames). |
| `docs/docs/reference/design-research.md` | Fix the evaluator persona vignette (was "creates an assessment at end of season scoring work" → reviews approved work **against the assessment baseline**); add the Capital enum-order note. |
| `docs/docs/builders/specs/v1-0.mdx` | Add a `:::note` banner to §3.4: the canonical set is **4 domains** (`SOLAR/AGRO/EDU/WASTE`); "Mutual Credit & Farmer Verification" was offered in Season-1 onboarding but never implemented (deferred build-vs-drop). Historical PRD text retained, not deleted. |
| `CLAUDE.md` ⚠️ | Fix the **Documentation** section — all five doc paths pointed at directories that don't exist (`docs/docs/developers/…`, `docs/docs/concepts/…`, `docs/docs/glossary.md`). Repointed to the real files. |

> ⚠️ **`CLAUDE.md` is a security-sensitive surface.** The only change is correcting five stale documentation paths in the "Documentation" section — no permissions, hooks, or behavioral rules touched.

## Intentionally left alone

- `docs/docs/builders/specs/greenwill-*-2026-03.md` — dated point-in-time audits that already flag the 4-vs-5 discrepancy ("the protocol enforces four"). Editing them would rewrite history; the live source (v1-0.mdx) is the one that needed the banner.
- `docs/docs/builders/integrations/entity-matrix.mdx` — uses "domain entities" in the glossary-entity sense; no domain-count error.

## Validation

- `bun run docs:audit:ci` → `docs-audit: no warnings`
- `bun run build:docs` → Docusaurus build compiled successfully (new admonition + cross-link anchors resolve)
- `bun format` → no fixes
- Commit is GPG-signed.

## Context

The full taxonomy artifact (the canonical domain vocabulary this PR reconciles toward) lives as a Linear document in the *Impact Framework v0.1 Refresh* project. This PR addresses only the in-repo documentation drift it revealed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
