### PR TITLE
ci(contracts): retry fork RPC calls

### DIFF
--- a/packages/contracts/script/utils/fork-shards.mjs
+++ b/packages/contracts/script/utils/fork-shards.mjs
@@ -8,7 +8,6 @@ const NO_MATCH_TEST = ".*[cC]elo.*|.*[uU]nlock.*";
 const DEFAULT_THREADS = "1";
 const DEFAULT_VERBOSITY = "-vvv";
 const DEFAULT_FORK_RETRIES = "5";
-const DEFAULT_FORK_RETRY_BACKOFF = "500";
 const DEFAULTS = {
   ARBITRUM_RPC_URL: "https://arbitrum-one.public.blastapi.io",
   ARBITRUM_FORK_BLOCK_NUMBER: "466388412",
@@ -104,7 +103,7 @@ function runForge(args, { profile = "fork", capture = false } = {}) {
 function commonArgs() {
   const verbosity = process.env.FORK_TEST_VERBOSITY || DEFAULT_VERBOSITY;
   const forkRetries = process.env.FORK_TEST_RETRIES || DEFAULT_FORK_RETRIES;
-  const forkRetryBackoff = process.env.FORK_TEST_RETRY_BACKOFF || DEFAULT_FORK_RETRY_BACKOFF;
+  const forkRetryBackoff = process.env.FORK_TEST_RETRY_BACKOFF;
   const args = [
     "--no-match-test",
     NO_MATCH_TEST,

--- a/packages/contracts/script/utils/fork-shards.mjs
+++ b/packages/contracts/script/utils/fork-shards.mjs
@@ -7,6 +7,8 @@ import { config as loadDotenv } from "dotenv";
 const NO_MATCH_TEST = ".*[cC]elo.*|.*[uU]nlock.*";
 const DEFAULT_THREADS = "1";
 const DEFAULT_VERBOSITY = "-vvv";
+const DEFAULT_FORK_RETRIES = "5";
+const DEFAULT_FORK_RETRY_BACKOFF = "500";
 const DEFAULTS = {
   ARBITRUM_RPC_URL: "https://arbitrum-one.public.blastapi.io",
   ARBITRUM_FORK_BLOCK_NUMBER: "466388412",
@@ -101,6 +103,8 @@ function runForge(args, { profile = "fork", capture = false } = {}) {
 
 function commonArgs() {
   const verbosity = process.env.FORK_TEST_VERBOSITY || DEFAULT_VERBOSITY;
+  const forkRetries = process.env.FORK_TEST_RETRIES || DEFAULT_FORK_RETRIES;
+  const forkRetryBackoff = process.env.FORK_TEST_RETRY_BACKOFF || DEFAULT_FORK_RETRY_BACKOFF;
   const args = [
     "--no-match-test",
     NO_MATCH_TEST,
@@ -108,6 +112,10 @@ function commonArgs() {
     process.env.FORK_TEST_THREADS || DEFAULT_THREADS,
     "--suppress-successful-traces",
   ];
+  if (forkRetries && forkRetries !== "0") {
+    args.push("--fork-retries", forkRetries);
+    if (forkRetryBackoff) args.push("--fork-retry-backoff", forkRetryBackoff);
+  }
   if (verbosity) args.push(verbosity);
   return args;
 }

--- a/packages/contracts/script/utils/fork-shards.mjs
+++ b/packages/contracts/script/utils/fork-shards.mjs
@@ -36,6 +36,7 @@ const SHARDS = {
     glob: "test/fork/{CrossChainENS,EthereumENSNameWrapper,EthereumENSReceiver}.t.sol",
   },
   gardens: {
+    chain: "ARBITRUM",
     description: "Mixed-chain Gardens V2 community governance and deployment registry fork coverage",
     glob: "test/fork/{DeploymentRegistryFork,gardens/GardensCommunityGovernance,gardens/GardensV2Community}.t.sol",
   },


### PR DESCRIPTION
## Summary
- Adds Foundry's built-in fork RPC retry flags to the existing fork-shard wrapper.
- Keeps the runner simple: no custom provider fallback, no workflow restructuring, no new scripts.
- Allows retries to be tuned with FORK_TEST_RETRIES / FORK_TEST_RETRY_BACKOFF or disabled with FORK_TEST_RETRIES=0.

## Validation
- [x] node --check packages/contracts/script/utils/fork-shards.mjs
- [x] bun script/utils/fork-shards.mjs manifest
- [x] FORK_TEST_RETRIES=0 bun script/utils/fork-shards.mjs manifest
- [x] git diff --check
- [x] pre-push checks passed (format + lint; existing warnings only)
- [ ] GitHub Actions fork-readiness rerun