### PR TITLE
fix(admin): repair Storybook interaction assertions after #610/#613 dialog refactor

### DIFF
--- a/packages/admin/src/components/AdminDialog.stories.tsx
+++ b/packages/admin/src/components/AdminDialog.stories.tsx
@@ -354,9 +354,11 @@ export const FlowVariant: Story = {
       '[data-component="AdminDialog"][data-slot="surface"]'
     );
     await waitFor(() => expect(surface).not.toBeNull());
-    // Bounded, centered 2xl card driven by the flow variant — not a fullscreen takeover.
+    // Bounded, centered card driven by the flow variant — not a fullscreen takeover.
+    // The flow variant sizes itself through FLOW_SIZE; the size scale collapsed to
+    // sm/md/lg, so the surface reports the "lg" tier.
     await expect(surface).toHaveAttribute("data-variant", "flow");
-    await expect(surface).toHaveAttribute("data-size", "2xl");
+    await expect(surface).toHaveAttribute("data-size", "lg");
     // Single header: the flow variant suppresses AdminDialog's structured header
     // (data-slot="header"), so ActionFlowShell's header is the only title bar.
     await expect(surface?.querySelector('[data-slot="header"]')).toBeNull();
@@ -608,10 +610,14 @@ export const MobileSheetGeometry: Story = {
       await expect(closeRect.left).toBeGreaterThan(surfaceRect.left + surfaceRect.width / 2);
       // Sits above the scrollable body — does not overlap content.
       await expect(closeRect.bottom).toBeLessThanOrEqual(bodyRect.top + VIEWPORT_EDGE_TOLERANCE_PX);
-      // Headline reserves right padding so its text never runs under the button.
+      // Headline text stays clear of the absolute close button. Clearance now
+      // lives on the header row (pr-14 on the title bar), not on the title's own
+      // paddingRight, so assert the geometry directly: the title never extends
+      // under the close button.
       const title = within(surface).getByRole("heading", { name: /mobile bottom sheet/i });
-      await expect(Number.parseFloat(getComputedStyle(title).paddingRight)).toBeGreaterThanOrEqual(
-        36
+      const titleRect = title.getBoundingClientRect();
+      await expect(titleRect.right).toBeLessThanOrEqual(
+        closeRect.left + VIEWPORT_EDGE_TOLERANCE_PX
       );
     }
   },

--- a/packages/admin/src/components/Layout/CanvasLayout.stories.tsx
+++ b/packages/admin/src/components/Layout/CanvasLayout.stories.tsx
@@ -282,8 +282,10 @@ export const RealProviderShell: Story = {
     await userEvent.click(settingsTrigger ?? canvas.getByRole("button", { name: "Notifications" }));
     // The right sheet is retired — account/notification content now renders in
     // the AdminDialog inspector, which portals to document.body (role="dialog").
+    // Scope by accessible name: the shell can leave other portaled dialogs mounted,
+    // so target the inspector whose title matches, not just the first dialog.
     const body = within(document.body);
-    const inspector = await body.findByRole("dialog");
+    const inspector = await body.findByRole("dialog", { name: sheetHeading });
     await expect(within(inspector).getByRole("heading", { name: sheetHeading })).toBeVisible();
     await userEvent.click(within(inspector).getByRole("button", { name: "Close" }));
   },


### PR DESCRIPTION
## Summary

The admin-dialog quality passes #610 and #613 left three `storybook-ci` interaction assertions stale, turning the Design workflow's **Storybook** check red on develop's head. Because Storybook is a required CI Gate check that runs the full story suite, this blocks the gate for **every** open PR (confirmed: copy PR #611 and docs PR #612 both inherit it). Story-only fixes; all three keep their original invariants.

- **AdminDialog "Flow Variant"** (`AdminDialog.stories.tsx`): the size scale collapsed to `sm/md/lg` (the `size` prop type no longer has `2xl`; the flow variant sizes via `FLOW_SIZE`). The surface reports `data-size="lg"`. Updated the assertion and comment.
- **AdminDialog "Mobile Sheet Geometry"**: close-button clearance moved from the title's `paddingRight` to the header row (`pr-14`, AdminDialog.tsx:268). Replaced the stale `paddingRight >= 36` check with a direct geometry assertion — the title never extends under the close button — so the real "text doesn't run under the button" invariant stays enforced.
- **CanvasLayout "Real Provider Shell"**: `findByRole("dialog")` grabbed the wrong (empty, hidden) portaled dialog the shell leaves mounted. Scoped the lookup to the inspector's accessible name (`sheetHeading`).

## Validation

Storybook interaction tests can't run in the fresh worktree (browser + build env), so this relies on the Design workflow's Storybook job in CI — the same job that reports the failures. Merging this greens develop's CI Gate and unblocks #611 and every other PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)