### PR TITLE
Admin dialog review follow-ups: dirty-report test coverage + campaign Cancel mid-write guard

### DIFF
--- a/packages/admin/src/components/Garden/GardenSettingsEditor.test.tsx
+++ b/packages/admin/src/components/Garden/GardenSettingsEditor.test.tsx
@@ -205,6 +205,44 @@ describe("GardenSettingsEditor explicit save", () => {
     });
   });
 
+  it("reports the dirty state to the hosting dialog on edit and cancel", async () => {
+    const user = userEvent.setup();
+    const onDirtyStateChange = vi.fn();
+    renderEditor({ onDirtyStateChange });
+
+    expect(onDirtyStateChange).toHaveBeenLastCalledWith({ isDirty: false, isSaving: false });
+
+    const nameInput = screen.getByLabelText(/Name/);
+    await user.clear(nameInput);
+    await user.type(nameInput, "New Garden Name");
+
+    expect(onDirtyStateChange).toHaveBeenLastCalledWith({ isDirty: true, isSaving: false });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onDirtyStateChange).toHaveBeenLastCalledWith({ isDirty: false, isSaving: false });
+  });
+
+  it("reports save-in-flight so the hosting dialog can hard-block close", async () => {
+    const user = userEvent.setup();
+    const onDirtyStateChange = vi.fn();
+    renderEditor({ onDirtyStateChange });
+
+    const nameInput = screen.getByLabelText(/Name/);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Renamed Garden");
+    await user.click(screen.getByRole("button", { name: "Save changes" }));
+
+    await waitFor(() => {
+      expect(onDirtyStateChange).toHaveBeenCalledWith({ isDirty: true, isSaving: true });
+    });
+    await waitFor(() => {
+      expect(onDirtyStateChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ isSaving: false })
+      );
+    });
+  });
+
   it("blocks Save while the name is empty and explains why", async () => {
     const user = userEvent.setup();
     renderEditor();

--- a/packages/admin/src/views/Cookies/components/CampaignCookieJarPanel.tsx
+++ b/packages/admin/src/views/Cookies/components/CampaignCookieJarPanel.tsx
@@ -1955,7 +1955,15 @@ export function CampaignCookieJarPanel() {
         preventClose={syncAllowlist.isPending || updateMetadata.isPending}
         actions={
           <>
-            <AdminButton type="button" variant="text" onClick={() => setSelectedCampaign(null)}>
+            {/* Disabled while a write is in flight: the sync/metadata hooks
+                report errors inline, so a Cancel-close mid-write would render
+                the failure into a dialog nobody can see. */}
+            <AdminButton
+              type="button"
+              variant="text"
+              onClick={() => setSelectedCampaign(null)}
+              disabled={syncAllowlist.isPending || updateMetadata.isPending}
+            >
               {formatMessage({ id: "app.common.cancel", defaultMessage: "Cancel" })}
             </AdminButton>
             <AdminButton


### PR DESCRIPTION
## Summary

The two recommended fixes from the #617 post-merge review:

1. **GardenSettingsEditor dirty-report coverage (the review's should-fix).** The #617 dialog-guard regression tests exercise the close guard through a *mocked* editor; the real editor's reporting effect had no direct test. Two new tests in the editor's own suite pin the seam: `{isDirty:false}` on mount → `{isDirty:true}` on edit → clean again on Cancel, and `{isSaving:true}` during a save followed by `isSaving:false` — the exact signals the hosting dialog uses for confirm-before-discard and hard-block-while-saving.

2. **Campaign manage dialog Cancel guard (the review's nice-to-have).** `preventClose` (added in #617) gates X/scrim/Escape during the `syncAllowlist`/`updateMetadata` mutations, but the footer Cancel could still close mid-write — and those hooks use `errorMode: "inline"`, so a post-close failure would render into a dialog nobody can see. Cancel now disables while either mutation is pending, matching the Sync button beside it.

## Evidence

- `GardenSettingsEditor` + `AdminDialogStandard` suites: **14/14 green** (7 editor incl. 2 new, 5 guard — the guard re-sweeps the changed panel tag).
- `bun format` clean; no i18n, token, or doc surfaces touched.

Not runtime-verified in authenticated Brave — carried by the Slice 4 census like the rest of the dialog work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)