### PR TITLE
chore(contracts): renew realism mock-allowlist + modernize README links

### DIFF
--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -209,10 +209,10 @@ bun script/deploy.ts core --network sepolia --broadcast --force
 ---
 
 **📖 For detailed documentation, see:**
-- Full Deployment Guide: [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook)
-- Upgrade Guide: [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook)
-- Environment Setup: [Developer Quickstart](https://docs.greengoods.app/welcome/quickstart-developer)
-- Troubleshooting: [Developer Quickstart](https://docs.greengoods.app/welcome/quickstart-developer)
+- Full Deployment Guide: [Contracts Handbook](https://docs.greengoods.app/builders/deployments/contracts-deploy)
+- Upgrade Guide: [Contracts Handbook](https://docs.greengoods.app/builders/deployments/contracts-deploy)
+- Environment Setup: [Environment Management](https://docs.greengoods.app/builders/env-management)
+- Troubleshooting: [Getting Started](https://docs.greengoods.app/builders/getting-started)
 
 
 ## HatsModule Operational Notes
@@ -324,9 +324,9 @@ Green Goods integrates with the **Karma Grantee Accountability Protocol (GAP)** 
 - Identity-first security - all resolvers verify roles before any logic
 
 **Documentation:**
-- User Guide: [Karma GAP Integration](https://docs.greengoods.app/developer/karma-gap)
-- Implementation: [Karma GAP Integration](https://docs.greengoods.app/developer/karma-gap)
-- Upgrade Guide: [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook)
+- User Guide: [Karma GAP Integration](https://docs.greengoods.app/builders/integrations/karma)
+- Implementation: [Karma GAP Integration](https://docs.greengoods.app/builders/integrations/karma)
+- Upgrade Guide: [Contracts Handbook](https://docs.greengoods.app/builders/deployments/contracts-deploy)
 - KarmaLib Source: `src/lib/Karma.sol`
 - Interfaces: `src/interfaces/IKarmaGap.sol`
 
@@ -359,7 +359,7 @@ bun script/deploy.ts core --network sepolia --broadcast --update-schemas
 bun script/deploy.ts core --network sepolia --broadcast --force
 ```
 
-See the [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook) for schema versioning strategy and deployment troubleshooting.
+See the [Contracts Handbook](https://docs.greengoods.app/builders/deployments/contracts-deploy) for schema versioning strategy and deployment troubleshooting.
 
 ## Configuration
 
@@ -484,7 +484,7 @@ forge script script/Upgrade.s.sol:Upgrade \
   --network arbitrum --broadcast
 ```
 
-See the [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook) for the complete upgrade guide.
+See the [Contracts Handbook](https://docs.greengoods.app/builders/deployments/contracts-deploy) for the complete upgrade guide.
 
 ### When to Deploy vs Upgrade
 
@@ -500,7 +500,7 @@ See the [Contracts Handbook](https://docs.greengoods.app/developer/contracts-han
 
 ### Documentation
 
-See the [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook) for the complete upgrade guide including:
+See the [Contracts Handbook](https://docs.greengoods.app/builders/deployments/contracts-deploy) for the complete upgrade guide including:
 - Deploy vs Upgrade decision matrix
 - Storage gap usage
 - Multisig upgrade process
@@ -843,12 +843,12 @@ echo $CELO_RPC_URL
 
 ## Documentation
 
-📖 **[Contracts Documentation](https://docs.greengoods.app/developer/architecture/contracts-package)** — Complete contracts architecture guide
+📖 **[Contracts Documentation](https://docs.greengoods.app/builders/packages/contracts)** — Complete contracts architecture guide
 
 **Essential Guides:**
-- 📘 [Contracts Handbook](https://docs.greengoods.app/developer/contracts-handbook) — Deployment, upgrades, schema management
-- 🏗️ [Architecture Overview](https://docs.greengoods.app/developer/architecture) — System design and package relationships
-- ✅ [Testing Guide](https://docs.greengoods.app/developer/testing) — Testing strategy and best practices
+- 📘 [Contracts Handbook](https://docs.greengoods.app/builders/deployments/contracts-deploy) — Deployment, upgrades, schema management
+- 🏗️ [Architecture Overview](https://docs.greengoods.app/builders/architecture) — System design and package relationships
+- ✅ [Testing Guide](https://docs.greengoods.app/builders/testing/forge) — Testing strategy and best practices
 
 **Configuration Files:**
 - 📝 [Schema Definitions](./config/schemas.json) — EAS schema configuration

--- a/packages/contracts/test/audit/mock-allowlist.json
+++ b/packages/contracts/test/audit/mock-allowlist.json
@@ -1,13 +1,13 @@
 {
   "version": 1,
-  "updated_at": "2026-04-21",
+  "updated_at": "2026-07-04",
   "entries": [
     {
       "file": "packages/contracts/test/fork/CrossChainENS.t.sol",
       "pattern": "vm.store",
       "reason": "ENS base node ownership cannot be transferred to ephemeral test accounts on public forks; vm.store is required to exercise receiver flow.",
       "owner": "contracts-core",
-      "expires_on": "2026-06-30",
+      "expires_on": "2026-09-30",
       "network_scope": ["mainnet"],
       "classification": "necessary",
       "replacement_recommendation": "Replace with delegated test-owned ENS test node when available."
@@ -17,7 +17,7 @@
       "pattern": "vm.store",
       "reason": "Mainnet ENS receiver tests require simulated control of greengoods.eth without private-key ownership in CI.",
       "owner": "contracts-core",
-      "expires_on": "2026-06-30",
+      "expires_on": "2026-09-30",
       "network_scope": ["mainnet"],
       "classification": "necessary",
       "replacement_recommendation": "Use a dedicated CI ENS node delegation path if introduced."


### PR DESCRIPTION
Contracts follow-up split out of docs PR #612, so the docs pass stayed decoupled from contracts CI.

## Realism mock-allowlist renewal

`packages/contracts/test/audit/mock-allowlist.json` had 2 `vm.store` entries (ENS fork tests) with `expires_on: 2026-06-30`. Once past, they fail the **Test Realism Audit** (`enforce-should-fix`) for **every** contracts-touching PR — this is what blocked #612's contracts README fix.

Decision: **renew, not retire.** Verified both mocks are still necessary:
- `test/fork/CrossChainENS.t.sol:193` and `test/fork/EthereumENSReceiver.t.sol:114` still use `vm.store` to grant ENS registry ownership of `greengoods.eth` (can't hold the real key in CI).
- No delegated-ENS replacement (the entries' `replacement_recommendation`) has landed.

Renewed to `2026-09-30` (short, one-quarter horizon so contracts-core re-reviews the checkpoint) and bumped `updated_at`. **@contracts-core** please re-confirm at next review.

## README link modernization

Fixed the stale `/developer/*` and `/welcome/*` doc links to their `/builders/*` equivalents. `…/developer/architecture/contracts-package` (line 846) was a true 404; the rest resolved only via fragile redirects. All 7 target pages verified to exist.

## Validation

- `CONTRACT_REALISM_MODE=enforce-should-fix bun run test:audit:realism` → **Must-fix 0 / Should-fix 0 / Nice-to-have 0** (was Should-fix 2, exit 1).
- No `/developer/` or `/welcome/` links remain in the README; JSON valid.
- develop's required contracts jobs (Unit Tests, Lint And Build, Test Realism Audit) were already green; this keeps them green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)