### PR TITLE
Admin design-system audit: close the 2 dialog-contract gaps + tone guard + guidance alignment

### DIFF
--- a/.claude/skills/ui/SKILL.md
+++ b/.claude/skills/ui/SKILL.md
@@ -61,17 +61,17 @@ The design identity (**restrained operator cockpit**, why-it's-different-from-cl
 
 UI-level implementation rules that follow from that identity:
 
-- **Layout default**: `PageHeader` → one primary workspace → optional secondary context in a sheet or rail. Start from layout and flow before reaching for `Card`.
+- **Layout default**: `CanvasRouteFrame` + `CanvasRouteHeader` → one primary workspace → secondary context and every detail/inspection flow in a centered `AdminDialog` (the side-sheet renderers are retired). Start from layout and flow before reaching for `Card`.
 - **Card usage**: cards and elevated surfaces are for records or bounded interactions, not the default page structure. Prefer one dominant workspace surface per route. Avoid nested stacks of rounded bordered panels.
 - **Tokens**: shared semantic tokens + one workspace accent. No decorative gradients behind routine product UI.
 - **Reference composition**: admin `/hub` route is the canonical cockpit layout — model new admin surfaces on it.
-- **Dialogs**: use `DialogShell` from `@green-goods/shared` by default; reserve `AdminDialog` for strict M3 flows (see Part 3).
+- **Dialogs**: use `AdminDialog` / `AdminConfirmDialog` for **every** admin dashboard dialog — pass the workspace `tone` (the portal escapes `[data-tone]`). `DialogShell` is for client PWA and shared (non-admin) surfaces only; never use it in admin (see Part 3 + [`design/prompt-contract.md § Overlays`](../design/prompt-contract.md)).
 
 ---
 
 ## Part 2: Component Development Workflow
 
-1. **Check existing patterns** (`CanvasLayout`, `AccountSurface`, `RightSheet`, `PageHeader`, `ListToolbar`, `SortSelect`, `Surface`, `Card`, `Alert`, `FormField`)
+1. **Check existing patterns** (`CanvasLayout`, `AccountSurface`, `AdminDialog`, `CanvasRouteFrame`/`CanvasRouteHeader`, `ListToolbar`, `SortSelect`, `Surface`, `Card`, `Alert`, `FormField`)
 2. **Develop reusable components in Storybook first** (`bun run storybook` in packages/shared)
 3. **Follow Radix UI + tailwind-variants patterns** (see [radix-ui.md](./radix-ui.md))
 4. **Run compliance checklist** before integration (see [compliance.md](./compliance.md))

--- a/.plans/active/uiux-followups/plan.md
+++ b/.plans/active/uiux-followups/plan.md
@@ -277,6 +277,17 @@ adjudicates ~7 latent runtime-bug candidates.
 > superseding this slice's `hub` assumption), CreateListing `garden`, Minting
 > `hub`, GardenDomainEditor `garden`. **This slice is fully superseded — do not
 > re-implement.** Slice 4's census pass should still re-verify tones live.
+>
+> **Audit addendum landed (2026-07-03, branch `fix/admin-design-system-contradictions`):**
+> a fresh design-system audit caught the two stragglers the quality pass missed and
+> closed them — Garden Settings dialog now guards dirty close (`useDirtyClose` route
+> mode + `DiscardChangesDialog` + `preventClose` while saving; editor reports
+> `onDirtyStateChange`), CampaignCookieJarPanel manage dialog gained
+> `tone="community"` + `preventClose` during sync/metadata mutations. The
+> `AdminDialogStandard.guard` now also enforces tone presence on every non-exempt
+> `<AdminDialog` site (allowlist: AdminConfirmDialog wrapper, CommandPalette), so
+> the #613 tone work can't silently regress. Stale guidance aligned in the same
+> pass (ui/SKILL.md dialog default + pattern list, CLAUDE.md palette line).
 
 Branch `fix/admin-dialog-tone-and-hidden-close`. Two small, related admin-dialog touches.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -208,7 +208,7 @@ Full skills: `design` (direction) + `ui` (implementation). Load explicitly when 
 - Client only: `operator cockpit`, `utility copy`, `KPI tile`, `dashboard`, `Plus Jakarta Sans`.
 
 **Component palettes** (do not invent component names — flag missing primitives instead):
-- Admin: 13 `Admin*` wrappers + `CanvasLayout` / `AppBar` / `MainSheet` / `LeftSheet` / `RightSheet` / `BottomSheet` / `NavigationBar` / `AdminFab`. Full list: `.claude/skills/design/prompt-contract.md § Canonical Component Palette`.
+- Admin: the `Admin*` M3 wrappers (filesystem is the count of record) + `CanvasLayout` / `AppBar` / `MainSheet` / `ActionFlowShell` / `NavigationBar` / `AdminFab`; every overlay is a centered `AdminDialog` (side sheets retired). Full list: `.claude/skills/design/prompt-contract.md § Canonical Component Palette`.
 - Client: `@green-goods/shared` primitives + presentation-mode loaders / `PublicShell` / `PwaRuntime` / `AppShell` / `SiteHeader` / `AppBar`. Full list: `.claude/skills/design/client-prompt-contract.md § Canonical Component Palette`.
 
 **Validation**: `bun run check:design-md` (root + dialect DesignMD lint) · `bun run check:design-generated` (DesignMD generated artifacts) · `bun run check:design-tokens` (spec ↔ theme.css drift + version coupling) · `bun run lint:vocab` (banned terms). When a component, story, or Storybook-covered surface changes, also run `bun run --filter @green-goods/shared check:stories` and `bun run --filter @green-goods/shared check:story-quality`.

--- a/packages/admin/src/__tests__/components/AdminDialogStandard.guard.test.ts
+++ b/packages/admin/src/__tests__/components/AdminDialogStandard.guard.test.ts
@@ -16,14 +16,38 @@ import { describe, expect, it } from "vitest";
  *   2. no consumer smuggles an ad-hoc `max-w-*` width override through
  *      `className` (the only sanctioned width override is the shared
  *      ADMIN_FLOW_DIALOG_CLASS constant),
- *   3. every `variant="flow"` dialog uses ADMIN_FLOW_DIALOG_CLASS, and
+ *   3. every `variant="flow"` dialog uses ADMIN_FLOW_DIALOG_CLASS,
  *   4. the guard's own idea of the scale stays anchored to the source of
  *      truth (sizeClasses in AdminDialog.tsx) — adding a tier fails here
- *      first, forcing the contract doc + this guard to move together.
+ *      first, forcing the contract doc + this guard to move together, and
+ *   5. every consumer re-establishes the workspace tone (the dialog portals
+ *      to <body>, escaping CanvasLayout's [data-tone] scope — an omitted
+ *      tone silently falls back to the neutral accent; the 2026-07 audit
+ *      caught exactly one such straggler after the #613 tone pass).
  */
 
 const ADMIN_SRC = join(__dirname, "..", "..");
 const VALID_SIZES = new Set(["sm", "md", "lg"]);
+const VALID_TONES = new Set(["hub", "garden", "community", "actions", "home"]);
+
+/**
+ * Files whose `<AdminDialog` sites are deliberately neutral — the only
+ * sanctioned omissions of the tone prop. Everything else must declare where
+ * it lives.
+ */
+const TONE_EXEMPT_FILES = [
+  // AdminConfirmDialog wrapper: confirms are transient alerts riding the
+  // neutral default by design (DiscardChanges, destructive confirms).
+  "components/AdminDialog.tsx",
+  // Command palette: global chrome available from every workspace — neutral
+  // by design (variant="palette").
+  "components/Layout/CommandPalette.tsx",
+];
+
+function isToneExempt(filePath: string): boolean {
+  const normalized = filePath.split("\\").join("/");
+  return TONE_EXEMPT_FILES.some((exempt) => normalized.endsWith(exempt));
+}
 
 function collectTsxFiles(dir: string): string[] {
   const out: string[] = [];
@@ -141,6 +165,24 @@ export function collectViolations(source: string, filePath: string): string[] {
       );
     }
 
+    // Tone (prompt-contract § Dialog size & variant standard): the dialog
+    // portals out of the [data-tone] scope, so every non-exempt consumer must
+    // pass tone explicitly — a literal from the shipped set, or an expression
+    // (descriptor bridges resolve tone dynamically).
+    if (!isToneExempt(filePath)) {
+      const toneLiteral = tag.match(/\btone="([^"]*)"/);
+      const hasToneExpression = /\btone=\{/.test(tag);
+      if (!toneLiteral && !hasToneExpression) {
+        violations.push(
+          `${where} — no tone prop; the dialog portals out of [data-tone], so omitting tone silently falls back to the neutral accent (pass the workspace tone, or allowlist a deliberately-neutral file in TONE_EXEMPT_FILES)`
+        );
+      } else if (toneLiteral && !VALID_TONES.has(toneLiteral[1])) {
+        violations.push(
+          `${where} — tone="${toneLiteral[1]}" is outside the shipped set (hub|garden|community|actions|home)`
+        );
+      }
+    }
+
     // Interior grammar (dialog quality pass) 5: the AdminDialog `actions`
     // slot already renders the pinned SheetFooter anatomy, so a non-flow
     // dialog that passes `actions` AND nests a <SheetFooter in the same file
@@ -186,13 +228,13 @@ describe("AdminDialog size/variant standard", () => {
 
   it("detects seeded violations (self-check)", () => {
     const seeded = `
-      <AdminDialog open size="xl" title="bad">
-      <AdminDialog open size={wide ? "2xl" : "lg"} title="bad">
-      <AdminDialog open size={dynamicSize} title="bad">
-      <AdminDialog open className="p-0 max-w-5xl" title="bad">
-      <AdminDialog open variant="flow" title="bad">
-      <AdminDialog open size="lg" variant="flow" className={ADMIN_FLOW_DIALOG_CLASS} title="good">
-      <AdminDialog open size="md" onOpenChange={(next) => { if (!next) close(); }} title="good">
+      <AdminDialog open size="xl" tone="hub" title="bad">
+      <AdminDialog open size={wide ? "2xl" : "lg"} tone="hub" title="bad">
+      <AdminDialog open size={dynamicSize} tone="hub" title="bad">
+      <AdminDialog open className="p-0 max-w-5xl" tone="hub" title="bad">
+      <AdminDialog open variant="flow" tone="hub" title="bad">
+      <AdminDialog open size="lg" variant="flow" tone="hub" className={ADMIN_FLOW_DIALOG_CLASS} title="good">
+      <AdminDialog open size="md" tone="hub" onOpenChange={(next) => { if (!next) close(); }} title="good">
     `;
     const violations = collectViolations(seeded, "seed.tsx");
     expect(violations).toHaveLength(5);
@@ -201,6 +243,26 @@ describe("AdminDialog size/variant standard", () => {
     expect(violations.join("\n")).toContain("dynamically");
     expect(violations.join("\n")).toContain("max-w-*");
     expect(violations.join("\n")).toContain("ADMIN_FLOW_DIALOG_CLASS");
+  });
+
+  it("detects seeded tone violations (self-check)", () => {
+    // Missing tone on a non-exempt file → violation.
+    const missing = `<AdminDialog open size="md" title="bad">`;
+    expect(collectViolations(missing, "views/Bad.tsx").join("\n")).toContain("no tone prop");
+
+    // Out-of-set literal → violation.
+    const invalid = `<AdminDialog open size="md" tone="brand" title="bad">`;
+    expect(collectViolations(invalid, "views/Bad.tsx").join("\n")).toContain(
+      'tone="brand" is outside the shipped set'
+    );
+
+    // Expressions are fine — descriptor bridges resolve tone dynamically.
+    const expression = `<AdminDialog open size="lg" tone={config?.tone ?? fallbackTone} title="good">`;
+    expect(collectViolations(expression, "components/Layout/CanvasLayout.tsx")).toEqual([]);
+
+    // Deliberately-neutral files are exempt.
+    const palette = `<AdminDialog open variant="palette" title="palette">`;
+    expect(collectViolations(palette, "components/Layout/CommandPalette.tsx")).toEqual([]);
   });
 
   it("detects seeded interior-grammar violations (self-check)", () => {
@@ -212,7 +274,7 @@ describe("AdminDialog size/variant standard", () => {
     );
 
     // Flow dialogs own their chrome via ActionFlowShell — SheetFooter is fine.
-    const flowSeed = `<AdminDialog open size="lg" variant="flow" className={ADMIN_FLOW_DIALOG_CLASS} title="x">
+    const flowSeed = `<AdminDialog open size="lg" variant="flow" tone="hub" className={ADMIN_FLOW_DIALOG_CLASS} title="x">
       <SheetFooter>flow footer</SheetFooter>
     </AdminDialog>`;
     expect(collectViolations(flowSeed, "views/Flow.tsx")).toEqual([]);

--- a/packages/admin/src/components/Garden/GardenSettingsEditor.tsx
+++ b/packages/admin/src/components/Garden/GardenSettingsEditor.tsx
@@ -50,6 +50,12 @@ interface GardenSettingsEditorProps {
    * carries upload/remove controls only, never a second image.
    */
   onBannerPreviewChange?: (preview: GardenBannerPreview) => void;
+  /**
+   * Reports draft dirtiness and save-in-flight so the hosting dialog can
+   * guard its close (confirm-before-discard when dirty, hard-block while
+   * saving) — the form owns the draft, the dialog owns the close.
+   */
+  onDirtyStateChange?: (state: { isDirty: boolean; isSaving: boolean }) => void;
 }
 
 interface SettingsDraft {
@@ -91,6 +97,7 @@ export function GardenSettingsEditor({
   canManage,
   isOwner,
   onBannerPreviewChange,
+  onDirtyStateChange,
 }: GardenSettingsEditorProps) {
   const { formatMessage } = useIntl();
 
@@ -174,6 +181,10 @@ export function GardenSettingsEditor({
   useEffect(() => {
     onBannerPreviewChange?.({ src: previewSrc || null, isDraft: bannerIsDraft });
   }, [bannerIsDraft, onBannerPreviewChange, previewSrc]);
+
+  useEffect(() => {
+    onDirtyStateChange?.({ isDirty, isSaving });
+  }, [isDirty, isSaving, onDirtyStateChange]);
 
   const handleCancel = () => {
     setDraft(draftFromGarden(garden));

--- a/packages/admin/src/views/Cookies/components/CampaignCookieJarPanel.tsx
+++ b/packages/admin/src/views/Cookies/components/CampaignCookieJarPanel.tsx
@@ -1951,6 +1951,8 @@ export function CampaignCookieJarPanel() {
             "Review the public link, update campaign metadata, and sync garden operator access.",
         })}
         size="lg"
+        tone="community"
+        preventClose={syncAllowlist.isPending || updateMetadata.isPending}
         actions={
           <>
             <AdminButton type="button" variant="text" onClick={() => setSelectedCampaign(null)}>

--- a/packages/admin/src/views/Garden/components/GardenWorkspaceContent.tsx
+++ b/packages/admin/src/views/Garden/components/GardenWorkspaceContent.tsx
@@ -2,6 +2,7 @@ import {
   type Address,
   EmptyState,
   type AdminWorkspaceSectionTab,
+  useDirtyClose,
   type useGardenWorkspaceController,
 } from "@green-goods/shared";
 import { AdminCard } from "@/components/AdminCard";
@@ -10,6 +11,7 @@ import { useState } from "react";
 import { useIntl } from "react-intl";
 import { AdminButton } from "@/components/AdminButton";
 import { AdminDialog } from "@/components/AdminDialog";
+import { DiscardChangesDialog } from "@/components/DiscardChangesDialog";
 import { GardenDomainModal } from "@/components/Garden/GardenDomainEditor";
 import { GardenMetadata } from "@/components/Garden/GardenMetadata";
 import {
@@ -37,6 +39,20 @@ export function GardenWorkspaceContent({ workspace }: GardenWorkspaceContentProp
   // Jar management is garden configuration — it opens from this dialog
   // (moved off the Community payout surface, which keeps deposits/withdrawals).
   const [cookieJarsOpen, setCookieJarsOpen] = useState(false);
+  // The settings form reports dirtiness/saving up so this dialog can guard its
+  // close per the dialog contract (confirm-before-discard, hard-block during
+  // save). Gated on the settings view so a stale report can't block later
+  // navigation after the dialog is gone.
+  const [settingsForm, setSettingsForm] = useState({ isDirty: false, isSaving: false });
+  const settingsOpen = workspace.view === "settings";
+  // The dialog closes by navigating (handleTabChange → navigate), so route
+  // mode makes the router blocker the single confirm trigger — X, scrim,
+  // Escape, back button, and nav links raise one prompt, never two.
+  const settingsDirtyClose = useDirtyClose({
+    isDirty: settingsOpen && settingsForm.isDirty,
+    onClose: () => workspace.handleTabChange("overview"),
+    blockRouteChange: true,
+  });
 
   if (!workspace.selectedGarden) {
     return (
@@ -118,10 +134,9 @@ export function GardenWorkspaceContent({ workspace }: GardenWorkspaceContentProp
           rendered over the Overview behind it. Deep-linking to /garden/settings
           opens it directly; closing returns to the Overview. */}
       <AdminDialog
-        open={workspace.view === "settings"}
-        onOpenChange={(open) => {
-          if (!open) workspace.handleTabChange("overview");
-        }}
+        open={settingsOpen}
+        onOpenChange={settingsDirtyClose.onOpenChange}
+        preventClose={settingsForm.isSaving}
         size="lg"
         tone="garden"
         title={formatMessage({
@@ -148,6 +163,7 @@ export function GardenWorkspaceContent({ workspace }: GardenWorkspaceContentProp
             canManage={workspace.canManage}
             isOwner={workspace.isOwner}
             onBannerPreviewChange={setBannerPreview}
+            onDirtyStateChange={setSettingsForm}
           />
 
           <div className="space-y-4">
@@ -243,6 +259,11 @@ export function GardenWorkspaceContent({ workspace }: GardenWorkspaceContentProp
           </div>
         </div>
       </AdminDialog>
+      <DiscardChangesDialog
+        open={settingsDirtyClose.confirmOpen}
+        onKeepEditing={settingsDirtyClose.cancelClose}
+        onDiscard={settingsDirtyClose.confirmClose}
+      />
       {workspace.canManage ? (
         <GardenDomainModal
           isOpen={workspace.domainEditorOpen}

--- a/packages/admin/src/views/Garden/garden-domain-ui.test.tsx
+++ b/packages/admin/src/views/Garden/garden-domain-ui.test.tsx
@@ -1,9 +1,9 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { IntlProvider } from "react-intl";
-import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MemoryRouter, Route, RouterProvider, Routes, createMemoryRouter } from "react-router-dom";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import enMessages from "../../../../shared/src/i18n/en.json";
 import { useGardenWorkspaceController } from "@green-goods/shared";
@@ -13,18 +13,31 @@ import { SubmitWorkPanel } from "./SubmitWork";
 
 const gardenAddress = "0xAbCdEf1234567890aBcDeF1234567890aBcDeF12";
 
-const { mockCanManageGarden } = vi.hoisted(() => ({
+const { mockCanManageGarden, settingsEditorProbe } = vi.hoisted(() => ({
   mockCanManageGarden: vi.fn(() => true),
+  // Captures the dirty-state reporter the workspace passes to the (mocked)
+  // settings editor, so tests can drive the dialog's close guard directly.
+  settingsEditorProbe: {
+    reportDirtyState: undefined as
+      | undefined
+      | ((state: { isDirty: boolean; isSaving: boolean }) => void),
+  },
 }));
 
 vi.mock("@green-goods/shared", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@green-goods/shared")>();
   const React = await import("react");
+  const Router = await import("react-router-dom");
 
   return {
     ...actual,
     useGardenWorkspaceController: () => {
       const [domainEditorOpen, setDomainEditorOpen] = React.useState(false);
+      // Route-faithful stub: the real controller derives the view from the
+      // pathname and closes the settings dialog by navigating — the dirty-close
+      // guard's router blocker only exists on that navigation path.
+      const navigate = Router.useNavigate();
+      const location = Router.useLocation();
       return {
         activityFilter: "all",
         assessments: [],
@@ -71,7 +84,8 @@ vi.mock("@green-goods/shared", async (importOriginal) => {
         gardenAddress,
         gardenOptions: [],
         handleSelectGarden: vi.fn(),
-        handleTabChange: vi.fn(),
+        handleTabChange: (nextView: string) =>
+          navigate(nextView === "settings" ? "/garden/settings" : "/garden/overview"),
         hypercertId: undefined,
         hypercerts: [],
         hypercertSheetCloseTo: "/garden",
@@ -89,7 +103,7 @@ vi.mock("@green-goods/shared", async (importOriginal) => {
         setActivityFilter: vi.fn(),
         treasuryBalance: "0",
         updateOverviewQueryState: vi.fn(),
-        view: "settings",
+        view: location.pathname.endsWith("/settings") ? "settings" : "overview",
       };
     },
     useCanvasSearchParams: () => ({
@@ -190,7 +204,12 @@ vi.mock("@green-goods/shared", async (importOriginal) => {
 });
 
 vi.mock("@/components/Garden/GardenSettingsEditor", () => ({
-  GardenSettingsEditor: () => <div data-testid="garden-settings-editor" />,
+  GardenSettingsEditor: (props: {
+    onDirtyStateChange?: (state: { isDirty: boolean; isSaving: boolean }) => void;
+  }) => {
+    settingsEditorProbe.reportDirtyState = props.onDirtyStateChange;
+    return <div data-testid="garden-settings-editor" />;
+  },
 }));
 
 // The settings dialog also hosts the cookie-jar manage modal, whose
@@ -228,18 +247,29 @@ describe("garden domain recovery UI", () => {
     return <GardenWorkspaceContent workspace={workspace} />;
   }
 
+  // Data router (not <MemoryRouter>): the settings dialog's dirty-close guard
+  // uses useBlocker, which requires the data-router APIs — same pattern as
+  // CreateAssessmentDialog.test.tsx.
+  function renderWorkspaceAtSettings() {
+    const router = createMemoryRouter(
+      [
+        { path: "/garden/settings", element: <GardenWorkspaceHarness /> },
+        { path: "/garden/overview", element: <div>Overview route</div> },
+      ],
+      { initialEntries: ["/garden/settings"] }
+    );
+    render(
+      <TestProviders>
+        <RouterProvider router={router} />
+      </TestProviders>
+    );
+    return router;
+  }
+
   it("opens the existing domain editor from the garden settings Domains row", async () => {
     const user = userEvent.setup();
 
-    render(
-      <TestProviders>
-        <MemoryRouter initialEntries={["/garden/settings"]}>
-          <Routes>
-            <Route path="/garden/settings" element={<GardenWorkspaceHarness />} />
-          </Routes>
-        </MemoryRouter>
-      </TestProviders>
-    );
+    renderWorkspaceAtSettings();
 
     expect(screen.getByText("No domains configured")).toBeVisible();
 
@@ -247,6 +277,59 @@ describe("garden domain recovery UI", () => {
 
     expect(screen.getByRole("dialog", { name: "Edit Domains" })).toBeVisible();
     expect(screen.getByRole("button", { name: "Save domains" })).toBeVisible();
+  });
+
+  it("closes pristine garden settings straight to overview with no discard prompt", async () => {
+    const user = userEvent.setup();
+
+    renderWorkspaceAtSettings();
+
+    expect(screen.getByRole("dialog", { name: "Garden Profile" })).toBeVisible();
+
+    await user.keyboard("{Escape}");
+
+    expect(await screen.findByText("Overview route")).toBeVisible();
+    expect(screen.queryByText("Discard Changes?")).not.toBeInTheDocument();
+  });
+
+  it("prompts before discarding dirty garden settings and keeps editing on cancel", async () => {
+    const user = userEvent.setup();
+
+    renderWorkspaceAtSettings();
+    act(() => settingsEditorProbe.reportDirtyState?.({ isDirty: true, isSaving: false }));
+
+    await user.keyboard("{Escape}");
+
+    expect(await screen.findByText("Discard Changes?")).toBeVisible();
+
+    await user.click(screen.getByRole("button", { name: "Keep editing" }));
+
+    expect(screen.getByRole("dialog", { name: "Garden Profile" })).toBeVisible();
+    expect(screen.queryByText("Overview route")).not.toBeInTheDocument();
+  });
+
+  it("discards dirty garden settings to overview on confirm", async () => {
+    const user = userEvent.setup();
+
+    renderWorkspaceAtSettings();
+    act(() => settingsEditorProbe.reportDirtyState?.({ isDirty: true, isSaving: false }));
+
+    await user.keyboard("{Escape}");
+    await user.click(await screen.findByRole("button", { name: "Discard" }));
+
+    expect(await screen.findByText("Overview route")).toBeVisible();
+  });
+
+  it("hard-blocks closing garden settings while a save is in flight", async () => {
+    const user = userEvent.setup();
+
+    renderWorkspaceAtSettings();
+    act(() => settingsEditorProbe.reportDirtyState?.({ isDirty: true, isSaving: true }));
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.getByRole("dialog", { name: "Garden Profile" })).toBeVisible();
+    expect(screen.queryByText("Discard Changes?")).not.toBeInTheDocument();
   });
 
   it("shows the empty-domain status with an inline edit action for managers", () => {


### PR DESCRIPTION
## Summary

A fresh read-only design-system audit of the admin dashboard (2026-07-03, develop @ 1a61a887d) found the system healthy overall — all 7 machine gates green, dialog taxonomy conformant, glass/token/typography discipline holding. The drift that existed was six contradictions: two code-vs-contract gaps, three stale guidance lines, and one contract-vs-enforcement hole. This PR closes all six.

### Code (commit 1)

- **Garden Settings dialog now guards its close** (contract: "Action Surfaces Confirm Before Discarding"). `GardenSettingsEditor` reports `{isDirty, isSaving}` up via `onDirtyStateChange` (same lift pattern as `onBannerPreviewChange`); `GardenWorkspaceContent` wires route-mode `useDirtyClose` + `DiscardChangesDialog` (the dialog closes by navigating, so the router blocker is the single confirm trigger — X/scrim/Esc/back/nav-links, one prompt, never two) and `preventClose` while a save runs.
- **CampaignCookieJarPanel manage dialog** gains `tone="community"` (was silently neutral; everything in it is community-domain) and `preventClose` during the `syncAllowlist`/`updateMetadata` mutations — matching the treatment its `CookieJarManageModal` sibling got in #613.
- **Guard extension (closes the blind spot both bugs lived in):** `AdminDialogStandard.guard` rule 5 — every non-exempt `<AdminDialog` site must pass a tone from the shipped set (`hub|garden|community|actions|home`); expressions allowed (descriptor bridges); allowlist = AdminConfirmDialog wrapper + CommandPalette (deliberately neutral). The #613 tone pass can no longer regress silently.

### Docs (commit 2, standards separate from code per packages/admin/AGENTS.md)

- `ui/SKILL.md`: the Admin Cockpit Mode dialog line said *DialogShell by default for admin* — inverted since the 2026-04 migration and contradicting the skill's own Part 3 + the prompt contract. Re-anchored, along with the layout-default line and the Part 2 pattern list (`RightSheet` deleted in #607).
- `CLAUDE.md`: admin palette line said "13 Admin* wrappers" (15 on disk) and listed the three deleted sheet renderers; now defers to the filesystem/prompt-contract so the count can't drift again.
- `.plans/active/uiux-followups/plan.md`: Slice 3 annotated with this addendum.

## No-regression evidence (the explicit constraint for this change)

- Full adjacent dialog sweep at final code state: **13 test files / 65 tests green** (AdminDialogStandard.guard, AdminDialogInstantExit, AdminDialog, dialogCloseSafetyNet, AddMembersDialog, ManageMembersDialog, SubmitWorkDialog, GardenSettingsEditor, CookieJarManageModal, CookieJarPayoutPanel, CreateAssessmentDialog, CreateHypercertDialog, SubmitWork.submit).
- `garden-domain-ui`: **9/9** — 5 pre-existing (incl. the #614-fixed banner test) + 4 new dirty-close regressions (pristine close → no prompt; dirty → prompt → keep-editing preserves; dirty → discard → overview; saving → close hard-blocked). Harness moved to `createMemoryRouter` (useBlocker requires the data router — same pattern as CreateAssessmentDialog.test).
- Extended guard sweep across all admin source: green — proving zero other tone-less sites exist (the audit census cross-check).
- Gates at final state: `bun format` ✓ · `bun lint` ✓ · `check:design-tokens` (incl. token_version coupling 2.4.0) ✓ · `check:design-md` ✓.
- Not runtime-verified in authenticated Brave this session — the census pass 3 (uiux-followups Slice 4) re-verifies tones + close behavior live and should include these two dialogs.

## Security-sensitive surfaces touched

`CLAUDE.md` and `.claude/skills/ui/SKILL.md` (guidance only — the three stale lines above; no frontmatter/version changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)