### PR TITLE
UI/UX Wave E — documentation coherence (P6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ The `docs/` directory contains a Docusaurus site with product documentation, use
 - Domain glossary: `docs/docs/reference/glossary-community.md`
 - Impact model & Eight Forms of Capital: `docs/docs/reference/design-research.md`
 - Action domains, goals & schema registry: `docs/docs/builders/specs/v1-0.mdx`
-- Entity matrix: `docs/docs/builders/integrations/entity-matrix.mdx`
+- Entity matrix (⚠️ intentional draft — `unlisted`, `feature_status: Planned`; a vocabulary aid, not a canonical contract): `docs/docs/builders/integrations/entity-matrix.mdx`
 
 Package-specific context files (`.claude/context/*.md`) include additional documentation references relevant to each package.
 

--- a/docs/docs/builders/architecture.mdx
+++ b/docs/docs/builders/architecture.mdx
@@ -46,7 +46,7 @@ Green Goods is an **offline-first, single-chain** platform for documenting regen
 
 ## System context
 
-How all packages connect end-to-end: contracts emit events, the indexer materializes them into GraphQL, and frontends read through shared hooks.
+Green Goods is an offline-first, single-chain monorepo. Data flows in one direction: on-chain **contracts** emit events, the **indexer** (Envio) materializes those into GraphQL, and the **frontends** (Client PWA for gardeners, Admin Dashboard for operators) read everything through the **`@green-goods/shared`** hook layer — no frontend talks to a data source directly. The diagram below groups the packages into four colour-coded layers, top to bottom: frontends (green), the shared logic layer (blue), data sources (amber), and the on-chain contracts (pink). Read it as a dependency stack — each layer depends only on the one beneath it.
 
 ```mermaid
 graph TB

--- a/docs/docs/builders/specs/v1-0.mdx
+++ b/docs/docs/builders/specs/v1-0.mdx
@@ -184,7 +184,9 @@ The product architecture serves a 5-sided marketplace, ensuring checks and balan
 This v1.0 PRD specifies **five** action domains. Green Goods production implements **four**: **Solar (Hub Development)**, **Agroforestry**, **Education**, and **Waste Management** (the `Domain` enum `SOLAR · AGRO · EDU · WASTE`). **Domain 5 — Mutual Credit and Farmer Verification** was offered in Season-1 onboarding but never received an action set or an enum value; it remains a deferred *build-vs-drop* decision, not an implemented domain. The canonical domain vocabulary is the Impact-Claim Domain Taxonomy + Glossary v1 (Impact Framework v0.1 Refresh). The five-domain text below is retained as the original product record.
 :::
 
-Green Goods is not a generic impact tracking tool. It is purpose-built to capture and verify specific categories of regenerative work emerging from Greenpill Network chapters and aligned initiatives. The protocol optimizes for five core action domains that reflect where local communities are actively creating value.
+Green Goods is not a generic impact tracking tool. It is purpose-built to capture and verify specific categories of regenerative work emerging from Greenpill Network chapters and aligned initiatives.
+
+_The five domains below are the original v1.0 product record. Production ships four of them today — see the reconciliation note above; the enum is `SOLAR · AGRO · EDU · WASTE`. Read this section as the historical specification, not current behavior._ As originally specified, the protocol optimized for five core action domains reflecting where local communities were actively creating value.
 
 #### Domain 1: Solar Infrastructure (DePIN Pillar)
 

--- a/docs/docs/community/welcome.mdx
+++ b/docs/docs/community/welcome.mdx
@@ -125,6 +125,19 @@ Verified work flows through an attestation chain into **Hypercerts** (tokenized 
 
 ---
 
+## Find your path
+
+The docs are organized by who you are and what you came to do:
+
+| You are… | Start here |
+|---|---|
+| **A gardener or operator** running a garden | [How It Works](/community/how-it-works) → [Glossary](/glossary) for the vocabulary |
+| **A funder or evaluator** supporting impact | [Funder Guide](/community/funder-guide/getting-started) → [Why We Build](/community/why-we-build) |
+| **A builder or integrator** working with the protocol | [Builders: Getting Started](/builders/getting-started) → [Architecture](/builders/architecture) |
+| **New to the mission** and exploring | [Why We Build](/community/why-we-build) → this page's sections above |
+
+---
+
 <NextBestAction
   title="Next: How It Works"
   why="Now that you understand the platform, dive deeper into the technical workflows - MDR submissions, passkey onboarding, offline sync, and more."


### PR DESCRIPTION
Wave E of the [UI/UX & systems improvement plan](.plans/active/ui-ux-systems-audit/plan.md) — task P6. **Independent of the code stack** — targets develop directly (docs-only, no dependency on the sheet migration).

- **P6.1** — `v1-0.mdx`: the present-tense 5-domain narrative is fenced as the historical v1.0 product record. Production ships four domains (`SOLAR · AGRO · EDU · WASTE`, verified against `packages/shared/src/types/domain.ts`); the reconciliation note already documented the deferral of domain 5, and the section intro now reads as spec-record rather than current behavior.
- **P6.2** — `CLAUDE.md`: the entity-matrix citation is caveated as an intentional draft (`unlisted`, `feature_status: Planned`, self-described "not a canonical contract"). Left `unlisted` because the doc explicitly waits for a tracked source artifact — promoting it would be wrong.
- **P6.3 / P6.4** — verified already-correct (glossary Assessment is baseline-first and disambiguated from Work Approval; the capital presentational-vs-enum ordering note is present in `design-research.md`). No change.
- **P6.5** — `architecture.mdx` gains a 3-sentence intro explaining the one-directional data flow and the four colour-coded dependency layers (no separate legend — the subgraph titles already serve that role, a conscious cut per the plan's hedge). The docs home (`welcome.mdx`) gains a persona reader-routing table.

Docusaurus build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)