### PR TITLE
docs(claude): commitment pooling specs, corrections log, and plan hub

### DIFF
--- a/.plans/active/commitment-pooling/contract-spec.md
+++ b/.plans/active/commitment-pooling/contract-spec.md
@@ -1,0 +1,1295 @@
+# Commitment Pooling: Contract Spec
+
+**Feature Slug**: `commitment-pooling`
+**Stage**: `active`
+**Created**: 2026-07-03
+**Companions**: `corrections-log.md` (verified repo facts, exact UIDs and addresses), `uiux-spec.md` (surface flows), `plan.todo.md` (execution plan). This spec is the contract-layer source of truth for the August release build track.
+
+Every technical claim below carries a repo file path (relative to repo root) or a NET-NEW marker. All contract names, functions, events, and entities introduced here are NET-NEW unless a path says otherwise. Format mirrors the house implementation-spec style of `docs/docs/builders/specs/greenwill-gif-implementation-spec-2026-03.md` (Purpose, Scope, Canonical Implementation Decisions, System Components, per-contract Contract Work, Package-Level Backlog, Launch Milestones).
+
+---
+
+## 1. Purpose
+
+Translate the locked commitment-pooling architecture (27 decisions from the 2026-07-03 alignment session, plus the locked state machines and aggregate semantics from the Linear lifecycle doc) into PR-openable contract, deployment, and indexer work. An implementer should be able to open the first PR from this document without asking questions.
+
+The system lets gardens and the protocol run pools of commitments: offers and requests of concrete support, seeded into season or campaign cycles, claimed by members or gardens, evidenced through the existing Work and WorkApproval rails or lightweight evidence, confirmed by counterparties, and rolled up into promises-kept aggregates and fulfilled-commitment Hypercerts. Vocabulary is mutual aid throughout: offer, request, promise kept, fulfilled, steward, season, campaign, readiness, confirmation. No leaderboard semantics anywhere, ever.
+
+## 2. Scope
+
+### In scope
+
+- `CommitmentPoolingModule`: control plane for pools, cycles, commitments, confirmations, disputes, reward records (NET-NEW `packages/contracts/src/modules/CommitmentPooling.sol`).
+- `CommitmentRegister`: non-transferable ERC-1155-style unit accounting companion, functionally controlled by the module (NET-NEW `packages/contracts/src/registries/Commitment.sol`).
+- GardenToken wiring: one new module field, setter, event, gap 37 to 36, live 42161 UUPS upgrade (`packages/contracts/src/tokens/Garden.sol`).
+- WorkApprovalResolver bridge: optional non-blocking module hook on approval (`packages/contracts/src/resolvers/WorkApproval.sol`).
+- Exactly two new EAS schema registrations: assessment v3 and community testimony, each with a new resolver, registered via the standalone badge-schemas path (decision #14, #26).
+- Deployment plumbing: `DeployHelper.sol` result fields, `DeploymentBase.sol` helpers, artifact keys, storage-layout baselines.
+- Envio indexer plan: two new contract blocks, four new entities, one handler module; all locked stats derivable from module and register events alone.
+- Hypercert cut-over: `bundleKind` discriminator, fulfilled-commitment bundling, on-chain allocation-class bps at cycle open with app-computed allowlists.
+
+### Out of scope
+
+- Celo anything. Settlement contracts, settlement adapters beyond a reserved address field, voucher transfers, value custody, swap or redemption mechanics (Model B activates these later on the same poolId).
+- Sarafu integration or any reading of Sarafu source code (AGPL clean-room, decision #17; grounding is the Grassroots Economics paper and public docs only).
+- Bridging, G$ movement, GoodDollar rails (zero G$ references exist in production code, `corrections-log.md` H7).
+- Leaderboards, rankings, comparison views, countdown or streak mechanics of any kind.
+- A separate aggregator contract (PRD-649 locked: aggregates come from events, not an on-chain aggregator).
+- CookieJar contract changes (decision #18: rewards are declared references plus operator-executed payouts on existing rails).
+- Re-indexing EAS attestations (indexer boundary, `packages/indexer/schema.graphql:282-288`).
+
+## 3. Canonical Implementation Decisions
+
+Settled for v1 unless explicitly revised. Numbers in parentheses reference the locked decision register in the approved session plan.
+
+1. **Commitments are NOT EAS attestations** (#14). Commitment records are module-native storage plus events, shaped by the Grassroots Economics commitment-pooling register grammar. This supersedes Document A and the original PRD-649/650 "commitment schema + FulfillmentConfirmation resolver" language. EAS registrations shrink to exactly two: assessment v3 and community testimony.
+2. **Module-event-driven lifecycle because EAS is not indexed.** Envio indexes only Green Goods core contracts; EAS attestations are queried from easscan directly (`packages/indexer/schema.graphql:282-288`, `corrections-log.md` §2 Envio boundary row). Every commitment state and all four locked stats must be derivable from `CommitmentPoolingModule` and `CommitmentRegister` events alone.
+3. **Hybrid state weight** (#6). Hard transitions on-chain: pool register/ready/open/pause/close/compost, cycle seed/open/close/compost/cancel, commitment create (offer/request), accept, approved-work count, ReadyForConfirmation, confirm to Fulfilled, cancel, expire, dispute raise/resolve, reward record. Draft states live in app IndexedDB; Active, EvidenceSubmitted, PartiallyApproved, InProgress, Reviewing, and Reconciled are derived app/indexer-side from events. Full locked vocabulary is preserved across layers (section 5 table).
+4. **Two-contract shape** (#15, #16). `CommitmentPoolingModule` is the control plane (pool registry, cycles, curation, claim modes, permissions, stat events). `CommitmentRegister` is voucher-shaped, non-transferable, ERC-1155-style unit accounting so Model B settlement vouchers can wrap classes 1:1 on the same poolId later. Supersedes PRD-649's single-artifact V1 stance (user-approved). poolId semantics unchanged.
+5. **EAS bridge** (#5). `WorkApprovalResolver.onAttest` calls `module.onWorkApproved(...)` in try/catch (non-blocking, module optional), mirroring the existing GAP side effect (`packages/contracts/src/resolvers/WorkApproval.sol:179-183`). Operator-callable `syncApprovedWork` is the catch-up fallback. Work attestations cannot carry commitment refs (schema immutable, `corrections-log.md` H2), so linkage is module-side: claimant or operator links workUID to commitmentId before or after approval; the resolver hook only counts approvals for pre-linked workUIDs. Trust model: operator-curated linkage.
+6. **v3 authorship split** (#7). Baseline assessment: evaluator OR operator (analog capture preserved, matches today's `packages/contracts/src/resolvers/Assessment.sol:114-121`). Delta/re-assessment and technical assessment: Evaluator Hat only. Community testimony: Community Hat only (`packages/contracts/src/interfaces/IGardenAccessControl.sol:45` provides `isCommunity`).
+7. **Protocol pool = root garden pool** (#8). The root garden (`packages/contracts/deployments/42161-latest.json:40-43`: `0xf401f34378384713222d1d21f63359cc4E8a858a`, tokenId 1) anchors the protocol pool with `poolType = Protocol`. Cross-garden claiming: claimant is a GardenAccount or a hat-wearing individual; the claimant field is an address plus a ClaimType kind enum. Protocol-pool stewardship reuses root-garden Hats.
+8. **Rewards are references, not custody** (#18). A commitment carries a declared reward (source address, token, amount). On Fulfilled, the operator or protocol executes the payout on existing rails (jar, treasury) and records `RewardPaid` on the module. Zero CookieJar changes; jars remain pull-based (`packages/contracts/src/modules/CookieJar.sol:243-296`).
+9. **Claim mode per commitment** (#19). Open claim vs approval gated, set at seeding. App-level defaults: protocol pool prefills ApprovalGated, garden campaign commitments prefill Open. The module stores what is passed.
+10. **Lightweight evidence** (#20). `EvidenceAttached(commitmentId, cid, attacher)` module event, offline-queueable. For SupportService and OperatorCaptured commitments, counterparty confirmation IS the review; no separate approval step. DomainImpact keeps the full Work to WorkApproval path.
+11. **Schema registration is the first PR chain of the August track** (#26), via the standalone badge-schemas-style path (`packages/contracts/script/deploy/badge-schemas.ts`, `packages/contracts/script/DeployBadgeSchema.s.sol`), never via `--update-schemas` (which re-registers and overwrites all existing schema artifact keys, `packages/contracts/script/Deploy.s.sol:122-151`).
+12. **Allocation classes on-chain as bps at cycle open**. Six-role bps snapshot (gardeners, treasury, operator, evaluator, community, funder) validated to sum exactly 10000 (precedent: `InvalidSplitRatio`, `packages/contracts/src/resolvers/Yield.sol:107,373`), emitted in `CycleOpened`. Per-address allowlist expansion stays app-computed on the existing merkle pipeline (`corrections-log.md` §2 Hypercert row).
+13. **Post-MVP garden-to-garden is reserved, not implemented**. `counterpartyPoolId` and `counterpartyGardenAccount` exist as reserved struct fields (always zero in MVP) so the L3 amendment is additive.
+14. **Anti-farming posture from day one**: counterparty-first confirmation, self-confirmation blocked (mirrors `SelfAttestation`, `packages/contracts/src/resolvers/WorkApproval.sol:153-156`), operator fallback requires a visible reason, exposure caps in the register, dispute flag with operator resolution.
+
+## 4. System Components
+
+| Component | Responsibility | Location |
+|---|---|---|
+| `CommitmentPoolingModule` | pool registry, cycle lifecycle, commitment records and transitions, confirmations, disputes, work linkage, evidence events, reward records | NET-NEW `packages/contracts/src/modules/CommitmentPooling.sol` |
+| `ICommitmentPoolingModule` | canonical interface, enums, structs, events, errors | NET-NEW `packages/contracts/src/interfaces/ICommitmentPoolingModule.sol` |
+| `CommitmentRegister` | non-transferable unit classes, committed/fulfilled balances, quotas, exposure caps | NET-NEW `packages/contracts/src/registries/Commitment.sol` |
+| `ICommitmentRegister` | register interface | NET-NEW `packages/contracts/src/interfaces/ICommitmentRegister.sol` |
+| GardenToken wiring | module field + setter + mint callback | `packages/contracts/src/tokens/Garden.sol:27-34` (module fields), `181-227` (setter block), `421-456` (phase-2 integration callbacks) |
+| WorkApprovalResolver bridge | approval hook into module | `packages/contracts/src/resolvers/WorkApproval.sol:115-185` |
+| `AssessmentV3Resolver` | v3 authorship + baseline/delta validation | NET-NEW `packages/contracts/src/resolvers/AssessmentV3.sol` |
+| `CommunityTestimonyResolver` | Community-Hat-gated testimony validation | NET-NEW `packages/contracts/src/resolvers/CommunityTestimony.sol` |
+| Schema structs | decode layouts for the two new schemas | `packages/contracts/src/Schemas.sol` (append) |
+| Schema config | canonical field lists, new keys only | `packages/contracts/config/schemas.json` (append keys `assessmentV3`, `communityTestimony`) |
+| Deploy plumbing | CREATE2 proxies, wiring, artifacts | `packages/contracts/test/helpers/DeploymentBase.sol:257-338` (`_deployCorePart2`), `341-385` (`_wireModules`), `718-759` (`_deployCookieJarModule` template); `packages/contracts/script/DeployHelper.sol:42-72,276-347` |
+| Standalone schema deploy | two registrations + resolver deploys + artifact merge | NET-NEW `packages/contracts/script/DeployCommitmentSchemas.s.sol` + `packages/contracts/script/deploy/commitment-schemas.ts` (template: badge-schemas pair) |
+| Indexer | entities + handlers for pools, cycles, commitments, units | `packages/indexer/config.yaml`, `packages/indexer/schema.graphql`, NET-NEW `packages/indexer/src/handlers/commitmentPool.ts` |
+| Shared substrate | types, ABIs, hooks, job kinds (consumed by the UI/UX spec) | `packages/shared/src/types/job-queue.ts` (today exactly two kinds, `corrections-log.md` §6) |
+
+Module wiring follows the hub-and-spoke pattern: GardenToken holds the module address and calls it during mint inside try/catch so garden mint never reverts on module failure (`packages/contracts/src/tokens/Garden.sol:421-430` CookieJar precedent).
+
+## 5. State Machines: On-Chain Functions vs Derived States
+
+Locked vocabulary from the lifecycle doc is preserved in full. "On-chain" means a named module function performs the transition and emits the listed event. "Derived" means app/indexer computes the state from the listed events; the chain never stores it. Draft states exist only as IndexedDB drafts in the app (decision #6).
+
+### 5.1 Pool
+
+On-chain enum: `PoolState { None, NotReady, Ready, Open, Paused, Closed, Composted }`. Every pool state is on-chain (transitions are rare, operator console actions).
+
+| Transition | Layer | Mechanism |
+|---|---|---|
+| (create) -> NotReady | on-chain | `onGardenMinted(garden)` (GardenToken-only, idempotent) or `registerPool(garden, poolType)` (backfill + protocol pool). Event `PoolRegistered`. |
+| NotReady -> Ready | on-chain | `markPoolReady(poolId)`, requires non-empty charter CID. Event `PoolReady`. App enforces the readiness checklist (charter + baseline assessment) before offering the action. |
+| Ready -> Open | on-chain | `openPool(poolId)`. Event `PoolOpened`. |
+| Open <-> Paused | on-chain | `pausePool(poolId)` / `resumePool(poolId)`. Events `PoolPaused` / `PoolResumed`. |
+| Open or Paused -> Closed | on-chain | `closePool(poolId)`. Event `PoolClosed`. |
+| Closed -> Composted | on-chain | `compostPool(poolId)`. Event `PoolComposted`. |
+| Composted -> Ready or Open | on-chain | `reopenPool(poolId, toOpen)`. Event `PoolReopened`. |
+
+### 5.2 Cycle (types: Season, Campaign)
+
+On-chain enum: `CycleState { None, Seeded, Open, Reconciled, Composted, Cancelled }`. `Draft`, `InProgress`, and `Reviewing` are never stored on-chain.
+
+| Transition | Layer | Mechanism |
+|---|---|---|
+| Draft (exists) | off-chain | Admin IndexedDB draft. No chain state, no event. |
+| Draft -> Seeded | on-chain | `seedCycle(poolId, cycleType, startTime, endTime, metadataCID, allocation)`. Event `CycleSeeded`. |
+| Seeded -> Open | on-chain | `openCycle(cycleId)`. Event `CycleOpened` carries the six allocation-class bps (sum == 10000 validated at seed). |
+| Open -> InProgress | derived | Indexer/app: cycle is Open on-chain AND (first `CommitmentAccepted` with this cycleId OR block time >= startTime). |
+| InProgress -> Reviewing | derived | Indexer/app: cycle Open on-chain AND block time > endTime, OR all cycle commitments in terminal or ReadyForConfirmation states. |
+| Reviewing <-> InProgress | derived | New `EvidenceAttached` / `WorkLinked` / `ApprovedWorkCounted` on a cycle commitment while still Open on-chain flips back. |
+| Reviewing -> Reconciled | on-chain | `closeCycle(cycleId)` (the reconcile act). Event `CycleClosed`. Commitment-level `Reconciled` derivation hangs off this event (5.3). |
+| Reconciled -> Composted | on-chain | `compostCycle(cycleId)`. Event `CycleComposted`. |
+| Draft/Seeded/Open/InProgress -> Cancelled | on-chain for Seeded and Open (`cancelCycle(cycleId, reasonCID)`, event `CycleCancelled`); off-chain discard for Draft. InProgress is on-chain Open, so the same function covers it. |
+| Composted -> Draft/Seeded/Open (next cycle) | on-chain | A fresh `seedCycle` on the same pool. Succession is derived by pool ordering; no on-chain predecessor pointer. |
+
+### 5.3 Commitment
+
+On-chain enum: `CommitmentState { None, Offered, Requested, Accepted, ReadyForConfirmation, Fulfilled, Cancelled, Expired, Disputed }`. `Draft`, `Active`, `EvidenceSubmitted`, `PartiallyApproved`, and `Reconciled` are derived.
+
+| Transition | Layer | Mechanism |
+|---|---|---|
+| Draft (exists) | off-chain | Client/admin IndexedDB draft (offline-first). |
+| Draft -> Offered or Requested | on-chain | `createCommitment(params)`. Event `CommitmentCreated` (direction Offer or Request sets the initial state). |
+| Offered/Requested -> Accepted | on-chain | Open mode: `claimCommitment(...)` transitions immediately. ApprovalGated mode: `claimCommitment` emits `ClaimRequested` (state unchanged; "claim pending" is derived), then operator `acceptClaim(...)` transitions. Event `CommitmentAccepted`. Register records committed units (`UnitsCommitted`). |
+| Accepted -> Active | derived | First `WorkLinked` or `EvidenceAttached` after acceptance. |
+| Active -> EvidenceSubmitted | derived | Any `EvidenceAttached` or `WorkLinked` event. |
+| EvidenceSubmitted -> PartiallyApproved | derived | `ApprovedWorkCounted` events: 0 < approvedWorkCount < requiredApprovedWorkCount. |
+| PartiallyApproved <-> EvidenceSubmitted | derived | New evidence/work after partial approvals flips forward; the counter events flip back. |
+| -> ReadyForConfirmation | on-chain | Three paths, all emitting `CommitmentReadyForConfirmation`: (a) automatic inside `onWorkApproved`/`syncApprovedWork` when approvedWorkCount reaches requiredApprovedWorkCount and any declared assessment requirement is satisfied; (b) `submitForConfirmation(commitmentId)` for commitments with requiredApprovedWorkCount == 0 (SupportService/OperatorCaptured review-is-confirmation path; requires >= 1 evidence); (c) `markReadyForConfirmation(commitmentId, reason)` operator/owner override, reason emitted (overrides stay visible, per the locked work-approval gates). |
+| ReadyForConfirmation -> Fulfilled | on-chain | `confirmFulfillment(commitmentId)` by a named confirmer (or the counterparty under the default rule); each confirmation emits `ConfirmationRecorded`; reaching threshold N emits `CommitmentFulfilled`. Self-confirmation blocked. Fallback: `confirmFulfillmentAsFallback(commitmentId, reason)` operator/owner with mandatory reason. Register converts units (`UnitsFulfilled`). |
+| Fulfilled -> Reconciled | derived | `CycleClosed` for the commitment's cycleId; cycle-less commitments (cycleId == 0) derive Reconciled from `PoolClosed`. |
+| -> Cancelled | on-chain | `cancelCommitment(commitmentId, reasonCID)` from Offered/Requested (creator or steward) and Accepted (steward only; derived Active/PartiallyApproved are on-chain Accepted). Event `CommitmentCancelled`. Register releases units (`UnitsReleased`). Not allowed from ReadyForConfirmation except via dispute resolution. |
+| -> Expired | on-chain | `expireCommitment(commitmentId)`, permissionless, allowed once block time > dueDate (or the cycle endTime when dueDate == 0), from Offered/Requested/Accepted/ReadyForConfirmation. Event `CommitmentExpired`. Register releases units. |
+| -> Disputed | on-chain | `raiseDispute(commitmentId, reasonCID)` from Accepted/ReadyForConfirmation/Expired (the locked EvidenceSubmitted/PartiallyApproved entries map to on-chain Accepted). Raiser: creator, counterparty, named confirmer, or steward. Event `CommitmentDisputed`. |
+| Disputed -> ReadyForConfirmation / Fulfilled / Cancelled / Expired / Reconciled | on-chain | `resolveDispute(commitmentId, resolution, reasonCID)` steward-only. Event `DisputeResolved`. Resolution to Reconciled allowed only when the commitment's cycle is already Reconciled on-chain. |
+| Cancelled/Expired -> Reconciled at cycle close | derived | `CycleClosed` event; no on-chain per-commitment write (no unbounded loops at close). |
+
+Fulfillment posture (locked): counterparty-first, self-confirmation blocked, operator/owner fallback with reason.
+
+## 6. Contract Work
+
+### 6.1 `CommitmentPoolingModule`
+
+#### Objective
+
+One UUPS module that owns the whole commitment-pooling control plane: durable poolId per garden, cycle lifecycle, module-native commitment records, confirmations, disputes, EAS work-approval bridging, evidence and reward events.
+
+#### Responsibilities
+
+- Register exactly one pool per garden account (idempotent), including the protocol pool anchored to the root garden.
+- Drive the three state machines exactly as tabled in section 5, emitting one event per hard transition.
+- Hold commitment records: requirement fields, confirmer rule (address[] + threshold N), assessment UID ref, declared reward, claim mode, due date, unit label + target quantity, required approved-work count, reserved counterparty-pool fields.
+- Enforce Hats-based permissions per function (gating table below) via the garden-scoped operator check copied from `packages/contracts/src/modules/Hypercerts.sol:282-287`.
+- Verify EAS attestations (work, approval, assessment) via `_eas.getAttestation` when linking or syncing, with schema UID checks (zero-bypass convention matching `packages/contracts/src/resolvers/Work.sol:59-66`).
+- Call the `CommitmentRegister` for every unit-count change (commit, release, fulfill).
+
+#### Scaffold conventions (copied, not invented)
+
+- `UUPSUpgradeable + OwnableUpgradeable + ReentrancyGuardUpgradeable`, `_disableInitializers()` constructor, initializer with owner transfer: template `packages/contracts/src/modules/CookieJar.sol:17-115`.
+- `onlyGardenToken`-style authorized-caller modifier for the mint callback: `packages/contracts/src/modules/CookieJar.sol:65-68`.
+- Steward gate `_requirePoolSteward(poolId)` resolves `pools[poolId].garden` and applies `hatsModule.isOperatorOf || isOwnerOf`, falling back to module owner: copy of `_requireOperator` in `packages/contracts/src/modules/Hypercerts.sol:282-287`. For the protocol pool this resolves to root-garden Hats, so the protocol team stewards it by wearing root-garden Operator hats (decision #7).
+- Graceful mint integration: GardenToken wraps `onGardenMinted` in try/catch (`packages/contracts/src/tokens/Garden.sol:421-430` pattern); the module itself is idempotent like `packages/contracts/src/modules/CookieJar.sol:138-141`.
+
+#### Storage layout (slot accounting)
+
+Named storage entries, in declaration order. Comment style follows `packages/contracts/src/modules/CookieJar.sol:55-59` ("declares N storage entries above and reserves M more here (50 total); inherited contracts maintain their own storage layouts independently").
+
+| # | Entry | Type |
+|---|---|---|
+| 1 | `hatsModule` | `IHatsModule` |
+| 2 | `gardenToken` | `address` |
+| 3 | `commitmentRegister` | `ICommitmentRegister` |
+| 4 | `workApprovalResolver` | `address` (authorized hook caller) |
+| 5 | `eas` | `IEAS` |
+| 6 | `workSchemaUID` | `bytes32` |
+| 7 | `workApprovalSchemaUID` | `bytes32` |
+| 8 | `legacyAssessmentSchemaUID` | `bytes32` (v2, `packages/contracts/deployments/42161-latest.json:48`) |
+| 9 | `assessmentV3SchemaUID` | `bytes32` |
+| 10 | `paused` | `bool` (module-wide guard, `packages/contracts/src/modules/Hypercerts.sol:69` precedent) |
+| 11 | `nextPoolId` | `uint256` (starts at 1; 0 is the null sentinel) |
+| 12 | `nextCycleId` | `uint256` |
+| 13 | `nextCommitmentId` | `uint256` |
+| 14 | `gardenPool` | `mapping(address garden => uint256 poolId)` |
+| 15 | `pools` | `mapping(uint256 poolId => Pool)` |
+| 16 | `cycles` | `mapping(uint256 cycleId => Cycle)` |
+| 17 | `commitments` | `mapping(uint256 commitmentId => Commitment)` |
+| 18 | `commitmentConfirmers` | `mapping(uint256 commitmentId => address[])` |
+| 19 | `hasConfirmed` | `mapping(uint256 commitmentId => mapping(address => bool))` |
+| 20 | `workCommitment` | `mapping(bytes32 workUID => uint256 commitmentId)` |
+| 21 | `approvalCounted` | `mapping(bytes32 approvalUID => bool)` |
+
+Gap: `uint256[29] private __gap;` (21 named + 29 reserved = 50 total).
+
+#### Interface (canonical)
+
+Interface style mirrors `packages/contracts/src/interfaces/ICookieJarModule.sol` and `packages/contracts/src/interfaces/IHatsModule.sol` (sectioned events/errors/functions, PascalCase enum members like `IHatsModule.GardenRole`). GraphQL mirrors use SCREAMING_SNAKE.
+
+```solidity
+// NET-NEW: packages/contracts/src/interfaces/ICommitmentPoolingModule.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+interface ICommitmentPoolingModule {
+    // ═════════════════════════════ Types ═════════════════════════════
+
+    enum PoolType { Garden, Protocol }
+
+    enum PoolState { None, NotReady, Ready, Open, Paused, Closed, Composted }
+
+    enum CycleType { Season, Campaign }
+
+    /// @notice On-chain subset. Draft is an app-side IndexedDB state;
+    ///         InProgress and Reviewing are derived (spec section 5.2).
+    enum CycleState { None, Seeded, Open, Reconciled, Composted, Cancelled }
+
+    enum CommitmentDirection { Offer, Request }
+
+    enum CommitmentType { DomainImpact, SupportService, SeasonCampaign, OperatorCaptured }
+
+    /// @notice On-chain subset. Draft is app-side; Active, EvidenceSubmitted,
+    ///         PartiallyApproved, Reconciled are derived (spec section 5.3).
+    enum CommitmentState { None, Offered, Requested, Accepted, ReadyForConfirmation, Fulfilled, Cancelled, Expired, Disputed }
+
+    /// @notice Claimant class. Garden = a GardenAccount claims (protocol pool
+    ///         cross-garden reach); Individual = a hat-wearing person claims.
+    enum ClaimType { Garden, Individual }
+
+    enum ClaimMode { Open, ApprovalGated }
+
+    enum DisputeResolution { ReadyForConfirmation, Fulfilled, Cancelled, Expired, Reconciled }
+
+    /// @notice Allocation-class snapshot for Hypercert cut-over. Must sum to
+    ///         exactly 10_000 bps (Yield.sol InvalidSplitRatio precedent).
+    struct AllocationBps {
+        uint16 gardeners;
+        uint16 treasury;
+        uint16 operator;
+        uint16 evaluator;
+        uint16 community;
+        uint16 funder;
+    }
+
+    struct Pool {
+        address garden;            // ERC-6551 garden account
+        PoolType poolType;
+        PoolState state;
+        bool proofEnabled;         // capability flag; true for MVP pools
+        bool settlementEnabled;    // RESERVED: always false in MVP
+        string charterCID;         // policy/charter metadata (IPFS)
+        uint256 activeCycleId;     // 0 = none
+        address settlementAdapter; // RESERVED: always zero in MVP (Model B)
+    }
+
+    struct Cycle {
+        uint256 poolId;
+        CycleType cycleType;
+        CycleState state;
+        uint64 startTime;
+        uint64 endTime;
+        string metadataCID;
+        AllocationBps allocation;  // snapshot emitted in CycleOpened
+    }
+
+    /// @notice Declared reward is a reference, never custody (decision #18).
+    struct DeclaredReward {
+        address source; // cookie jar or treasury address; informational
+        address token;
+        uint256 amount; // 0 = no declared reward
+    }
+
+    struct Commitment {
+        uint256 poolId;
+        uint256 cycleId;                 // 0 = not cycle-scoped
+        address creator;                 // social source (OperatorCaptured: the member, not the recorder)
+        address counterparty;            // provider (Request) or engager (Offer); zero until Accepted
+        ClaimType counterpartyKind;
+        CommitmentDirection direction;
+        CommitmentType commitmentType;
+        CommitmentState state;
+        ClaimType claimType;             // eligibility class set at seeding
+        ClaimMode claimMode;
+        uint8 domain;                    // 0-3 for DomainImpact (Schemas.sol domain enum); ignored otherwise
+        uint256 requiredActionUID;       // 0 = any action
+        uint64 dueDate;                  // 0 = cycle endTime governs
+        string unitLabel;                // hours, tasks, meals, rides, plants...
+        uint256 targetUnits;
+        uint32 requiredApprovedWorkCount;
+        uint32 approvedWorkCount;
+        uint32 confirmationThreshold;    // N of the named group; 1 under the counterparty default
+        uint32 confirmationCount;
+        bool requiresAssessment;
+        bytes32 assessmentUID;           // attached v2/v3 assessment; zero until attached
+        string metadataCID;              // terms/description payload (IPFS)
+        DeclaredReward reward;
+        bool rewardPaid;
+        // RESERVED post-MVP garden-to-garden (L3); never written in MVP:
+        uint256 counterpartyPoolId;
+        address counterpartyGardenAccount;
+    }
+
+    struct CreateCommitmentParams {
+        uint256 poolId;
+        uint256 cycleId;
+        CommitmentDirection direction;
+        CommitmentType commitmentType;
+        ClaimType claimType;
+        ClaimMode claimMode;
+        address onBehalfOf;              // OperatorCaptured only: the member who made the promise
+        uint8 domain;
+        uint256 requiredActionUID;
+        string unitLabel;
+        uint256 targetUnits;
+        uint32 requiredApprovedWorkCount;
+        bool requiresAssessment;
+        uint64 dueDate;
+        string metadataCID;
+        address[] confirmers;            // empty = counterparty rule
+        uint32 confirmationThreshold;    // ignored (forced 1) when confirmers is empty
+        DeclaredReward reward;
+    }
+
+    // ═════════════════════════════ Events ════════════════════════════
+    // One event per hard transition (spec section 5), plus unit-count and
+    // linkage events. All indexed on poolId/commitmentId for Envio.
+
+    event PoolRegistered(uint256 indexed poolId, address indexed garden, PoolType poolType);
+    event PoolCharterUpdated(uint256 indexed poolId, string charterCID);
+    event PoolReady(uint256 indexed poolId);
+    event PoolOpened(uint256 indexed poolId);
+    event PoolPaused(uint256 indexed poolId);
+    event PoolResumed(uint256 indexed poolId);
+    event PoolClosed(uint256 indexed poolId);
+    event PoolComposted(uint256 indexed poolId);
+    event PoolReopened(uint256 indexed poolId, bool toOpen);
+
+    event CycleSeeded(
+        uint256 indexed cycleId,
+        uint256 indexed poolId,
+        CycleType cycleType,
+        uint64 startTime,
+        uint64 endTime,
+        string metadataCID
+    );
+    /// @notice Allocation-class bps ride in the open event (decision #12).
+    event CycleOpened(
+        uint256 indexed cycleId,
+        uint256 indexed poolId,
+        uint16 gardenersBps,
+        uint16 treasuryBps,
+        uint16 operatorBps,
+        uint16 evaluatorBps,
+        uint16 communityBps,
+        uint16 funderBps
+    );
+    event CycleClosed(uint256 indexed cycleId, uint256 indexed poolId);
+    event CycleComposted(uint256 indexed cycleId, uint256 indexed poolId);
+    event CycleCancelled(uint256 indexed cycleId, uint256 indexed poolId, string reasonCID);
+
+    event CommitmentCreated(
+        uint256 indexed commitmentId,
+        uint256 indexed poolId,
+        uint256 indexed cycleId,
+        address creator,
+        address recordedBy,          // msg.sender; differs from creator for OperatorCaptured
+        CommitmentDirection direction,
+        CommitmentType commitmentType,
+        ClaimType claimType,
+        ClaimMode claimMode,
+        string unitLabel,
+        uint256 targetUnits,
+        uint32 requiredApprovedWorkCount,
+        uint64 dueDate
+    );
+    event RewardDeclared(uint256 indexed commitmentId, address source, address token, uint256 amount);
+    event ConfirmerRuleSet(uint256 indexed commitmentId, address[] confirmers, uint32 threshold);
+    event ClaimRequested(uint256 indexed commitmentId, address indexed claimant, ClaimType kind, address gardenContext);
+    event CommitmentAccepted(uint256 indexed commitmentId, address indexed counterparty, ClaimType kind);
+    event WorkLinked(uint256 indexed commitmentId, bytes32 indexed workUID, address linker);
+    event WorkUnlinked(uint256 indexed commitmentId, bytes32 indexed workUID, address unlinker);
+    /// @notice Unit-count change event; approvedUnits is the module-computed
+    ///         integer floor(targetUnits * approvedWorkCount / requiredApprovedWorkCount).
+    event ApprovedWorkCounted(
+        uint256 indexed commitmentId,
+        bytes32 indexed workUID,
+        bytes32 approvalUID,
+        uint32 approvedWorkCount,
+        uint256 approvedUnits
+    );
+    /// @notice Lightweight evidence (decision #20); offline-queueable write.
+    event EvidenceAttached(uint256 indexed commitmentId, string cid, address indexed attacher);
+    event AssessmentAttached(uint256 indexed commitmentId, bytes32 indexed assessmentUID, address attacher);
+    event CommitmentReadyForConfirmation(uint256 indexed commitmentId, bool overridden, string reason);
+    event ConfirmationRecorded(
+        uint256 indexed commitmentId, address indexed confirmer, uint32 confirmationCount, uint32 threshold
+    );
+    event CommitmentFulfilled(uint256 indexed commitmentId, bool fallbackConfirmation, string reason);
+    event CommitmentCancelled(uint256 indexed commitmentId, address indexed canceller, string reasonCID);
+    event CommitmentExpired(uint256 indexed commitmentId, address indexed caller);
+    event CommitmentDisputed(uint256 indexed commitmentId, address indexed raiser, string reasonCID);
+    event DisputeResolved(uint256 indexed commitmentId, DisputeResolution resolution, string reasonCID);
+    /// @notice Payout executed on existing rails and recorded here (decision #18).
+    event RewardPaid(
+        uint256 indexed commitmentId, address indexed payer, address token, uint256 amount, bytes32 payoutRef
+    );
+
+    // ═════════════════════════════ Errors ════════════════════════════
+
+    error UnauthorizedCaller(address caller);
+    error NotPoolSteward(address caller, uint256 poolId);
+    error ModulePaused();
+    error ZeroAddress();
+    error PoolExists(address garden);
+    error UnknownPool(uint256 poolId);
+    error PoolNotInState(uint256 poolId, PoolState actual);
+    error CharterRequired(uint256 poolId);
+    error UnknownCycle(uint256 cycleId);
+    error CycleNotInState(uint256 cycleId, CycleState actual);
+    error InvalidAllocation(); // bps sum != 10_000 (Yield.sol InvalidSplitRatio precedent)
+    error InvalidTimeWindow(uint64 startTime, uint64 endTime);
+    error UnknownCommitment(uint256 commitmentId);
+    error CommitmentNotInState(uint256 commitmentId, CommitmentState actual);
+    error NotEligibleClaimant(address claimant);
+    error ClaimModeMismatch(uint256 commitmentId);
+    error SelfCounterparty(); // creator cannot claim their own commitment
+    error SelfConfirmation(); // provider cannot confirm own fulfillment (WorkApproval SelfAttestation precedent)
+    error NotConfirmer(address caller);
+    error AlreadyConfirmed(address confirmer);
+    error InvalidConfirmerRule();
+    error InvalidWorkAttestation(bytes32 workUID);
+    error InvalidApprovalAttestation(bytes32 approvalUID);
+    error InvalidAssessmentAttestation(bytes32 assessmentUID);
+    error WorkAlreadyLinked(bytes32 workUID);
+    error ApprovalAlreadyCounted(bytes32 approvalUID);
+    error WorkNotLinkedToCommitment(bytes32 workUID, uint256 commitmentId);
+    error EvidenceRequired(uint256 commitmentId);
+    error AssessmentRequired(uint256 commitmentId);
+    error NotDue(uint256 commitmentId);
+    error RewardAlreadyRecorded(uint256 commitmentId);
+    error InvalidDomain(uint8 domain);
+
+    // ══════════════════════ Pool lifecycle ═══════════════════════════
+
+    /// @notice GardenToken mint callback. Idempotent; registers a Garden-type
+    ///         pool in NotReady. Gating: gardenToken only (CookieJar onlyGardenToken pattern).
+    function onGardenMinted(address garden) external returns (uint256 poolId);
+
+    /// @notice Backfill for pre-upgrade gardens and the protocol pool.
+    ///         Gating: PoolType.Protocol requires module owner; PoolType.Garden
+    ///         requires garden operator/owner or module owner.
+    function registerPool(address garden, PoolType poolType) external returns (uint256 poolId);
+
+    /// @notice Gating for all six below: pool steward (garden operator/owner
+    ///         via hatsModule, module owner fallback). Protocol pool resolves
+    ///         to root-garden hats.
+    function setPoolCharter(uint256 poolId, string calldata charterCID) external;
+    function markPoolReady(uint256 poolId) external;
+    function openPool(uint256 poolId) external;
+    function pausePool(uint256 poolId) external;
+    function resumePool(uint256 poolId) external;
+    function closePool(uint256 poolId) external;
+    function compostPool(uint256 poolId) external;
+    function reopenPool(uint256 poolId, bool toOpen) external;
+
+    // ══════════════════════ Cycle lifecycle ══════════════════════════
+
+    /// @notice Gating: pool steward. Pool must be Ready or Open to seed;
+    ///         Open to open a cycle. Allocation bps must sum to 10_000.
+    function seedCycle(
+        uint256 poolId,
+        CycleType cycleType,
+        uint64 startTime,
+        uint64 endTime,
+        string calldata metadataCID,
+        AllocationBps calldata allocation
+    ) external returns (uint256 cycleId);
+    function openCycle(uint256 cycleId) external;
+    function closeCycle(uint256 cycleId) external;
+    function compostCycle(uint256 cycleId) external;
+    function cancelCycle(uint256 cycleId, string calldata reasonCID) external;
+
+    // ══════════════════════ Commitments ══════════════════════════════
+
+    /// @notice Gating by commitment type (creation authority, locked):
+    ///         members create own offers/requests (any of the six garden role
+    ///         hats in the pool garden, IHatsModule.GardenRole);
+    ///         SeasonCampaign and OperatorCaptured require pool steward;
+    ///         protocol-pool commitments require root-garden steward or module owner.
+    ///         OperatorCaptured must set onBehalfOf (the member stays the
+    ///         social source; msg.sender is recorded as recordedBy in the event).
+    function createCommitment(CreateCommitmentParams calldata params) external returns (uint256 commitmentId);
+
+    /// @notice Gating: pool steward, pre-acceptance only.
+    function setDeclaredReward(uint256 commitmentId, DeclaredReward calldata reward) external;
+    function setConfirmerRule(uint256 commitmentId, address[] calldata confirmers, uint32 threshold) external;
+
+    /// @notice Claim eligibility (decision #7, #8):
+    ///         Garden pools: caller must hold any role hat in the pool garden
+    ///         (gardenContext must equal the pool garden).
+    ///         Protocol pool, ClaimType.Garden: gardenContext must be a
+    ///         registered garden (gardenPool != 0) and caller its operator/owner;
+    ///         counterparty recorded = gardenContext.
+    ///         Protocol pool, ClaimType.Individual: caller must hold any role
+    ///         hat in gardenContext; counterparty = msg.sender.
+    ///         ClaimMode.Open transitions to Accepted; ApprovalGated only emits
+    ///         ClaimRequested. Creator cannot claim own commitment.
+    function claimCommitment(uint256 commitmentId, ClaimType kind, address gardenContext) external;
+
+    /// @notice Gating: pool steward. ApprovalGated acceptance path; validates
+    ///         the same eligibility rules for the named claimant.
+    function acceptClaim(uint256 commitmentId, address claimant, ClaimType kind, address gardenContext) external;
+
+    // ─────────────── Work linkage + EAS bridge (decision #5) ─────────
+
+    /// @notice Link a Work attestation to a commitment before or after its
+    ///         approval. Verifies via eas.getAttestation: schema == workSchemaUID,
+    ///         recipient == pool garden. One work maps to at most one commitment;
+    ///         one commitment maps to many works.
+    ///         Gating: commitment counterparty, creator, or pool steward.
+    function linkWork(uint256 commitmentId, bytes32 workUID) external;
+
+    /// @notice Gating: pool steward; only while the approval is not yet counted.
+    function unlinkWork(bytes32 workUID) external;
+
+    /// @notice Called by WorkApprovalResolver inside try/catch after full
+    ///         approval validation (WorkApproval.sol:179-183 GAP precedent).
+    ///         No-op (returns without revert) when the workUID is unlinked or
+    ///         the approvalUID was already counted. Never reverts on state it
+    ///         does not recognize: the approval must stand regardless.
+    ///         Gating: workApprovalResolver only.
+    function onWorkApproved(bytes32 workUID, bytes32 approvalUID, address garden) external;
+
+    /// @notice Operator-callable catch-up when the resolver hook was missed
+    ///         (module wired after approvals, or work linked after approval).
+    ///         Verifies each approvalUID via eas.getAttestation: schema ==
+    ///         workApprovalSchemaUID, decoded approved == true, decoded workUID
+    ///         linked to this commitmentId, recipient == pool garden; dedupes
+    ///         via approvalCounted. Gating: pool steward.
+    function syncApprovedWork(uint256 commitmentId, bytes32[] calldata approvalUIDs) external;
+
+    // ─────────────── Evidence, assessment, confirmation ──────────────
+
+    /// @notice Gating: creator, counterparty, or pool steward. Offline-queueable.
+    function attachEvidence(uint256 commitmentId, string calldata cid) external;
+
+    /// @notice Verifies via eas.getAttestation: schema is legacyAssessmentSchemaUID
+    ///         or assessmentV3SchemaUID, recipient == pool garden.
+    ///         Gating: pool steward or garden evaluator.
+    function attachAssessment(uint256 commitmentId, bytes32 assessmentUID) external;
+
+    /// @notice Path (b) to ReadyForConfirmation: commitments with
+    ///         requiredApprovedWorkCount == 0 (SupportService/OperatorCaptured);
+    ///         requires >= 1 attached evidence. Gating: counterparty, creator,
+    ///         or pool steward.
+    function submitForConfirmation(uint256 commitmentId) external;
+
+    /// @notice Path (c): steward override with visible reason.
+    function markReadyForConfirmation(uint256 commitmentId, string calldata reason) external;
+
+    /// @notice Gating: a named confirmer, or the counterparty under the default
+    ///         rule. The unit provider can never confirm their own fulfillment.
+    function confirmFulfillment(uint256 commitmentId) external;
+
+    /// @notice Gating: pool steward; reason mandatory (fallback stays visible).
+    function confirmFulfillmentAsFallback(uint256 commitmentId, string calldata reason) external;
+
+    // ─────────────── Exits, disputes, rewards ────────────────────────
+
+    /// @notice Gating: creator from Offered/Requested; pool steward from Accepted.
+    function cancelCommitment(uint256 commitmentId, string calldata reasonCID) external;
+
+    /// @notice Permissionless once past due (dueDate, or cycle endTime when 0).
+    function expireCommitment(uint256 commitmentId) external;
+
+    /// @notice Gating: creator, counterparty, named confirmer, or pool steward.
+    function raiseDispute(uint256 commitmentId, string calldata reasonCID) external;
+
+    /// @notice Gating: pool steward. Reconciled resolution only when the
+    ///         commitment's cycle is already Reconciled.
+    function resolveDispute(uint256 commitmentId, DisputeResolution resolution, string calldata reasonCID) external;
+
+    /// @notice Records an already-executed payout (no custody). Requires state
+    ///         Fulfilled; single record per commitment in MVP.
+    ///         Gating: pool steward.
+    function recordRewardPaid(uint256 commitmentId, address token, uint256 amount, bytes32 payoutRef) external;
+
+    // ══════════════════════ Views ════════════════════════════════════
+
+    function getPool(uint256 poolId) external view returns (Pool memory);
+    function getPoolByGarden(address garden) external view returns (uint256 poolId, Pool memory pool);
+    function getCycle(uint256 cycleId) external view returns (Cycle memory);
+    function getCommitment(uint256 commitmentId) external view returns (Commitment memory);
+    function getConfirmers(uint256 commitmentId) external view returns (address[] memory);
+    function workCommitmentOf(bytes32 workUID) external view returns (uint256 commitmentId);
+    function isApprovalCounted(bytes32 approvalUID) external view returns (bool);
+
+    // ══════════════════════ Admin (module owner) ═════════════════════
+
+    function setGardenToken(address gardenToken) external;
+    function setHatsModule(address hatsModule) external;
+    function setCommitmentRegister(address register) external;
+    function setWorkApprovalResolver(address resolver) external;
+    function setEAS(address eas) external;
+    function setSchemaUIDs(
+        bytes32 workUID,
+        bytes32 workApprovalUID,
+        bytes32 legacyAssessmentUID,
+        bytes32 assessmentV3UID
+    ) external;
+    function setPaused(bool paused) external;
+}
+```
+
+#### Behavior notes an implementer must not miss
+
+- **Confirmer rule storage**: `confirmers` array persisted in `commitmentConfirmers`; empty array means the counterparty confirms (threshold forced to 1 and the group resolves to `[counterparty]` at acceptance time). The named group is data, not a hat (documented divergence from the Hats-everything pattern; the group is operator-set at seeding, locked).
+- **Self-checks**: `claimCommitment` reverts `SelfCounterparty` when claimant == creator. `confirmFulfillment` reverts `SelfConfirmation` when msg.sender is the unit provider (counterparty for Requests, creator for Offers), mirroring `packages/contracts/src/resolvers/WorkApproval.sol:153-156`.
+- **Register coupling**: `createCommitment` calls `register.registerClass(commitmentId, poolId, unitLabel, targetUnits)`; acceptance calls `commitUnits`; cancel/expire call `releaseUnits`; fulfillment calls `fulfillUnits`. Exact functions in 6.2.
+- **approvedUnits math**: computed on-chain as `targetUnits * approvedWorkCount / requiredApprovedWorkCount` (integer floor) and emitted in `ApprovedWorkCounted` so the indexer never re-derives fractional units.
+- **ReadyForConfirmation auto-flip** happens inside `onWorkApproved` and `syncApprovedWork` only when `requiresAssessment == false || assessmentUID != 0`. If assessment is still pending, the flip waits for `attachAssessment`, which also checks and flips (emitting path (a)'s event).
+- **Pause semantics**: module-wide `paused` blocks all mutating functions except dispute resolution and cancel (stewards must always be able to wind down). Pool-level Paused blocks new commitments, claims, and confirmations on that pool only.
+- **onWorkApproved must never revert** for unrecognized state: the EAS approval succeeds regardless (approval flow is `critical` path per repo criticality matrix).
+
+#### Acceptance criteria
+
+- Every transition in the section 5 tables has exactly one emitting function or a documented derivation; no silent state changes.
+- `bun run test` unit suite covers: pool registration idempotency, protocol-pool gating via root-garden hats, all three ReadyForConfirmation paths, confirmer threshold with named group and counterparty default, self-claim and self-confirmation reverts, expiry timing (dueDate and cycle-endTime fallback), dispute resolutions, reward record, work-linkage verification against a mocked EAS, sync dedupe.
+- Storage layout test asserts 21 named entries + 29 gap (pattern: `packages/contracts/test/StorageLayout.t.sol`), and `script/check-storage-layout.sh` gains a `CommitmentPoolingModule:src/modules/CommitmentPooling.sol` entry (list at `packages/contracts/script/check-storage-layout.sh:23-33`).
+- Fork test proves a full Offer -> Accepted -> WorkLinked -> approval-hook count -> ReadyForConfirmation -> confirm -> Fulfilled -> RewardPaid pass against the deployed EAS on an Arbitrum fork (`bun run test:fork`, wrappers only per `.claude/rules/contracts.md`).
+
+### 6.2 `CommitmentRegister`
+
+#### Objective
+
+A non-transferable, ERC-1155-STYLE unit ledger internal to our own contract: commitment classes, committed/fulfilled balances per account, quotas, and exposure caps. It does NOT inherit ERC-1155 and exposes no transfer or approval surface of any kind; balances move only through module calls. This is the voucher-shaped substrate (decisions #15, #16) that Model B settlement vouchers later wrap 1:1 on the same poolId.
+
+#### Grassroots Economics grounding (clean-room, decision #17)
+
+Design vocabulary comes from Ruddick's "Commitment Pooling: an Economic Protocol Inspired by Ancestral Wisdom" (IJCCR) and the Grassroots Economics "Intro to Commitment Pools" docs, used as named design grammar only, never as code reference (the Sarafu Solidity source is AGPL and is not read):
+
+- **Curation**: which commitments enter the pool's register. Implemented as steward-gated `createCommitment`/`acceptClaim` on the module plus module-only `registerClass` here; nothing enters the register except through curated module paths.
+- **Limiting**: hard caps per asset in the pool. Implemented as the per-class `quota` (defaults to the commitment's targetUnits) and the per-pool `providerExposureCap` on open committed units per account. `openExposureUnits` is the safety gauge the aggregates surface.
+- **Valuing**: relative value against a reference asset. Deliberately NOT implemented in MVP (no swaps, no relative pricing, units are per-commitment labels with no global conversion). Named here as the reserved third primitive that Model B activates on the same classes.
+
+The GE pool step sequence (seed round, exchange in/out, redemption, cross exchange) maps to MVP as: seed = class registration at curated creation; the exchange and redemption steps stay out of scope until settlement (Model B) wraps these balances as transferable vouchers via the pool's reserved `settlementAdapter`.
+
+#### Model B attachment path (spec-now, build-later)
+
+- `classId == commitmentId` in MVP (1:1). The classId space is `uint256` and module-controlled, so later class kinds (per provider + unit label groupings) can join without migration.
+- A future settlement adapter (address reserved on the Pool struct) reads `fulfilledOf`/`committedOf` and issues transferable vouchers per class on the same poolId. The register itself never gains transfer functions; wrapping happens in the adapter's own token contract.
+
+#### Storage layout (slot accounting)
+
+Comment style follows `packages/contracts/src/modules/CookieJar.sol:55-59`.
+
+| # | Entry | Type |
+|---|---|---|
+| 1 | `module` | `address` (authorized mutator) |
+| 2 | `classes` | `mapping(uint256 classId => CommitmentClass)` |
+| 3 | `committedBalance` | `mapping(address account => mapping(uint256 classId => uint256))` |
+| 4 | `fulfilledBalance` | `mapping(address account => mapping(uint256 classId => uint256))` |
+| 5 | `providerExposureCap` | `mapping(uint256 poolId => uint256)` (0 = uncapped) |
+| 6 | `providerOpenUnits` | `mapping(uint256 poolId => mapping(address account => uint256))` |
+
+Gap: `uint256[44] private __gap;` (6 named + 44 reserved = 50 total).
+
+Ownership note: the decision language "owned by the module" is implemented as an `onlyModule` mutation gate (same shape as `onlyGardenToken`, `packages/contracts/src/modules/CookieJar.sol:65-68`). The `OwnableUpgradeable` owner stays the protocol multisig for UUPS upgrade authority, like every other upgradeable contract in the repo (`_authorizeUpgrade onlyOwner`, `packages/contracts/src/modules/CookieJar.sol:302-304`). If the owner were the module, nobody could upgrade the register.
+
+#### Interface (canonical)
+
+```solidity
+// NET-NEW: packages/contracts/src/interfaces/ICommitmentRegister.sol
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title ICommitmentRegister
+/// @notice Non-transferable ERC-1155-style unit accounting for commitment
+///         pooling. No transfer, no approval, no custody: balances move only
+///         through the CommitmentPoolingModule. Grounded in the Grassroots
+///         Economics register grammar (curation, limiting, valuing); valuing
+///         is reserved for Model B settlement.
+interface ICommitmentRegister {
+    // ═════════════════════════════ Types ═════════════════════════════
+
+    struct CommitmentClass {
+        uint256 poolId;
+        string unitLabel;
+        uint256 quota;           // LIMITING: hard cap on committed units for this class
+        uint256 totalCommitted;  // live open exposure for this class
+        uint256 totalFulfilled;
+        bool exists;
+    }
+
+    // ═════════════════════════════ Events ════════════════════════════
+
+    event ModuleUpdated(address indexed oldModule, address indexed newModule);
+    event ClassRegistered(uint256 indexed classId, uint256 indexed poolId, string unitLabel, uint256 quota);
+    event QuotaUpdated(uint256 indexed classId, uint256 quota);
+    event ProviderExposureCapUpdated(uint256 indexed poolId, uint256 cap);
+    event UnitsCommitted(uint256 indexed classId, address indexed account, uint256 units, uint256 totalCommitted);
+    event UnitsReleased(uint256 indexed classId, address indexed account, uint256 units, uint256 totalCommitted);
+    event UnitsFulfilled(uint256 indexed classId, address indexed account, uint256 units, uint256 totalFulfilled);
+
+    // ═════════════════════════════ Errors ════════════════════════════
+
+    error NotModule(address caller);
+    error ZeroAddress();
+    error ClassAlreadyRegistered(uint256 classId);
+    error UnknownClass(uint256 classId);
+    error QuotaExceeded(uint256 classId, uint256 requested, uint256 available);
+    error ExposureCapExceeded(uint256 poolId, address account, uint256 requested, uint256 available);
+    error InsufficientCommitted(uint256 classId, address account, uint256 requested, uint256 available);
+
+    // ══════════════════════ Mutations (onlyModule) ═══════════════════
+
+    function registerClass(uint256 classId, uint256 poolId, string calldata unitLabel, uint256 quota) external;
+    function setQuota(uint256 classId, uint256 quota) external;
+    function setProviderExposureCap(uint256 poolId, uint256 cap) external;
+
+    /// @notice Acceptance: records committed units against quota and the
+    ///         provider's per-pool exposure cap.
+    function commitUnits(uint256 classId, address account, uint256 units) external;
+
+    /// @notice Cancel/expire: releases committed units without fulfillment.
+    function releaseUnits(uint256 classId, address account, uint256 units) external;
+
+    /// @notice Fulfillment: converts committed units into fulfilled balance
+    ///         (all-or-nothing per commitment in MVP).
+    function fulfillUnits(uint256 classId, address account, uint256 units) external;
+
+    // ══════════════════════ Views ════════════════════════════════════
+
+    function getClass(uint256 classId) external view returns (CommitmentClass memory);
+    function committedOf(address account, uint256 classId) external view returns (uint256);
+    function fulfilledOf(address account, uint256 classId) external view returns (uint256);
+    function openUnitsOf(uint256 poolId, address account) external view returns (uint256);
+
+    // ══════════════════════ Admin (owner) ════════════════════════════
+
+    function setModule(address module) external;
+
+    // Deliberately absent: transferFrom, safeTransferFrom, setApprovalForAll,
+    // balanceOfBatch, any ERC-1155 receiver hooks. Non-transferable by
+    // construction; adding a transfer surface is a spec violation.
+}
+```
+
+Scaffold: `UUPSUpgradeable + OwnableUpgradeable`, `_disableInitializers()`, initializer takes `(owner, module)` where module may be zero and set later during wiring (template `packages/contracts/src/modules/CookieJar.sol:74-115`).
+
+#### Acceptance criteria
+
+- No function in the compiled ABI moves balance between two non-module accounts; a dedicated test asserts the ABI contains no `transfer`/`approve` selector.
+- Quota and exposure-cap reverts covered by unit tests; `openUnitsOf` matches the sum of live committed balances per pool.
+- Register mutations revert `NotModule` for every caller except the wired module.
+- Storage layout test (6 named + 44 gap) and `check-storage-layout.sh` entry `CommitmentRegister:src/registries/Commitment.sol` added.
+- Model B attachment documented: a reviewer can point at the classId, the reserved settlementAdapter field, and the fulfilled balances and see the 1:1 wrap path without register changes.
+
+### 6.3 GardenToken wiring (live UUPS upgrade)
+
+#### Changes to `packages/contracts/src/tokens/Garden.sol`
+
+1. New module field after `communityToken` (module fields block, lines 27-34): `ICommitmentPoolingModule public commitmentPoolingModule;`
+2. New setter + event in the setter block (lines 181-227 pattern):
+   `setCommitmentPoolingModule(address)` onlyOwner, emitting `CommitmentPoolingModuleUpdated(oldModule, newModule)`.
+3. Mint callback in `_initializeIntegrationsAndAccount` (lines 421-456), after the CookieJar block, same graceful shape as lines 423-430: `if (address(commitmentPoolingModule) != address(0)) { try commitmentPoolingModule.onGardenMinted(gardenAccount) returns (uint256) { } catch { } }`. Garden mint MUST NOT revert on module failure.
+4. **Gap 37 to 36** with comment rewrite. Current comment (`packages/contracts/src/tokens/Garden.sol:56-62`) reserves 37 slots against 13 used; the new comment reads 14 used slots (adds `commitmentPoolingModule` to the enumerated list) and `uint256[36] private __gap;`.
+
+#### Live-chain implication
+
+GardenToken on 42161 is a live UUPS proxy at `0xe1Da335110b1ed48e7df63209f5D424d02276593` (`packages/contracts/deployments/42161-latest.json:14`) holding real garden state for 13 live gardens. The upgrade appends one variable in gap space (safe append) and shrinks the gap by exactly one, preserving total slot count. Required proof chain before broadcast:
+
+- `script/check-storage-layout.sh` passes against the regenerated baseline (`--update` run committed in the same PR; GardenToken entry already exists at `packages/contracts/script/check-storage-layout.sh:24`).
+- `packages/contracts/test/StorageLayout.t.sol` gains assertions for the new field position and updated gap. Known drift, do not silently fix beyond this contract: the existing GardenToken comments there still describe an old 7-named/43-gap layout (`packages/contracts/test/StorageLayout.t.sol:31-35,59-69`) while the source has 13 used + 37 gap; the upgrade PR corrects the GardenToken numbers it touches and logs the tautology-shaped gap tests as debt (section 12).
+- Upgrade preserves state test extended (`testGardenTokenUpgradePreservesState`, `packages/contracts/test/StorageLayout.t.sol:270-289`) to set and survive `commitmentPoolingModule`.
+- Broadcast via the named root `contracts:*` scripts only (keystore + sender encoding per root CLAUDE.md; never raw forge, `.claude/rules/contracts.md`).
+
+Post-upgrade ops sequence (one-shot, lives in `.plans/`, not `scripts/`): `gardenToken.setCommitmentPoolingModule(module)`, then `registerPool(rootGarden, Protocol)` by the module owner, then `registerPool(garden, Garden)` backfill for the 13 live gardens (steward or module owner per call).
+
+### 6.4 EAS schema work: exactly two registrations (decision #14)
+
+No commitment schema exists or will exist. The two registrations are assessment v3 and community testimony. Both non-revocable, matching every existing Green Goods schema (`packages/contracts/config/schemas.json` `"revocable": false`; resolvers return false from `onRevoke`, e.g. `packages/contracts/src/resolvers/Assessment.sol:173-176`). Note the GreenWill badge schema is revocable (`packages/contracts/script/DeployBadgeSchema.s.sol:23`); ours deliberately are not.
+
+#### 6.4.1 Assessment v3 schema
+
+Deployed v2 stays untouched and readable: UID `0x97b3a7378bc97e8e455dbf9bd7958e4c149bef5e1f388540852b6d53eb6dbf93`, string `string title,string description,string assessmentConfigCID,uint8 domain,uint256 startDate,uint256 endDate,string location` (`packages/contracts/deployments/42161-latest.json:47-48`). Schemas are immutable (`corrections-log.md` H2), so v3 is a fresh UID following the same thin-schema + config-CID pattern, appending only what resolvers and indexed consumers need (`corrections-log.md` §3).
+
+Proposed canonical v3 string (v2's seven fields first, three appended):
+
+```text
+string title,string description,string assessmentConfigCID,uint8 domain,uint256 startDate,uint256 endDate,string location,uint8 assessmentKind,uint256 cycleId,bytes32 baselineUID
+```
+
+- `assessmentKind`: 0 = Baseline, 1 = Delta (re-assessment), 2 = Technical.
+- `cycleId`: module cycle reference; 0 = not cycle-scoped. The resolver does not cross-check it against the module (deliberate decoupling; validity is an app/indexer concern; the module-to-resolver coupling stays one-way, section 6.5).
+- `baselineUID`: required non-zero for Delta; the resolver verifies it resolves to an existing v2-or-v3 assessment attestation with the same recipient garden via `_eas.getAttestation`. Zero for Baseline/Technical.
+
+Struct appended to `packages/contracts/src/Schemas.sol` as `AssessmentV3Schema` (tuple-decode comment convention as in `packages/contracts/src/resolvers/Work.sol:90-95`).
+
+#### 6.4.2 Community testimony schema
+
+Proposed canonical string:
+
+```text
+uint256 commitmentId,string title,string testimonyCID
+```
+
+- `commitmentId`: module commitment reference; 0 = garden-level story not tied to one commitment.
+- `testimonyCID`: IPFS payload with the narrative, media, and attribution. Kept off-chain to stay thin.
+- Recipient = garden account, matching every existing schema's recipient convention (`corrections-log.md` §2).
+- No numeric score field, on purpose. Testimony gates nothing by itself: when a commitment is explicitly aimed at the community, its confirmation power flows through the module's named-confirmer group (Community-Hat wearers placed in `confirmers` at seeding), never through this schema. Everywhere else testimony is narrative only. "Never averaged" is enforced off-chain (indexer and app never aggregate testimony into scores); flagged in section 12.
+
+Struct appended to `packages/contracts/src/Schemas.sol` as `CommunityTestimonySchema`.
+
+#### 6.4.3 Resolvers
+
+Both NET-NEW, following the four resolver conventions verbatim from `packages/contracts/src/resolvers/{Work,WorkApproval,Assessment}.sol`: validation-order doc comment (`Work.sol:78-84`), flat-tuple decode with explanatory comment (`Work.sol:90-95`), `setSchemaUID` zero-bypass for the deployment window (`Work.sol:59-66`), `onRevoke` returns false, 48-slot-style gap with used-slot comment (`WorkApproval.sol:47-53`), UUPS + Ownable + `_disableInitializers`.
+
+**`AssessmentV3Resolver`** (NET-NEW `packages/contracts/src/resolvers/AssessmentV3.sol`), validation order:
+
+1. Schema UID check (zero-bypass).
+2. Decode v3 tuple.
+3. IDENTITY by kind (decision #7): Baseline requires `accessControl.isEvaluator || accessControl.isOperator` (exact parity with today's `packages/contracts/src/resolvers/Assessment.sol:114-121`, preserving operator analog capture); Delta and Technical require `accessControl.isEvaluator` only (`packages/contracts/src/interfaces/IGardenAccessControl.sol:25`).
+4. REQUIRED FIELDS: title, assessmentConfigCID non-empty; domain <= 3 (`Assessment.sol:124-136` parity).
+5. KIND VALIDATION: assessmentKind <= 2; Delta requires baselineUID != 0 and `_eas.getAttestation(baselineUID)` returning an attestation whose schema is the v2 or v3 UID and whose recipient equals `attestation.recipient`; Baseline/Technical require baselineUID == 0.
+6. GAP INTEGRATION: same optional KarmaGAP milestone try/catch as v2 (`Assessment.sol:138-141,150-167`), reusing `createMilestone`.
+
+Storage: `karmaGAPModule`, `schemaUID`, `legacySchemaUID` (v2 UID for baseline cross-checks) = 3 used slots, `uint256[47] __gap` (50 total).
+
+**`CommunityTestimonyResolver`** (NET-NEW `packages/contracts/src/resolvers/CommunityTestimony.sol`), validation order:
+
+1. Schema UID check (zero-bypass).
+2. Decode tuple.
+3. IDENTITY: `accessControl.isCommunity(attestation.attester)` only (`packages/contracts/src/interfaces/IGardenAccessControl.sol:42-45`). Community Hat becomes a real attestation gate for the first time (today it only gates GreenWill genesis eligibility, `corrections-log.md` H6).
+4. REQUIRED FIELDS: testimonyCID non-empty.
+5. COMMITMENT CHECK (optional module ref, zero-bypass): when `commitmentModule != address(0)` and `commitmentId != 0`, verify `module.getCommitment(commitmentId)` exists and its pool's garden equals `attestation.recipient`.
+
+Storage: `schemaUID`, `commitmentModule` = 2 used slots, `uint256[48] __gap` (matches `Assessment.sol:39-44` accounting style).
+
+#### 6.4.4 Registration path (standalone, decision #26; first PR chain of the August track)
+
+Never use `--update-schemas`: that mode reloads the three legacy resolvers and re-registers ALL legacy schemas, overwriting every schema artifact key (`packages/contracts/script/Deploy.s.sol:122-151`, `_registerSchemas` at `packages/contracts/test/helpers/DeploymentBase.sol:955-990`). Additive registration goes through the badge-schemas standalone precedent instead:
+
+- NET-NEW `packages/contracts/script/DeployCommitmentSchemas.s.sol` (template `packages/contracts/script/DeployBadgeSchema.s.sol:15-73`): deploys the two resolver UUPS proxies (CREATE2 + ERC1967Proxy, `_deployAssessmentResolver` shape at `packages/contracts/test/helpers/DeploymentBase.sol:913-953`), registers both schemas with `SchemaRegistry.register(schemaString, resolverAddr, false)` against `eas.schemaRegistry` `0xA310da9c5B885E7fb3fbA9D66E9Ba6Df512b78eB` (`packages/contracts/deployments/42161-latest.json:10`), then calls `setSchemaUID` on each resolver, then writes `deployments/{chainId}-commitment-schemas.json`.
+- NET-NEW `packages/contracts/script/deploy/commitment-schemas.ts` (template `packages/contracts/script/deploy/badge-schemas.ts:76-168`): wraps the forge script with keystore handling and merges the result into `deployments/{chainId}-latest.json` under NEW keys only, exactly like `mergeIntoDeployment` (`badge-schemas.ts:128-168`).
+- Artifact keys added (v2 keys untouched): `assessmentV3SchemaUID`, `assessmentV3Schema`, `assessmentV3Name`, `assessmentV3Description`, `communityTestimonySchemaUID`, `communityTestimonySchema`, `communityTestimonyName`, `communityTestimonyDescription`, plus top-level `assessmentV3Resolver` and `communityTestimonyResolver` addresses.
+- `packages/contracts/config/schemas.json` gains sibling keys `assessmentV3` and `communityTestimony` (name, description, revocable false, fields array) so `_generateSchemaString` and its bun utility keep producing canonical strings (`packages/contracts/script/DeployHelper.sol:416-462`). The deployed `assessment` key is never edited.
+- `packages/contracts/script/validate-resolver-eas.mjs` and `validate-eas-immutables.mjs` extended to cover the two new schema/resolver pairs.
+- Invocation: `bun script/deploy.ts commitment-schemas --network <chain> --broadcast` wired into the existing deploy CLI dispatch next to `badge-schemas`.
+
+#### Acceptance criteria
+
+- Both schema strings byte-match between `config/schemas.json`-generated output and the registered on-chain schema record.
+- v2 assessment attestations keep resolving and the v2 artifact keys are byte-identical before and after the merge.
+- Resolver unit tests cover: baseline by operator (passes), delta by operator (reverts), delta with missing/foreign baselineUID (reverts), testimony by non-community (reverts), testimony with commitmentId pointing at another garden's pool (reverts when module wired).
+- Sepolia registration precedes Arbitrum (release-age gate posture of `assertSepoliaGate`, `packages/contracts/script/deploy/badge-schemas.ts:77-81`).
+- Registered before cycle 1 opens so baselines exist for seeding (decision #26).
+
+### 6.5 WorkApprovalResolver bridge (upgrade)
+
+Changes to `packages/contracts/src/resolvers/WorkApproval.sol`:
+
+1. New storage: `ICommitmentPoolingModule public commitmentModule;` + `setCommitmentModule(address)` onlyOwner + `CommitmentModuleUpdated` event. Gap 48 to 47 with comment update (`WorkApproval.sol:47-53`).
+2. In `onAttest`, after ALL existing validation passes and alongside the GAP block (`WorkApproval.sol:179-183`):
+
+```solidity
+// COMMITMENT BRIDGE: count approved work toward a pre-linked commitment.
+// Non-blocking: approval must succeed even if the module call fails.
+if (schema.approved && address(commitmentModule) != address(0)) {
+    // solhint-disable-next-line no-empty-blocks
+    try commitmentModule.onWorkApproved(schema.workUID, attestation.uid, attestation.recipient) {
+        // Success: module emitted ApprovedWorkCounted (or no-op if unlinked)
+    } catch {
+        // Intentionally ignored; syncApprovedWork is the recovery path
+    }
+}
+```
+
+Linkage mechanism, stated plainly (decision #5): Work attestations carry no commitment reference and never will (the Work schema is immutable, `corrections-log.md` H2). The mapping lives on the module: claimant or steward calls `linkWork(commitmentId, workUID)` before or after the approval. The resolver hook matches by workUID: the module looks up `workCommitment[workUID]`; if zero it returns without effect. Approvals landing before linkage are recovered by steward-called `syncApprovedWork(commitmentId, approvalUIDs)`, which verifies each approval on EAS and dedupes via `approvalCounted`.
+
+Trust model: linkage is operator-curated (steward and claimant are the only linkers), the resolver hook only counts approvals for pre-linked workUIDs, the module re-verifies garden and schema on every sync, and dedupe makes double-count impossible. The bridge couples resolver to module exactly as loosely as the existing KarmaGAP coupling: optional address, try/catch, disable by setting zero (`WorkApproval.sol:69-78`).
+
+Upgrade mechanics: WorkApprovalResolver is a live UUPS proxy at `0x166732eD81Ab200A099215cF33F6A712309B69F7` (`packages/contracts/deployments/42161-latest.json:59`); baseline entry already exists (`packages/contracts/script/check-storage-layout.sh:30`); regenerate baseline in the same PR; broadcast via `contracts:*` scripts.
+
+Acceptance criteria: approval with module unset behaves byte-identically to today; approval with module set and work unlinked emits nothing from the module and still validates; approval with linked work increments the counter once; a reverting module never blocks an approval (test with a mock module that always reverts).
+
+## 7. Deployment
+
+### 7.1 Deploy helpers
+
+- NET-NEW `_deployCommitmentRegister(...)` and `_deployCommitmentPoolingModule(...)` in `packages/contracts/test/helpers/DeploymentBase.sol`, copying `_deployCookieJarModule` byte-for-byte in shape (implementation `new`, ERC1967Proxy init bytecode, salted CREATE2 predict + deploy-if-absent + mismatch revert; `packages/contracts/test/helpers/DeploymentBase.sol:718-759`). Register deploys first (module address zero in init), module second, wiring closes the loop.
+- Call sites appended to `_deployCorePart2` after HypercertsModule (`DeploymentBase.sol:257-338` numbering continues at step 15c).
+- `_wireModules` additions (`DeploymentBase.sol:341-385`):
+  `commitmentRegister.setModule(module)`; `module.setGardenToken(gardenToken)`; `module.setHatsModule(hatsModule)`; `module.setCommitmentRegister(register)`; `module.setWorkApprovalResolver(workApprovalResolver)`; `module.setEAS(eas)`; `module.setSchemaUIDs(work, workApproval, legacyAssessment, assessmentV3)`; `gardenToken.setCommitmentPoolingModule(module)`; `workApprovalResolver.setCommitmentModule(module)`.
+
+### 7.2 Artifacts
+
+- `DeploymentResult` gains `address commitmentPoolingModule;` and `address commitmentRegister;` (`packages/contracts/script/DeployHelper.sol:42-72`) plus two `vm.serializeAddress` lines in `_saveDeployment` (`DeployHelper.sol:293-316`). Artifact keys: `commitmentPoolingModule`, `commitmentRegister` in `deployments/{chainId}-latest.json`.
+- Do NOT extend the fixed `NetworkConfig` struct (`DeployHelper.sol:24-40`); the module has no external network dependency beyond what wiring provides (HypercertsModule precedent: deployed and wired without a NetworkConfig field).
+- Schema artifact keys land via the standalone merge path (6.4.4), not `_saveDeployment`.
+
+### 7.3 Order of operations for 42161 (August)
+
+Deployment artifacts are the source of truth for addresses; pre-broadcast zero/missing addresses mean pending broadcast, post-broadcast they are blockers (root CLAUDE.md contract deployment rules).
+
+1. PR chain 1 (schemas): deploy resolvers + register the two schemas on Sepolia, then Arbitrum. Merge artifact keys.
+2. PR chain 2 (module + register): deploy `CommitmentRegister` + `CommitmentPoolingModule` proxies, wire module-side references, run `setSchemaUIDs` with the chain's artifact values.
+3. PR chain 3 (upgrades): upgrade GardenToken implementation (6.3) and WorkApprovalResolver implementation (6.5); `setCommitmentPoolingModule` / `setCommitmentModule`; register protocol pool on the root garden (`deployments/42161-latest.json:40-43`); backfill `registerPool` for the 13 live gardens.
+4. Update `packages/indexer/config.yaml` addresses from zero-address placeholders and bump `start_block` (8.1).
+
+All invocations through bun wrappers and named `contracts:*` root scripts; never raw forge (`.claude/rules/contracts.md`).
+
+## 8. Indexer plan
+
+Boundary restated: Envio indexes Green Goods core state only; EAS attestations are read from easscan (`packages/indexer/schema.graphql:282-288`). Every entity and stat below derives exclusively from `CommitmentPoolingModule` and `CommitmentRegister` events. Rules that bind every entity here: `chainId: Int!` on all entities, composite IDs `${chainId}-${identifier}`, create-if-not-exists in update handlers, `bun codegen` after any `schema.graphql`/`config.yaml` change (`.claude/rules/indexer.md`).
+
+### 8.1 `config.yaml` additions
+
+Contract blocks (event signatures match the 6.1/6.2 interfaces; enum params surface as `uint8`):
+
+```yaml
+  - name: CommitmentPoolingModule
+    handler: src/EventHandlers.ts
+    events:
+      - event: PoolRegistered(uint256 indexed poolId, address indexed garden, uint8 poolType)
+      - event: PoolCharterUpdated(uint256 indexed poolId, string charterCID)
+      - event: PoolReady(uint256 indexed poolId)
+      - event: PoolOpened(uint256 indexed poolId)
+      - event: PoolPaused(uint256 indexed poolId)
+      - event: PoolResumed(uint256 indexed poolId)
+      - event: PoolClosed(uint256 indexed poolId)
+      - event: PoolComposted(uint256 indexed poolId)
+      - event: PoolReopened(uint256 indexed poolId, bool toOpen)
+      - event: CycleSeeded(uint256 indexed cycleId, uint256 indexed poolId, uint8 cycleType, uint64 startTime, uint64 endTime, string metadataCID)
+      - event: CycleOpened(uint256 indexed cycleId, uint256 indexed poolId, uint16 gardenersBps, uint16 treasuryBps, uint16 operatorBps, uint16 evaluatorBps, uint16 communityBps, uint16 funderBps)
+      - event: CycleClosed(uint256 indexed cycleId, uint256 indexed poolId)
+      - event: CycleComposted(uint256 indexed cycleId, uint256 indexed poolId)
+      - event: CycleCancelled(uint256 indexed cycleId, uint256 indexed poolId, string reasonCID)
+      - event: CommitmentCreated(uint256 indexed commitmentId, uint256 indexed poolId, uint256 indexed cycleId, address creator, address recordedBy, uint8 direction, uint8 commitmentType, uint8 claimType, uint8 claimMode, string unitLabel, uint256 targetUnits, uint32 requiredApprovedWorkCount, uint64 dueDate)
+      - event: RewardDeclared(uint256 indexed commitmentId, address source, address token, uint256 amount)
+      - event: ConfirmerRuleSet(uint256 indexed commitmentId, address[] confirmers, uint32 threshold)
+      - event: ClaimRequested(uint256 indexed commitmentId, address indexed claimant, uint8 kind, address gardenContext)
+      - event: CommitmentAccepted(uint256 indexed commitmentId, address indexed counterparty, uint8 kind)
+      - event: WorkLinked(uint256 indexed commitmentId, bytes32 indexed workUID, address linker)
+      - event: WorkUnlinked(uint256 indexed commitmentId, bytes32 indexed workUID, address unlinker)
+      - event: ApprovedWorkCounted(uint256 indexed commitmentId, bytes32 indexed workUID, bytes32 approvalUID, uint32 approvedWorkCount, uint256 approvedUnits)
+      - event: EvidenceAttached(uint256 indexed commitmentId, string cid, address indexed attacher)
+      - event: AssessmentAttached(uint256 indexed commitmentId, bytes32 indexed assessmentUID, address attacher)
+      - event: CommitmentReadyForConfirmation(uint256 indexed commitmentId, bool overridden, string reason)
+      - event: ConfirmationRecorded(uint256 indexed commitmentId, address indexed confirmer, uint32 confirmationCount, uint32 threshold)
+      - event: CommitmentFulfilled(uint256 indexed commitmentId, bool fallbackConfirmation, string reason)
+      - event: CommitmentCancelled(uint256 indexed commitmentId, address indexed canceller, string reasonCID)
+      - event: CommitmentExpired(uint256 indexed commitmentId, address indexed caller)
+      - event: CommitmentDisputed(uint256 indexed commitmentId, address indexed raiser, string reasonCID)
+      - event: DisputeResolved(uint256 indexed commitmentId, uint8 resolution, string reasonCID)
+      - event: RewardPaid(uint256 indexed commitmentId, address indexed payer, address token, uint256 amount, bytes32 payoutRef)
+  - name: CommitmentRegister
+    handler: src/EventHandlers.ts
+    events:
+      - event: ClassRegistered(uint256 indexed classId, uint256 indexed poolId, string unitLabel, uint256 quota)
+      - event: QuotaUpdated(uint256 indexed classId, uint256 quota)
+      - event: ProviderExposureCapUpdated(uint256 indexed poolId, uint256 cap)
+      - event: UnitsCommitted(uint256 indexed classId, address indexed account, uint256 units, uint256 totalCommitted)
+      - event: UnitsReleased(uint256 indexed classId, address indexed account, uint256 units, uint256 totalCommitted)
+      - event: UnitsFulfilled(uint256 indexed classId, address indexed account, uint256 units, uint256 totalFulfilled)
+```
+
+Network entries for both `42161` and `11155111` start with the zero-address placeholder until broadcast, exactly like OctantVault today (`packages/indexer/config.yaml:81-82,104-105`), then swap to artifact addresses.
+
+### 8.2 `schema.graphql` additions
+
+The existing `PoolType` enum is taken by signal pools (`packages/indexer/schema.graphql:29-32`); all new enums are namespaced `Commitment*` to avoid the collision (also flagged in section 12).
+
+```graphql
+enum CommitmentPoolType { GARDEN PROTOCOL }
+enum CommitmentPoolState { NOT_READY READY OPEN PAUSED CLOSED COMPOSTED }
+enum CommitmentCycleType { SEASON CAMPAIGN }
+# On-chain vocabulary only. DRAFT / IN_PROGRESS / REVIEWING are derived in
+# shared selectors from these states + timestamps + commitment events.
+enum CommitmentCycleState { SEEDED OPEN RECONCILED COMPOSTED CANCELLED }
+enum CommitmentDirection { OFFER REQUEST }
+enum CommitmentKind { DOMAIN_IMPACT SUPPORT_SERVICE SEASON_CAMPAIGN OPERATOR_CAPTURED }
+# On-chain vocabulary only. DRAFT / ACTIVE / EVIDENCE_SUBMITTED /
+# PARTIALLY_APPROVED / RECONCILED are derived in shared selectors.
+enum CommitmentOnchainState { OFFERED REQUESTED ACCEPTED READY_FOR_CONFIRMATION FULFILLED CANCELLED EXPIRED DISPUTED }
+enum CommitmentClaimType { GARDEN INDIVIDUAL }
+enum CommitmentClaimMode { OPEN APPROVAL_GATED }
+enum CommitmentEventType {
+  POOL_REGISTERED POOL_CHARTER_UPDATED POOL_READY POOL_OPENED POOL_PAUSED
+  POOL_RESUMED POOL_CLOSED POOL_COMPOSTED POOL_REOPENED
+  CYCLE_SEEDED CYCLE_OPENED CYCLE_CLOSED CYCLE_COMPOSTED CYCLE_CANCELLED
+  CREATED REWARD_DECLARED CONFIRMER_RULE_SET CLAIM_REQUESTED ACCEPTED
+  WORK_LINKED WORK_UNLINKED APPROVED_WORK_COUNTED EVIDENCE_ATTACHED
+  ASSESSMENT_ATTACHED READY_FOR_CONFIRMATION CONFIRMATION_RECORDED FULFILLED
+  CANCELLED EXPIRED DISPUTED DISPUTE_RESOLVED REWARD_PAID
+  UNITS_COMMITTED UNITS_RELEASED UNITS_FULFILLED
+}
+
+type CommitmentPool {
+  id: ID! # chainId-poolId
+  chainId: Int!
+  poolId: BigInt!
+  garden: String! # garden account address, lowercase
+  poolType: CommitmentPoolType!
+  state: CommitmentPoolState!
+  charterCID: String
+  activeCycleId: BigInt # null when no open cycle
+  providerExposureCap: BigInt!
+  # Lifetime counts (event-driven counters, greenWill dedup pattern)
+  commitmentsOffered: BigInt!
+  commitmentsRequested: BigInt!
+  commitmentsAccepted: BigInt!
+  commitmentsReadyForConfirmation: BigInt!
+  commitmentsFulfilled: BigInt!
+  commitmentsCancelled: BigInt!
+  commitmentsExpired: BigInt!
+  commitmentsDisputed: BigInt!
+  workLinkedCount: BigInt!
+  workApprovedCount: BigInt!
+  # Unit tallies: numerators and denominators only, BigInt, never floats.
+  # Derived rates (computed in shared selectors, never stored):
+  #   workApprovalProgress = approvedUnits / expectedUnits
+  #   promiseKeptRate      = commitmentsFulfilled / commitmentsDue
+  #   cycleCompletionRate  = fulfilledUnits / expectedUnits
+  #   openExposureUnits is the safety gauge (not a ratio)
+  expectedUnits: BigInt!      # sum targetUnits of accepted commitments
+  approvedUnits: BigInt!      # sum approvedUnits from ApprovedWorkCounted
+  fulfilledUnits: BigInt!     # sum units from UnitsFulfilled
+  openExposureUnits: BigInt!  # committed minus released minus fulfilled
+  commitmentsDue: BigInt!     # accepted minus cancelled (mutually released promises are not broken promises)
+  createdAt: Int!
+  updatedAt: Int!
+}
+
+type CommitmentCycle {
+  id: ID! # chainId-cycleId
+  chainId: Int!
+  cycleId: BigInt!
+  poolId: BigInt!
+  garden: String!
+  cycleType: CommitmentCycleType!
+  state: CommitmentCycleState!
+  startTime: BigInt!
+  endTime: BigInt!
+  metadataCID: String!
+  # Allocation-class snapshot from CycleOpened (Hypercert cut-over input)
+  gardenersBps: Int!
+  treasuryBps: Int!
+  operatorBps: Int!
+  evaluatorBps: Int!
+  communityBps: Int!
+  funderBps: Int!
+  # Per-cycle stats, same numerator/denominator discipline as the pool
+  commitmentsAccepted: BigInt!
+  commitmentsFulfilled: BigInt!
+  commitmentsCancelled: BigInt!
+  commitmentsExpired: BigInt!
+  commitmentsDue: BigInt!
+  expectedUnits: BigInt!
+  approvedUnits: BigInt!
+  fulfilledUnits: BigInt!
+  openExposureUnits: BigInt!
+  createdAt: Int!
+  updatedAt: Int!
+}
+
+type Commitment {
+  id: ID! # chainId-commitmentId
+  chainId: Int!
+  commitmentId: BigInt!
+  poolId: BigInt!
+  cycleId: BigInt # null when not cycle-scoped
+  garden: String!
+  creator: String!
+  recordedBy: String!
+  counterparty: String # null until accepted
+  counterpartyKind: CommitmentClaimType
+  direction: CommitmentDirection!
+  commitmentType: CommitmentKind!
+  state: CommitmentOnchainState!
+  claimType: CommitmentClaimType!
+  claimMode: CommitmentClaimMode!
+  unitLabel: String!
+  targetUnits: BigInt!
+  requiredApprovedWorkCount: Int!
+  approvedWorkCount: Int!
+  approvedUnits: BigInt!
+  confirmationThreshold: Int!
+  confirmationCount: Int!
+  confirmers: [String!]!
+  requiresAssessment: Boolean!
+  assessmentUID: String
+  workUIDs: [String!]!
+  evidenceCIDs: [String!]!
+  dueDate: BigInt!
+  rewardSource: String
+  rewardToken: String
+  rewardAmount: BigInt
+  rewardPaid: Boolean!
+  rewardPayoutRef: String
+  readyOverridden: Boolean!
+  fulfilledByFallback: Boolean!
+  disputeReasonCID: String
+  cancelReasonCID: String
+  createdAt: Int!
+  updatedAt: Int!
+}
+
+# Audit trail, one row per event (VaultEvent pattern, schema.graphql:132-144)
+type CommitmentEvent {
+  id: ID! # chainId-txHash-logIndex
+  chainId: Int!
+  poolId: BigInt!
+  cycleId: BigInt
+  commitmentId: BigInt
+  eventType: CommitmentEventType!
+  actor: String!
+  units: BigInt
+  data: String # reason / CID / payoutRef payload where the event carries one
+  txHash: String!
+  timestamp: Int!
+}
+```
+
+### 8.3 Handler plan
+
+NET-NEW `packages/indexer/src/handlers/commitmentPool.ts`, registered as a side-effect import in `packages/indexer/src/EventHandlers.ts:18-25`. Patterns to copy, by name:
+
+- **Dedup counters**: pool/cycle counters increment exactly the way `holderCount`/`grantCount` do in `packages/indexer/src/handlers/greenWill.ts:66-88` (read existing entity, branch on prior existence, never double-count).
+- **Idempotency**: same-tx replay and already-exists guards as `packages/indexer/src/handlers/hypercerts.ts:38-42,71-75`.
+- **Create-if-not-exists**: out-of-order events materialize placeholder entities first (`createDefaultGarden` precedent, `packages/indexer/src/handlers/helpers.ts:89-110`; `.claude/rules/indexer.md`).
+- **ID helpers**: add `getCommitmentPoolId(chainId, poolId)`, `getCommitmentCycleId(chainId, cycleId)`, `getCommitmentId(chainId, commitmentId)`, `getCommitmentEventId(chainId, txHash, logIndex)` to `packages/indexer/src/handlers/helpers.ts`, re-exported through `packages/indexer/src/handlers/shared.ts`; composite `${chainId}-${identifier}` format throughout.
+- **Address normalization**: `normalizeAddress` for every address field (`helpers.ts:68-70`).
+- **Register events** update `openExposureUnits`/`fulfilledUnits` on both `CommitmentPool` and `CommitmentCycle` plus append `CommitmentEvent` rows; `UnitsCommitted`/`UnitsReleased`/`UnitsFulfilled` carry running class totals so handlers never re-sum.
+
+Run `bun codegen` in `packages/indexer` after the schema/config edits and before writing handler code (`.claude/rules/indexer.md`).
+
+### 8.4 Stat derivation contract
+
+The four locked aggregates, restated as indexer-owned numerators/denominators plus shared-selector division (no floats stored, no leaderboard semantics):
+
+| Aggregate | Numerator | Denominator | Notes |
+|---|---|---|---|
+| workApprovalProgress | `approvedUnits` | `expectedUnits` | per pool and per cycle |
+| promiseKeptRate | `commitmentsFulfilled` | `commitmentsDue` (accepted minus cancelled) | expiries count against; mutual releases do not |
+| cycleCompletionRate | `fulfilledUnits` | `expectedUnits` | per cycle |
+| openExposureUnits | running gauge | none | committed minus released minus fulfilled |
+
+## 9. Hypercert cut-over
+
+Zero HypercertsModule contract changes. The cut-over swaps the bundling unit and the allocation source; the mint pipeline is untouched.
+
+### 9.1 Bundling unit
+
+- Today: operator curates approved Work attestations at mint time; UIDs land in `Hypercert.attestationUIDs` via IPFS metadata parse (`corrections-log.md` §2 Hypercert row; `packages/indexer/src/handlers/hypercerts.ts:150-165`).
+- After cut-over: the bundling unit is fulfilled commitments. The mint metadata composer (shared, `corrections-log.md` §4 pointer to `packages/shared/src/modules/data/hypercerts-metadata.ts`) writes `bundleKind: "COMMITMENT"`, a `commitmentIds` array, and nests each commitment's work attestation UIDs and evidence CIDs as evidence within the IPFS metadata. Work stays visible as evidence; commitments are the impact claims.
+- The legacy work-bundling path stays readable and mintable (`bundleKind: "WORK_LEGACY"`, the default when metadata carries no discriminator). Existing certificates never re-migrate.
+
+### 9.2 Indexer entity change
+
+```graphql
+enum HypercertBundleKind { WORK_LEGACY COMMITMENT }
+
+# Fields appended to the existing Hypercert entity (schema.graphql:190-206):
+#   bundleKind: HypercertBundleKind!     (default WORK_LEGACY when absent)
+#   commitmentIds: [BigInt!]             (optional; present for COMMITMENT bundles)
+```
+
+Populated by extending `parseHypercertMetadata` in the ClaimStored handler (`packages/indexer/src/handlers/hypercerts.ts:131-177`); absent or unrecognized metadata resolves to `WORK_LEGACY`.
+
+### 9.3 Allocation classes
+
+- On-chain: only the six-role bps snapshot, set at cycle open, validated `sum == 10_000` (`InvalidAllocation`, mirroring `InvalidSplitRatio` at `packages/contracts/src/resolvers/Yield.sol:107,373`), emitted in `CycleOpened`, stored on the cycle and indexed on `CommitmentCycle` (8.2).
+- App-computed: per-address allowlist expansion. The app resolves each class to concrete addresses (fulfilled-commitment providers for gardeners' share, garden treasury, steward, evaluators, community confirmers, funders), multiplies by class bps against `TOTAL_UNITS = 100_000_000` and runs the existing validate + IPFS upload + merkle-root pipeline unchanged (`corrections-log.md` §2: allowlist/merkle/IPFS are already app-side).
+- Holder: already satisfied. `createAllowlistAndRegister(garden, ...)` passes the garden as hypercert creator/holder, so the ERC-6551 garden account holds the cert (`packages/contracts/src/modules/Hypercerts.sol:139-166`, holder at line 160).
+
+### 9.4 Protocol-shipped allocation presets (guidance models from Document A)
+
+Shipped as shared constants (app-level presets; the chain enforces only the 10_000 sum). Per-garden policy is chosen at cycle open by the steward.
+
+| Class | Model 1 (default) | Model 2 | Model 3 |
+|---|---|---|---|
+| gardeners | 6000 | 3000 | 4000 |
+| treasury | 1500 | 4500 | 2000 |
+| operator | 1000 | 1000 | 2000 |
+| evaluator | 500 | 500 | 1000 |
+| community | 500 | 500 | 500 |
+| funder | 500 | 500 | 500 |
+
+Default is Model 1. Guidance (not chain-enforced): keep the treasury class at a 1500-2000 bps floor so garden regeneration is always funded; the app warns below it.
+
+### 9.5 Acceptance criteria
+
+- A COMMITMENT-bundle mint produces an indexed Hypercert with `bundleKind: COMMITMENT` and populated `commitmentIds`; a legacy mint still resolves `WORK_LEGACY`.
+- Cycle-open bps snapshot equals the allocation encoded in the minted allowlist within rounding (app test).
+- No change to `HypercertsModule` bytecode; `createAllowlistAndRegister` call shape is identical.
+
+## 10. Package-Level Backlog
+
+Each block below is shaped to map 1:1 onto one Linear workstream issue (acceptance criteria + surface + validation hint), children of PRD-650 for the August build per decision #23. Repo build order applies: contracts -> shared -> indexer -> client/admin/agent surfaces (root CLAUDE.md Build Order; indexer needs contract ABIs, frontends need shared).
+
+### `packages/contracts` PR chain 1: schemas and resolvers (FIRST, decision #26)
+
+Deliverables: `AssessmentV3Schema` + `CommunityTestimonySchema` structs in `src/Schemas.sol`; `src/resolvers/AssessmentV3.sol` + `src/resolvers/CommunityTestimony.sol`; `config/schemas.json` keys `assessmentV3` + `communityTestimony`; `script/DeployCommitmentSchemas.s.sol` + `script/deploy/commitment-schemas.ts` + deploy CLI wiring; validate-script extensions; resolver unit tests; storage-layout entries + baselines.
+
+Acceptance: 6.4 acceptance criteria pass; Sepolia registration broadcast, then Arbitrum; artifact keys merged with v2 keys byte-identical; `bun run test` green in `packages/contracts`.
+
+### `packages/contracts` PR chain 2: module + register
+
+Deliverables: `src/modules/CommitmentPooling.sol`, `src/registries/Commitment.sol`, both interfaces, unit + fork tests, `DeploymentBase.sol` deploy helpers + wiring, `DeployHelper.sol` result fields + serialization, storage-layout entries + baselines + `StorageLayout.t.sol` additions.
+
+Acceptance: 6.1 and 6.2 acceptance criteria pass; deployed to Sepolia and smoke-tested with a scripted offer -> fulfilled pass; Arbitrum broadcast gated on chain-3 readiness.
+
+### `packages/contracts` PR chain 3: live upgrades + backfill
+
+Deliverables: GardenToken change set (6.3), WorkApprovalResolver bridge (6.5), 42161 broadcast runbook (one-shot ops doc in `.plans/active/commitment-pooling/`, not `scripts/`), protocol pool registration, 13-garden pool backfill.
+
+Acceptance: storage-layout gates green pre-broadcast; post-broadcast artifact shows both new addresses and non-zero pool count; a live approval on an existing garden emits `ApprovedWorkCounted` for a linked work.
+
+### `packages/indexer`
+
+Deliverables: `config.yaml` blocks (8.1, zero-address placeholders until broadcast), `schema.graphql` entities + enums (8.2, 9.2), `src/handlers/commitmentPool.ts`, hypercerts handler `bundleKind` extension, helper ID functions, `EventHandlers.ts` import, handler tests, `bun codegen` artifacts.
+
+Acceptance: local Docker stack replays a scripted Sepolia fixture and produces correct pool/cycle counters and unit gauges; the four aggregates in 8.4 derive with integer math only; no EAS reads anywhere in handlers.
+
+### `packages/shared`
+
+Deliverables: domain types (`CommitmentPool`, `CommitmentCycle`, `Commitment`, allocation preset constants; `Address` type per repo rules); ABI + address exports from the deployment artifact (import pattern per root CLAUDE.md Contract Integration); query hooks + `queryKeys.*` entries; derived-state selectors implementing the section 5 overlays (Active, EvidenceSubmitted, PartiallyApproved, InProgress, Reviewing, Reconciled) and the 8.4 rate math; **four new job-queue kinds**: `commitment` (create offer/request), `claim` (claim/accept), `evidence` (attach evidence CID), `confirm` (confirm fulfillment), extending the exactly-two-kinds baseline (`packages/shared/src/types/job-queue.ts` + `packages/shared/src/modules/job-queue/`, `corrections-log.md` §6); mutation hooks with `createMutationErrorHandler`.
+
+Acceptance: hooks exported from the barrel only; job kinds run through the existing IndexedDB + XState machine with MAX_RETRIES parity; locale keys mirrored es/pt (repo i18n gate); `bun run --filter @green-goods/shared test` green.
+
+### `packages/admin`
+
+Deliverables (full flows in `uiux-spec.md`; contract touchpoints listed here): steward seeding console (createCommitment with confirmer rule + declared reward + claim mode), cycle management across 5.2, claims queue (`acceptClaim`), analog capture (OperatorCaptured via `onBehalfOf`, extending the `SubmitWork` on-behalf precedent), per-cycle assessment creation against the v3 schema, allocation preset picker at cycle open, dispute handling, `RewardPaid` recording. Garden workspace + new Pools workspace per decision #10.
+
+Acceptance: every module write goes through shared mutation hooks; no direct contract calls in views; admin remains restrained (no hero moments).
+
+### `packages/client`
+
+Deliverables (full flows in `uiux-spec.md`): offer/request creation, browse/claim, work linkage through the existing MDR flow, evidence capture, counterparty confirmation, commitment + cycle views in the Garden tab; personal commitments + pending-confirmations panel on the Profile wallet surface; Fulfilled and cycle-close hero moments (decision #27, client only). All field actions offline-queued via the four new job kinds.
+
+Acceptance: offline queue proof for each field action; mutual-aid copy only (banned-vocab lint passes).
+
+### Editorial website (client public routes)
+
+Deliverables: `/gardens/:id` GardenDialog pool view, cycle progress, promises-kept stats; `/impact` protocol-wide pool aggregates. Read-only, aggregate-only, no new routes (decision #21).
+
+Acceptance: renders exclusively from indexer aggregates; no per-person listings; small-community sensitivity respected (readiness copy before live numbers).
+
+## 11. Launch Milestones
+
+### Milestone 1: July dry run (no code)
+
+Goal: run the commitment loop socially on existing rails while the build proceeds.
+Exit criteria: methodology + scoping surveys complete (mandate artifact per garden); activations recorded; rewards flowing through existing Cookie Jar/treasury paths; zero contract dependencies.
+
+### Milestone 2: August release (the hard commitment)
+
+Goal: pools, cycles, commitments, confirmations, aggregates, and commitment-bundled Hypercerts live on Arbitrum One.
+Exit criteria, in dependency order:
+
+1. Schemas registered on Sepolia + Arbitrum with resolvers live (PR chain 1); baselines attestable before cycle 1 opens.
+2. Module + register deployed, wired, storage baselines committed (PR chain 2).
+3. GardenToken + WorkApprovalResolver upgraded on 42161; protocol pool + 13 garden pools registered (PR chain 3).
+4. Indexer serving the four aggregates from events alone.
+5. Shared substrate (types, hooks, four job kinds) consumed by admin + client + editorial surfaces.
+6. First real cycle seeded and opened with an allocation preset; first commitment fulfilled with counterparty confirmation; first `RewardPaid` recorded.
+
+### Milestone 3: September community interface
+
+Goal: `packages/community` PWA (view/signal/confirm-when-named) consuming the same shared substrate.
+Exit criteria: contract layer requires zero changes for it (view + confirm paths already exist in this spec); community testimony attestable from the new surface.
+
+## 12. Risks and Open Questions
+
+Carried verbatim from the session-plan skeleton (1-6), plus findings from this pass (7-12). Items marked DO-NOT-SILENTLY-FIX must be logged or decided, never patched in passing.
+
+1. **On-chain vs derived state weight.** The module carries more transition logic than the repo's thin-module convention (modules today mostly wire external protocols). Decision #6 accepts this deliberately; reviewers should challenge any FURTHER on-chain state before it lands, not the tabled set.
+2. **EAS -> module bridge coupling.** The resolver -> module hook has GAP precedent (`packages/contracts/src/resolvers/WorkApproval.sol:179-183`) but couples the approval path (criticality: critical) to a new module. Mitigations specced: optional address, try/catch, never-revert no-op semantics, sync fallback, mock-revert test. The bridge and trust model are named in 6.5; any change to linkage authority is a spec change.
+3. **Schema key versioning.** `assessmentV3*` keys sit beside untouched `assessment*` (v2) keys. Consumers must select by key, never by "latest". A future v4 repeats the pattern; nothing may ever rewrite an existing key (the `--update-schemas` overwrite hazard, `packages/contracts/script/Deploy.s.sol:122-151`).
+4. **Storage-layout script drift** (DO-NOT-SILENTLY-FIX). `script/check-storage-layout.sh:23-33` never gained CookieJarModule, HypercertsModule, GardensModule, OctantModule, YieldResolver, or UnifiedPowerRegistry. This spec adds ONLY its own two contracts plus touches to already-listed GardenToken/WorkApprovalResolver; the missing-module backfill is separate debt (log to the docs-freshness/debt Linear issue).
+5. **"Campaign" naming collision** (DO-NOT-SILENTLY-FIX). `CycleType.Campaign` collides conceptually with the existing `CampaignCookieJar` indexer entity (`packages/indexer/schema.graphql:259-280`) and the admin Cookies workspace. They are different things (a cycle type vs a funding jar). Copy, docs, and glossary entries must always say "campaign cycle" vs "campaign cookie jar"; do not rename either side in code.
+6. **Testimony "never averaged" is off-chain law only.** The schema deliberately has no score field, but nothing on-chain stops a future consumer from scoring testimony. Enforcement lives in indexer/app review (no aggregation of testimony into numbers) and the banned-vocab/design gates. Flag any PR that counts testimony.
+7. **StorageLayout.t.sol GardenToken drift** (DO-NOT-SILENTLY-FIX beyond the touched contract). Comments and gap tests describe a 7-named/43-gap layout (`packages/contracts/test/StorageLayout.t.sol:31-35,59-69`) while the source is 13 used + 37 gap (`packages/contracts/src/tokens/Garden.sol:56-62`); the gap tests are arithmetic tautologies (`expectedNamed + expectedGap == 50`). PR chain 3 corrects the GardenToken numbers it touches and must add real slot assertions for the new field; the tautology pattern across other contracts is logged debt.
+8. **Expiry timing with cycle fallback.** `expireCommitment` with `dueDate == 0` reads the cycle's endTime; commitments that are cycle-less AND dueDate-less can never expire (only cancel). Accepted for MVP; seeding UX should require one of the two.
+9. **Protocol-pool individual claims.** ClaimType.Individual accepts any role hat in any registered garden via a caller-supplied `gardenContext`. This is broad by design (protocol commitments are curated + default ApprovalGated per decision #19); if farming appears, tighten eligibility in the module without schema impact. Sarafu-precedent reclamation posture applies (suspend via pool pause, dispute, cancel).
+10. **GraphQL `PoolType` collision.** Existing enum at `packages/indexer/schema.graphql:29-32` is kept for signal pools; all new enums are `Commitment*`-namespaced. Do not "clean up" the old enum in this workstream.
+11. **Partial fulfillment is out of MVP.** Units convert all-or-nothing at Fulfilled. If gardens need partial credit mid-cycle, that is a module v1.1 (`fulfillUnits` already takes a units argument, so the register is ready).
+12. **Register upgrade authority.** The register is UUPS-owned by the multisig while mutations are module-gated (6.2). Anyone proposing owner==module must answer who upgrades the register.
+
+---
+
+Build order restated for the August track: contracts (schemas -> module/register -> upgrades) -> indexer -> shared -> admin + client PWA + editorial in parallel -> September community interface. The July dry run needs none of it.
+
+
+
+

--- a/.plans/active/commitment-pooling/corrections-log.md
+++ b/.plans/active/commitment-pooling/corrections-log.md
@@ -1,0 +1,95 @@
+# Commitment Pooling: Document A Corrections Log
+
+**Feature Slug**: `commitment-pooling`
+**Stage**: `active`
+**Created**: 2026-07-03
+**Scope**: Every repo-dependent claim in Document A ("Commitment Pooling Spec Direction", third pass) resolved against the codebase at branch `claude/loving-almeida-5126d7` (develop-parity worktree). Verdicts: **VERIFIED** (claim holds as written), **CORRECTED** (claim wrong or imprecise; actual truth stated with evidence), **UNVERIFIABLE** (cannot be resolved from repo or public sources), **SUPERSEDED** (user decision on 2026-07-03 overrode the claim; see Decision Register below).
+
+The contract and UI/UX specs in this folder build on THIS log, not on Document A as written.
+
+---
+
+## 1. Hypotheses H1–H7
+
+| # | Hypothesis | Verdict | Evidence |
+|---|---|---|---|
+| H1 | `GardenAssessment` is a registered EAS schema with a fixed field set | **VERIFIED**, with corrections to the assumed fields (§3) | UID `0x97b3a7378bc97e8e455dbf9bd7958e4c149bef5e1f388540852b6d53eb6dbf93`, registered name "Green Goods Assessment v2": `packages/contracts/deployments/42161-latest.json:44-48` |
+| H2 | EAS schemas are immutable once registered; any field addition needs a new UID | **VERIFIED** | No update path in EAS SchemaRegistry (`eas.schemaRegistry` `0xA310da9c5B885E7fb3fbA9D66E9Ba6Df512b78eB`, artifact line 10); resolvers validate exactly one `schemaUID` with a zero-bypass deployment window (`packages/contracts/src/resolvers/Work.sol:59-66`). v3 = fresh UID, decisive for the v2-vs-v3 call. |
+| H3 | No `CommitmentPoolingModule` exists | **VERIFIED** | No commitment/pool/cycle contract in `packages/contracts/src/`; the only "pools" are Gardens V2 conviction signal pools (`packages/contracts/src/modules/Gardens.sol`) |
+| H4 | Octant integration = OctantModule + "Granger UI" + MultistrategyVaultFactory on Arbitrum One | **CORRECTED** | OctantModule `0x70b25a2bAAA4f2Ae477bab315a87A03cfe89CEe9` and `octantFactory` `0x84bc88EdEB7d8C74683890070761bA225B65B74a` are real and on 42161 (artifact lines 36-37). **No "Granger" UI exists anywhere in `packages/admin`** (case-insensitive search: zero hits). Vault admin surface = `packages/admin/src/views/Garden/Vault.tsx` + `packages/admin/src/components/Vault/*` (PositionCard, DepositModal, WithdrawModal, GardenSupporters, ImpactFunders, VaultEventHistory). Client has read-only public `/vaults` (`packages/client/src/views/Public/Vaults.tsx`). |
+| H5 | Conviction voting wired through GardensModule signal pools, read via external subgraph; confirm whether yield-conviction AND priority-signal poll both exist | **CORRECTED (richer than hypothesized)** | GardensModule (`0x9d9F913eEeBAC1142E38E5276dE7c8bc9Cf7a183`) creates **two** CVStrategy signal pools per garden: **ActionSignalPool** (priority signal) and **HypercertSignalPool** (yield conviction): `packages/contracts/src/modules/Gardens.sol:52-62,93-94`. The yield-conviction path is live end-to-end: `packages/contracts/src/resolvers/Yield.sol:652-672,740-761` reads HypercertSignalPool conviction and distributes hypercert-fraction yield proportionally; app hooks exist (`packages/shared/src/hooks/conviction/useRegisterHypercert.ts`, `useAllocateHypercertSupport.ts`, admin `Garden/SignalPool.tsx`). The **priority-signal poll has NO app implementation**: ActionSignalPool is a contract-level rail only. CV math is external (Gardens V2). |
+| H6 | Community Hat created but not used as a distinct attestation gate | **VERIFIED** | Protocol-level Community/genesis hat `0x0000005c00020002...` exists (artifact line 22) and per-garden Community role exists (`IHatsModule.GardenRole`); its only live use is GreenWill genesis-badge eligibility (`rule: "Hat"`, artifact lines 110-111). No attestation gate, no app-side role surface. |
+| H7 | Cookie Jar = separate contract (allowlist, Hats-gated, rate limits, Safe or 6551 giver), read via RPC, not wired to G$ | **VERIFIED with corrections** | Per-garden per-asset jars via 1Hive `cookieJarFactory` `0x294d222eDE6DF6625B43544F1C634322467528Da` + `cookieJarModule` `0x726bfbd0B7449C8f4aBfbcc2FBC5a89eB18fF157` (artifact lines 5-6). Withdrawals are **Gardener-Hat** (ERC-1155) gated (`packages/contracts/src/modules/CookieJar.sol:248-296`); defaults `maxWithdrawal = 100 ether`, `withdrawalInterval = 86_400s` (lines 108-110). The **giver is the YieldResolver** (`yieldSplitter` `0x90896C86108528abB600Da3C48a1aa054958bDeb`) via `_routeToCookieJar` (`packages/contracts/src/resolvers/Yield.sol:582-606`): not a Safe. Jar owner is the garden TBA. Assets: WETH/DAI; **zero G$/GoodDollar references in the repo**. Indexer reads `CampaignCookieJar` metadata from `CookieJarFactory` events (not full jar ops). |
+
+## 2. §11 verification checklist
+
+| Item | Verdict | Actual truth + evidence |
+|---|---|---|
+| Assessment schema UID, field list, revocability, reporting-period type | **CORRECTED** | UID above. Registered string: `string title,string description,string assessmentConfigCID,uint8 domain,uint256 startDate,uint256 endDate,string location` (artifact line 47). Non-revocable (`AssessmentResolver.onRevoke → false`; work/approval likewise). **There is no reporting-period field**: `startDate`/`endDate` uint256 pair. The full strategy kernel (diagnosis, SMART outcomes, Cynefin phase, SDG targets, attachments) lives in IPFS behind `assessmentConfigCID` (artifact line 45). Document A's §2 "v2 field table" (diagnosis/SMART on-chain) actually described the **app-level TS type** `GardenAssessment` (`packages/shared/src/types/domain.ts:206-248`, `schemaVersion: "assessment_v2"`, `reportingPeriod: {start,end}`), not the on-chain schema. |
+| Assessment-to-work reference field | **VERIFIED (absent)** | No cross-reference field in `packages/contracts/src/Schemas.sol` (direct read, all three structs); assessments and work are independent attestation types. Linkage exists only app-side: Hypercert metadata is derived FROM an assessment (`packages/shared/src/modules/data/hypercerts-metadata.ts:142-205`: timeframe from reportingPeriod, SDGs, impactScopes from smartOutcomes). |
+| Where assessments are created | **CORRECTED** | **Admin only**: `packages/admin/src/views/Hub/CreateAssessment.tsx` and `packages/admin/src/views/Garden/Assessment.tsx`, orchestrated by shared `packages/shared/src/hooks/assessment/useCreateAssessmentWorkflow.ts` (IPFS uploads → SchemaEncoder → direct `eas.attest()`; **not offline-queued**). The client PWA does not create assessments. Authorship gate: resolver allows **evaluator OR operator** (`packages/contracts/src/resolvers/Assessment.sol:86-144`), not evaluator-only. No re-assessment / baseline-vs-delta / versioning concept exists anywhere in app or contracts. |
+| EAS immutability | **VERIFIED** | See H2. |
+| CommitmentPoolingModule absence | **VERIFIED** | See H3. |
+| Work + WorkApproval UIDs and resolver logic | **VERIFIED with corrections** | Work UID `0x43ebd37da5479df9d495a4c6514e7cb7f370e9f4166a0a58e14a3baf466078c4`; schema `uint256 actionUID,string title,string feedback,string metadata,string[] media`. WorkApproval UID `0x6f44cac380791858e86c67c75de1f10b186fb6534c00f85b596709a3cd51f381`; schema `uint256 actionUID,bytes32 workUID,bool approved,string feedback,uint8 confidence,uint8 verificationMethod,string reviewNotesCID` (artifact lines 49-56). WorkResolver validation order (doc comment `packages/contracts/src/resolvers/Work.sol:78-84`): identity = **gardener OR operator** (docs' "gardener" is incomplete), required fields, action exists, **TIMING: action start/end window enforced** (lines 117-131: the docs' "time window" claim is TRUE via the action's registry window), domain enabled for garden. WorkApprovalResolver (`packages/contracts/src/resolvers/WorkApproval.sol:96-185`): same-garden work ref, attester is operator, **no self-attestation** (lines 153-156), action active, **confidence 0–3** (docs' "0-100" is WRONG), verificationMethod 0–15 bitmask. Both non-revocable. Resolvers at `workResolver` `0x23F29AF...`, `workApprovalResolver` `0x166732eD...`, `assessmentResolver` `0x0646B09...` (artifact lines 3-4, 59-60). |
+| YieldSplitter split 30/40/30 and where configured | **CORRECTED** | Actual default in `packages/contracts/src/resolvers/Yield.sol:119-129`: **CookieJar 4,865 bps / Hypercert fractions 4,865 bps / Juicebox 270 bps** (sum 10,000; `InvalidSplitRatio` guard at line ~373). The 30/40/30 on docs.greengoods.app is stale: flagged for the docs-freshness Linear issue. Indexer tracks per-event `YieldAllocation {cookieJarAmount, fractionsAmount, juiceboxAmount, totalAmount}`. |
+| Hypercert minting path: work→hypercert mapping, TransferRestrictions, totalUnits, Arbitrum deployment | **VERIFIED with detail** | Path: admin `packages/admin/src/views/Hub/CreateHypercert.tsx` → shared `useMintHypercert` (`packages/shared/src/hooks/hypercerts/useMintHypercert.ts:268-297`, workflow `packages/shared/src/workflows/mintHypercert.ts`) → `HypercertsModule.createAllowlistAndRegister(garden, expectedHypercertId, totalUnits, merkleRoot, metadataUri)` (`packages/contracts/src/modules/Hypercerts.sol:139-166`) → `IHypercertMinter.createAllowlist`. The **garden ERC-6551 account is the hypercert creator/holder** (line 160 passes `garden`). Operator selects approved Work attestations at mint; UIDs recorded in indexer `Hypercert.attestationUIDs`; allowlist (addresses→fractions) validated + uploaded to IPFS + merkle-rooted app-side; app constant `TOTAL_UNITS = 100_000_000n` (`packages/shared/src/types/hypercerts.ts:74-83`, matches SDK default); `TransferRestrictions = 0` (AllowAll, `Hypercerts.sol:160` region). Mint auto-registers into HypercertSignalPool. **Arbitrum marketplace is live**: `hypercertMinter 0x822F17A9...`, `hypercertExchange 0xcE8fa095...`, `marketplaceAdapter`, `strategyHypercertFractionOffer` all deployed (artifact lines 31-39); Document A's mid-2024 "marketplace Arbitrum readiness open" is resolved. |
+| OctantModule + Granger + factory address | **CORRECTED** | See H4. |
+| Conviction voting both mechanisms | **CORRECTED (richer)** | See H5. |
+| Community Hat created vs used | **VERIFIED** | See H6. |
+| Cookie Jar interface, not wired to G$ | **VERIFIED with corrections** | See H7. |
+| Greenwill/Unlock: PublicLock deployment, grantKeys, Envio stat source | **VERIFIED with detail** | `greenWill` registry `0x6e6895580b386eB3aB9efe228f79cdBe5B61F5e7` + 3 non-transferable PublicLocks (v15) live on 42161: Genesis `0x3703EfF5...`, First Work `0x7BE17077...`, First Support `0xE8096e5E...` (artifact lines 62-145). Badge rules: `Hat` (genesis ← Community/genesis hat), `WorkAttestation` (← Work schema UID), `VaultShares`. Fully indexed: `GreenWillBadgeDefinition/Grant/Ownership` entities with `holderCount`/`grantCount` + `unlockLock` ref (`packages/indexer/src/handlers/greenWill.ts:63-115`). **No app UI exists for badges/locks**: recognition surfaces are net-new. Promise badges (rate-threshold rules from Fulfilled events) = a new rule type on this existing, indexed rail. |
+| Envio boundary | **VERIFIED** | `packages/indexer/config.yaml`: 10 contracts on 42161 + 11155111 (ActionRegistry, GardenToken, GardenAccount, HatsModule, OctantModule, OctantVault, YieldSplitter, HypercertMinter, GreenWill, CookieJarFactory); 21 entities. **EAS attestations are NOT indexed**: the app queries EAS directly via `packages/shared/src/modules/data/eas.ts` (assessments: lines 253-295; work/approvals similar; hypercert attestations via `hypercerts-attestations.ts`). Gardens V2 external; cookie jars: `CampaignCookieJar` metadata only. Consequence for the spec: **all commitment state and the four locked stats must be derivable from CommitmentPoolingModule events alone.** |
+
+## 3. §2 assessment delta audit: corrected baseline
+
+- Document A's "what v2 already covers" list conflated on-chain schema and app-level config. Corrected split: **on-chain** = title, description, configCID, domain (uint8 0–3: SOLAR/AGRO/EDU/WASTE), startDate, endDate, location. **IPFS config** (`AssessmentConfigPayload`) = diagnosis, SMART outcomes, Cynefin phase, SDG targets, attachments, capitals, metrics CID, evidence media. **App type** adds `schemaVersion: "assessment_v2"`, `selectedActionUIDs`, `reportingPeriod {start,end}` (mapped to startDate/endDate).
+- The v3 conclusion **stands** (H2): cycle reference and baseline/delta anchor fields cannot be added to the deployed UID. v3 must follow the thin-schema + config-CID pattern (new on-chain fields limited to what resolvers/indexed consumers need: cycle ref + baseline UID anchor + assessment kind).
+- Baseline-vs-delta, re-assessment, and versioned assessments: **absent everywhere**: net-new in v3.
+- Authorship today is evaluator OR operator; per the 2026-07-03 decisions, v3 keeps that for the baseline and tightens delta/re-assessment to Evaluator Hat only, with community testimony (Community Hat) as a separate schema.
+- **SUPERSEDED**: Document A's "commitment anchoring" via a commitment EAS schema. Decision #14 (2026-07-03): commitment records are **module-native** (Grassroots-Economics-shaped register), NOT EAS attestations. EAS registrations shrink to exactly two: assessment v3 + community testimony. Commitment→assessment anchoring becomes a field on the module's commitment record pointing at the assessment UID.
+
+## 4. §6 Hypercert cut-over checklist
+
+Covered in §2 table (minting path row). Additional facts for the cut-over spec: metadata prefill from assessment exists today (`hypercerts-metadata.ts`); claims read via indexer `HypercertClaim`; public garden dialog shows certificates. The current bundling unit is an operator-curated approved-work list at mint time: the cut-over replaces the selection source (fulfilled commitments, work nested as evidence) without touching the allowlist/merkle pipeline.
+
+## 5. §9 Greenpill Commons
+
+| Claim | Verdict | Evidence (gh, 2026-07-03) |
+|---|---|---|
+| Archived read-only May 8 2026 | **VERIFIED** | `isArchived: true`, `updatedAt: 2026-05-08T02:04:15Z` |
+| Exact last-commit date | **RESOLVED**: 2024-03-28 ("updated nav links"); last push 2024-04-27 | `gh api repos/greenpill-dev-guild/greenpill-commons/commits` |
+| Whether EAS writes actually happen | **RESOLVED: NO** | Code search for `eas` in the repo: **0 hits**. The `eas`/`attestations` topics are aspirational; on-chain layer is the thin Privy/wagmi/viem inheritance from the impact-stream fork. |
+| Stack (Next.js/Supabase/Storybook/Tailwind/pnpm) | **VERIFIED** | Repo tree: `next.config.mjs`, `supabase/`, `.storybook/`, `tailwind.config.js`, `pnpm-lock.yaml`; primary language TypeScript |
+| Code-level UX flows | **PARTIALLY UNVERIFIABLE from metadata**: description confirms "propose problems and solution onchain and upvote where action is needed"; view-level detail to be pulled from `src/` during the community-interface spec if needed | `gh repo view` description + topics (`pwa`, `voting`, `proposals`) |
+
+Reuse boundary confirmed: UX patterns (problem/solution proposal, upvote, surface-to-decision) only; the contract-facing architecture predates the current protocol and contains no EAS integration to reuse anyway.
+
+## 6. §1 "documented" claims spot-check
+
+- Module system, hub-and-spoke on GardenToken, UUPS + CREATE2, optional-module try/catch degradation: **VERIFIED** (`packages/contracts/src/tokens/Garden.sol`; graceful `onGardenMinted` try/catch at lines ~423-430).
+- "`uint256[37] __gap` plus a setter plus DeploymentBase wiring" per new module: **VERIFIED** (`Garden.sol:56-62` gap + slot comment; setters lines 181-227; `test/helpers/DeploymentBase.sol:341-383 _wireModules`).
+- Module names: **CORRECTED to actual filenames**: `src/modules/{Hats,CookieJar,Gardens,Octant,Hypercerts,Karma,Unlock}.sol` + `ActionRegistry` + ENS (`GreenGoodsENS` artifact key). Document A's list omitted Hypercerts.sol and Unlock.sol.
+- Six-role Hats tree + protocol hats: **VERIFIED** (`IHatsModule.GardenRole`: Owner/Operator/Evaluator/Gardener/Funder/Community + Admin parent; protocol genesis hat).
+- "YieldAllocation records three-way split (cookie jar / hypercert fractions / juicebox)": **VERIFIED** as destinations, **CORRECTED** on percentages (§2).
+- Root garden exists for protocol anchoring: `rootGarden.address 0xf401f34378384713222d1d21f63359cc4E8a858a, tokenId 1` (artifact lines 40-43): supports decision #8 (protocol pool = root garden pool).
+- Offline queue: **exactly two job kinds** (`work`, `approval`) in `packages/shared/src/types/job-queue.ts:57-95` + `packages/shared/src/modules/job-queue/` (IndexedDB, XState, MAX_RETRIES=5). All commitment actions need new job kinds.
+- Client PWA tabs Home/Garden/Profile, Passkey login, editorial routes incl. `/gardens/:id` GardenDialog: **VERIFIED** (`packages/client/src/components/Layout/AppBar.tsx:35-59`, `views/Login/`, `views/Public/*`).
+- Admin IA: 6 workspaces (Hub, Garden, Actions, Community, Profile, Cookies) + canvas sheets; analog-capture precedent `views/Garden/SubmitWork.tsx`: **VERIFIED**. No season/cycle UI exists.
+
+## 7. Docs-site staleness found (input to the docs-freshness Linear issue; no docs edits this session)
+
+1. Yield split "30/40/30" vs actual 4865/4865/270 bps (architecture pages).
+2. `v1-0.mdx` lists 5 action domains; implemented enum is 4 (5th "Mutual Credit and Farmer Verification" never built).
+3. WorkApproval "confidence 0-100" vs actual 0–3.
+4. Glossary has no Commitment/Campaign/Pool/Cycle entries (Season exists and is consistent).
+5. "Granger" naming (if present in any doc) does not correspond to any code.
+
+## 8. Decision Register supersessions applied to this log
+
+Per the 2026-07-03 alignment session (27 decisions recorded in the approved session plan and mirrored into `plan.todo.md` in this folder):
+- #14: no commitment EAS schema: module-native records (GE-shaped register). Affects §3 and every Document A mention of a "commitment schema" or "FulfillmentConfirmation resolver".
+- #15/#16: voucher-shaped unit accounting in a companion non-transferable ERC-1155-style `CommitmentRegister` owned by the module (supersedes PRD-649's single-artifact V1 stance; poolId semantics unchanged).
+- #17: Grassroots Economics grounding from the paper/docs only (Ruddick, "Commitment Pooling: an Economic Protocol", IJCCR; "Intro to Commitment Pools": curation/limiting/valuing grammar; seed round → exchange in/out → redemption steps). Never the AGPL Sarafu source.
+- #11: prompt's "create a dedicated project" superseded by convert-in-place of "Green Goods Seasons & Campaigns" → "Green Goods Commitment Pooling".
+
+Two-layer MVP (protocol pool + garden pools, August), counterpartyPoolId as post-MVP amendment, cycle types season/campaign, and all state machines: unchanged from the locked register and PRD-649 companions.

--- a/.plans/active/commitment-pooling/plan.todo.md
+++ b/.plans/active/commitment-pooling/plan.todo.md
@@ -1,0 +1,169 @@
+# Commitment Pooling Plan
+
+**Feature Slug**: `commitment-pooling`
+**Stage**: `active`
+**Status**: `ACTIVE: specs approved, Linear restructured, implementation not started`
+**Created**: `2026-07-03`
+**Last Updated**: `2026-07-04`
+
+Linear mirror: project [Green Goods Commitment Pooling](https://linear.app/greenpill-dev-guild/project/green-goods-commitment-pooling-4bc53572f354) (converted in place from Seasons & Campaigns). Every plan item below names its Linear issue. Milestones: July dry run (2026-07-31), August release (2026-08-31, hard commitment), September community interface (2026-09-30). Specs in this folder: `corrections-log.md`, `contract-spec.md`, `uiux-spec.md`.
+
+## Decision Log
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Commitments are module-native records, not EAS attestations; EAS gains exactly two schemas (assessment v3, community testimony) | EAS attestations are immutable one-shot records; commitment state changes constantly. User decision 2026-07-03, drawing on the Grassroots Economics structure. |
+| 2 | `CommitmentPoolingModule` (control plane) + companion non-transferable ERC-1155-style `CommitmentRegister` (classes, balances, quotas), voucher-shaped from day one | Model B settlement vouchers later wrap register classes 1:1 on the same poolId; no proof construct gets replaced. Supersedes PRD-649's single-artifact stance (user-approved). |
+| 3 | Hybrid state weight: hard transitions on-chain (seed, offer/request, accept, evidence count, ReadyForConfirmation, Fulfilled, cancel/expire, dispute flag, cycle open/close/compost, pool pause); Draft and review-soft states derived | Full three-machine on-chain would be the heaviest contract in the repo; EAS is not indexed so events must carry everything the indexer needs. |
+| 4 | EAS bridge: WorkApprovalResolver try/catch hook (GAP precedent) + operator `syncApprovedWork` fallback; approvals count only for pre-linked workUIDs | Automatic state without blocking attestations; operator-curated linkage is the trust model. |
+| 5 | Protocol pool = root garden (tokenId 1) pool, poolType PROTOCOL, cross-garden claim reach | Reuses existing custody and hats; no new identity machinery. |
+| 6 | Per-commitment claim mode (open vs approval-gated) set at seeding; declared reward + operator-executed payout + rewardPaid event; module never custodies funds | Zero CookieJar contract changes in August; custody stays where it is. |
+| 7 | Lightweight evidence object (IPFS CID via module event) for SupportService/OperatorCaptured; counterparty confirmation is the review; DomainImpact keeps full MDR | One human loop for low-stakes mutual aid; full approval rigor where impact is claimed. |
+| 8 | v3 authorship split: baseline = evaluator or operator; delta/re-assessment = Evaluator Hat only; testimony = Community Hat only | Preserves analog capture while keeping the two-voice evaluation model clean. |
+| 9 | Surfaces: PWA Garden tab + WalletDrawer pools panel; admin Garden workspace + NEW Pools workspace + Hub queue; editorial GardenDialog + /impact; September packages/community | Q&A decisions 9, 10, 21, 3; WalletDrawer already reserves the commitments tab. |
+| 10 | Clean room: Grassroots Economics paper + public docs only, never AGPL Sarafu source | RESR-57 D3 + non-AGPL constraint. |
+| 11 | Seasons & Campaigns project converted in place; legacy season issues composted with pointer comments | Seasons and campaigns are cycle types inside the pool; separate project inverted the dependency. |
+| 12 | Out of scope everywhere: Celo, settlement contracts, Sarafu integration, bridging, G$ movement, leaderboards | Locked register; Architecture 2 split-state stands. |
+
+Full register: 27 decisions in the approved session plan, mirrored into the specs.
+
+## Research / Plan Gate
+
+- [x] Research evidence recorded: `corrections-log.md` (every Document A repo claim verified, corrected, or superseded, with file paths)
+- [x] Existing repo patterns identified: CookieJar.sol module template, badge-schemas standalone registration, greenWill/hypercerts handler patterns, SubmitWork analog capture, WalletDrawer pools tab
+- [x] Human judgment points surfaced and decided: 27 alignment decisions (2026-07-03) + approved Linear change set (2026-07-04)
+- [x] Out of scope defined: Celo/settlement/Sarafu/bridging/G$ movement; no commitment EAS schema; no claim flow in the community interface v1
+- [x] Lightest honest validation chosen per lane (see Validation)
+
+## Requirements Coverage
+
+| Requirement | Lane | Linear issue | Status |
+|---|---|---|---|
+| Assessment v3 + community testimony schemas + resolvers (first PR chain) | `contracts` | [PRD-671](https://linear.app/greenpill-dev-guild/issue/PRD-671) | ⏳ |
+| CommitmentPoolingModule + CommitmentRegister + GardenToken wiring + deploy | `contracts` | [PRD-672](https://linear.app/greenpill-dev-guild/issue/PRD-672) | ⏳ |
+| Indexer entities, handlers, four locked stats, bundleKind | `indexer` | [PRD-673](https://linear.app/greenpill-dev-guild/issue/PRD-673) | ⏳ |
+| Shared substrate: types, hooks, queryKeys.pools, five job kinds, lightweight evidence, v3 workflow | `state_api` | [PRD-674](https://linear.app/greenpill-dev-guild/issue/PRD-674) | ⏳ |
+| Client PWA: Garden tab pool flows, WalletDrawer panel, hero moments | `ui_client` | [PRD-675](https://linear.app/greenpill-dev-guild/issue/PRD-675) | ⏳ |
+| Admin: Garden workspace pool console (cycles, seeding, claims, analog capture, assessment v3) | `ui_admin` | [PRD-676](https://linear.app/greenpill-dev-guild/issue/PRD-676) | ⏳ |
+| Admin: Pools workspace + Hub confirmation queue | `ui_admin` | [PRD-677](https://linear.app/greenpill-dev-guild/issue/PRD-677) | ⏳ |
+| Editorial: GardenDialog pool story + /impact aggregates | `editorial` | [PRD-678](https://linear.app/greenpill-dev-guild/issue/PRD-678) | ⏳ |
+| Hypercert cut-over: fulfilled-commitment bundling + allocation presets | `state_api` + `ui_admin` | [PRD-679](https://linear.app/greenpill-dev-guild/issue/PRD-679) | ⏳ |
+| Docs: glossary + architecture freshness | `docs` | [PRD-680](https://linear.app/greenpill-dev-guild/issue/PRD-680) | ⏳ |
+| Docs: operator seeding guide + gardener promises guide | `docs` | [PRD-681](https://linear.app/greenpill-dev-guild/issue/PRD-681) | ⏳ |
+| July: methodology survey (proto-commitment #1) | `july_dry_run` | [RESR-53](https://linear.app/greenpill-dev-guild/issue/RESR-53) (homed in Impact Framework, linked) | ⏳ |
+| July: commitment-scoping surveys + mandate artifacts (gates August seeding) | `july_dry_run` | [RESR-62](https://linear.app/greenpill-dev-guild/issue/RESR-62) | ⏳ |
+| July: activations + proto-commitment loops (TAS) | `july_dry_run` | [RESR-63](https://linear.app/greenpill-dev-guild/issue/RESR-63) | ⏳ |
+| July: pilot cohort readiness | `july_dry_run` | [RESR-13](https://linear.app/greenpill-dev-guild/issue/RESR-13) | ⏳ |
+| September: packages/community scaffold (view, signal, confirm) | `community` | [PRD-682](https://linear.app/greenpill-dev-guild/issue/PRD-682) | ⏳ |
+| September: community signals intake into the cycle-2 seeding gate | `ui_admin` | [PRD-683](https://linear.app/greenpill-dev-guild/issue/PRD-683) | ⏳ |
+
+Spine records (not work items): [PRD-649](https://linear.app/greenpill-dev-guild/issue/PRD-649) architecture record (closes when contract-spec merges), [PRD-650](https://linear.app/greenpill-dev-guild/issue/PRD-650) proof capability (parent of the August workstreams), [PRD-651](https://linear.app/greenpill-dev-guild/issue/PRD-651) settlement (gated), [RESR-57](https://linear.app/greenpill-dev-guild/issue/RESR-57)/[RESR-58](https://linear.app/greenpill-dev-guild/issue/RESR-58) research framing. Linked research: RESR-15, RESR-4, PRD-275.
+
+## Tracks and Sequencing (no week-by-week dates)
+
+### Track A: July dry run (existing rails, no code)
+
+Runs entirely in parallel with Track B. Tracks (a) methodology and (c) activations run in parallel; (b) scoping surveys gate August seeding.
+
+- [ ] (a) Methodology survey fielded and confirmed (RESR-53; first protocol-pool proto-commitment)
+- [ ] (b) Scoping surveys per cohort garden; one mandate artifact each (RESR-62); cohort per RESR-13
+- [ ] (c) Activations defined and run; at least one full proto-commitment loop per focus garden (RESR-63)
+- [ ] Tracking table maintained in the Linear project doc "July dry run: proto-commitment tracking"; rewards via Cookie Jar or treasury
+
+### Track B: August release build (the hard commitment)
+
+Sequencing (build order contracts, indexer, shared, then apps in parallel):
+
+1. [ ] PRD-671 schemas PR chain (independent; lands first so baselines exist before cycle 1)
+2. [ ] PRD-672 module + register + wiring (parallel with PRD-671 after interface freeze)
+3. [ ] PRD-673 indexer (starts from PRD-672's event signatures; zero-address placeholders pre-broadcast)
+4. [ ] PRD-674 shared substrate (starts from PRD-672 interfaces + PRD-673 schema; blocks all app lanes)
+5. [ ] In parallel after PRD-674: PRD-675 client, PRD-676 admin Garden, PRD-677 admin Pools, PRD-678 editorial, PRD-679 Hypercert cut-over
+6. [ ] PRD-680 + PRD-681 docs (PRD-680 can start any time; PRD-681 needs shipped surfaces for screenshots)
+7. [ ] Gated broadcast step: GardenToken upgrade + module/register deploy + schema registrations on Arbitrum One (post-broadcast blockers: artifact addresses, indexer config, schema UIDs)
+8. [ ] Cycle 1 opens: operator-curated seeding from the July mandate artifacts
+
+### Track C: September community interface
+
+- [ ] PRD-682 packages/community scaffold (after PRD-674 substrate; wireframes in `uiux-spec.md`)
+- [ ] PRD-683 signals intake into the seeding console (after PRD-676/682)
+
+## TDD / Proof Order
+
+- [ ] Identify the behavior boundary for each implementation lane before editing code
+- [ ] Write or select the minimal failing test/proof first
+- [ ] Run the RED command and record evidence in the lane handoff
+- [ ] Implement the smallest change that can satisfy the proof
+- [ ] Run the GREEN command and record evidence in the lane handoff
+- [ ] Record machine-readable proof with `node scripts/harness/plan-hub.mjs record-tdd`
+- [ ] If TDD cannot honestly apply, record `not_applicable` or `proof_limit` with a concrete note in `status.json`
+
+## Lane Checklists
+
+Agent eligibility per the 2026-07-03 decision: contracts / indexer / state-api lanes are Codex-eligible; all UI, design, and editorial lanes are Claude-only; QA pass 1 Codex, QA pass 2 Claude. Per-issue dispatch stays with Afo.
+
+### Contracts (`codex/contracts/commitment-pooling`): PRD-671, PRD-672
+
+- [ ] Contract logic and tests per `contract-spec.md`; bun wrappers only, never raw forge
+- [ ] Respect deployment ordering, storage-layout baselines, and upgrade safety (GardenToken gap 37 to 36)
+- [ ] Record RED/GREEN proof or a proof-limit note before marking the lane complete
+- [ ] Write `handoffs/codex-contracts.md`
+
+### Indexer (`codex/indexer/commitment-pooling`): PRD-673
+
+- [ ] Entities, handlers, stats per the spec's fenced definitions; `bun codegen` clean
+- [ ] Record RED/GREEN proof (scripted event-sequence test) before marking complete
+- [ ] Write `handoffs/codex-indexer.md`
+
+### State / API (`codex/state-api/commitment-pooling`): PRD-674, PRD-679 (shared half)
+
+- [ ] Hooks, stores, query keys, five job kinds; hooks stay in shared
+- [ ] Record RED/GREEN proof before marking complete
+- [ ] Write `handoffs/codex-state-api.md`
+
+### UI Client (`claude/ui-client/commitment-pooling`): PRD-675
+
+- [ ] Client tasks only; i18n en/es/pt for every new string; hero moments per spec
+- [ ] Record RED/GREEN proof or a proof-limit note
+- [ ] Write `handoffs/claude-ui-client.md`
+
+### UI Admin (`claude/ui-admin/commitment-pooling`): PRD-676, PRD-677, PRD-679 (admin half), PRD-683
+
+- [ ] Admin tasks only; AdminDialog anatomy (side sheets retired); i18n; Storybook coverage
+- [ ] Record RED/GREEN proof or a proof-limit note
+- [ ] Write `handoffs/claude-ui-admin.md`
+
+### Editorial (`claude/editorial/commitment-pooling`): PRD-678
+
+- [ ] Public surfaces only; aggregate-only data; small-community thresholds
+- [ ] Write `handoffs/claude-editorial.md`
+
+### Docs (`claude/docs/commitment-pooling`): PRD-680, PRD-681
+
+- [ ] Glossary anchors preserved; vocab lint green
+- [ ] Write `handoffs/claude-docs.md`
+
+### QA Pass 1 (`codex/qa-pass-1/commitment-pooling`)
+
+- [ ] Review implementation edges and regressions per lane acceptance criteria
+- [ ] Run targeted validation commands
+- [ ] Write `handoffs/codex-qa-pass-1.md`
+
+### QA Pass 2 (`claude/qa-pass-2/commitment-pooling`)
+
+- [ ] Review UI behavior and user flows through the authenticated Brave QA profile
+- [ ] Verify acceptance criteria against the specs; offline queue proof via mockAuth
+- [ ] Write `handoffs/claude-qa-pass-2.md`
+
+## Validation
+
+Per the Validation Intent Ladder: lane work uses targeted proof; the coordinator runs the Repo Quick Gate at checkpoints; Ship Gate before merge/release.
+
+- [ ] Lane-targeted: per-issue Validation sections (each Linear issue body names its commands)
+- [ ] Checkpoint: `node scripts/dev/ci-local.js --quick` after multi-lane merges
+- [ ] Ship Gate before release: `bun format && bun lint && bun run test && bun build` + `bun run lint:vocab` + `bun run check:design-tokens` + `bun run --filter @green-goods/shared check:stories` where stories changed
+- [ ] Full-local dogfood before cycle 1: `bun run dev` + `bun run dev:smoke:full`
+
+## Boundary
+
+No implementation code starts from this plan without the per-issue dispatch. Celo, settlement contracts, Sarafu integration, bridging, and G$ movement are out of scope for every lane. Garden-to-garden ships post-MVP via the reserved counterpartyPoolId amendment.

--- a/.plans/active/commitment-pooling/plan.todo.md
+++ b/.plans/active/commitment-pooling/plan.todo.md
@@ -25,7 +25,35 @@ Linear mirror: project [Green Goods Commitment Pooling](https://linear.app/green
 | 11 | Seasons & Campaigns project converted in place; legacy season issues composted with pointer comments | Seasons and campaigns are cycle types inside the pool; separate project inverted the dependency. |
 | 12 | Out of scope everywhere: Celo, settlement contracts, Sarafu integration, bridging, G$ movement, leaderboards | Locked register; Architecture 2 split-state stands. |
 
-Full register: 27 decisions in the approved session plan, mirrored into the specs.
+### Full decision register (2026-07-03 alignment session, 27 decisions)
+
+1. Spec home: all artifacts in `.plans/active/commitment-pooling/`; no docs-site promotion.
+2. Linear issue depth: workstream-sized issues, one per package workstream per track.
+3. Community interface: NEW package `packages/community` (own PWA, three tabs, Passkey, consumes shared).
+4. Git ending: conventional commits on the session branch plus a PR to develop.
+5. EAS bridge: WorkApprovalResolver hook (try/catch, non-blocking) plus operator `syncApprovedWork` fallback.
+6. State weight: hybrid; hard transitions on-chain (seed, offer/request, accept, evidence count, ReadyForConfirmation, Fulfilled, cancel/expire, dispute flag, cycle open/close/compost, pool pause); Draft and review-soft states derived.
+7. v3 authorship: baseline = evaluator or operator; delta/re-assessment = Evaluator Hat only; testimony = Community Hat only.
+8. Protocol pool: the root garden's pool (tokenId 1), poolType PROTOCOL, cross-garden claim reach.
+9. PWA placement: pool flows in the Garden tab; personal commitments + pending confirmations in the WalletDrawer pools tab; Home gets at most a summary card.
+10. Admin placement: garden-pool flows in the Garden workspace; NEW Pools workspace for the protocol pool console and cross-garden overview; Hub gains a confirmation queue.
+11. Seasons & Campaigns project: converted in place to "Green Goods Commitment Pooling" (supersedes the create-new-project instruction).
+12. Legacy season issues: composted aggressively with pointer comments; RESR-13 to the July milestone; RESR-15/RESR-4/PRD-275 stay linked research; PRD-344/495/347 rehomed out.
+13. Docs staleness: logged in corrections-log plus a Linear docs issue; no docs edits in the spec session.
+14. Commitments are NOT EAS attestations; module-native records; EAS gains exactly two schemas (assessment v3, community testimony).
+15. Voucher-shaped from day one: commitment units as non-transferable token-like accounting so Model B vouchers attach 1:1 later.
+16. Companion register contract: `CommitmentPoolingModule` (control plane) plus non-transferable ERC-1155-style `CommitmentRegister` (classes, balances, quotas), supersedes PRD-649's single-artifact stance.
+17. Clean room: Grassroots Economics paper and public docs only; never the AGPL Sarafu source.
+18. Rewards: declared reward reference plus operator-executed payout plus rewardPaid event; the module never custodies funds; zero CookieJar changes.
+19. Claim mode per commitment: open-claim or approval-gated, set at seeding; protocol pool defaults approval-gated, garden campaigns default open-claim.
+20. Meta evidence: lightweight evidence object (IPFS CID via module event, offline-queueable) for SupportService/OperatorCaptured; counterparty confirmation IS the review; DomainImpact keeps the full MDR path.
+21. Editorial: extend the GardenDialog with the pool story and add /impact aggregates; no new public routes.
+22. August docs workstreams: glossary + architecture freshness plus operator and gardener guides; no Document B docs page; no spec promotion.
+23. Issue tree: August build workstreams are children of PRD-650; PRD-649 closes when the contract spec merges; PRD-651 stays gated; July and September issues sit flat with milestones.
+24. Agent lanes pre-assigned: contracts/indexer/state-api Codex-eligible; UI, editorial, and docs lanes Claude-only; QA pass 1 Codex, QA pass 2 Claude.
+25. July tracking: update the existing methodology survey (RESR-53, stays in Impact Framework) rather than duplicating; create scoping-survey and activations issues; lightweight tracking table in a project doc.
+26. Schema registration timing: assessment v3 + testimony register as the FIRST PR chain of the August track so baselines exist before cycle 1 opens.
+27. Hero moments: commitment Fulfilled and cycle close/compost, client PWA only.
 
 ## Research / Plan Gate
 

--- a/.plans/active/commitment-pooling/status.json
+++ b/.plans/active/commitment-pooling/status.json
@@ -1,0 +1,239 @@
+{
+  "version": 1,
+  "feature": {
+    "slug": "commitment-pooling",
+    "title": "Commitment Pooling",
+    "kind": "feature",
+    "stage": "active"
+  },
+  "workflow": {
+    "overall_status": "planned",
+    "priority": "p1",
+    "created_at": "2026-07-03",
+    "updated_at": "2026-07-04"
+  },
+  "links": {
+    "corrections_log": "corrections-log.md",
+    "contract_spec": "contract-spec.md",
+    "uiux_spec": "uiux-spec.md",
+    "plan": "plan.todo.md"
+  },
+  "linear": {
+    "parentIssue": "PRD-650",
+    "architectureRecord": "PRD-649",
+    "project": "Green Goods Commitment Pooling",
+    "projectId": "fa1b7a04-6eee-4f43-a861-07d8205aa0bf",
+    "initiative": "Sustainability & Monetization + Impact Methodologies & Evaluator Flywheel",
+    "milestones": {
+      "july_dry_run": "2026-07-31",
+      "august_release": "2026-08-31",
+      "september_community_interface": "2026-09-30"
+    },
+    "syncDirection": "plans_to_linear_visibility",
+    "lastSyncedAt": "2026-07-04",
+    "lanes": {
+      "contracts": ["PRD-671", "PRD-672"],
+      "indexer": ["PRD-673"],
+      "state_api": ["PRD-674", "PRD-679"],
+      "ui_client": ["PRD-675"],
+      "ui_admin": ["PRD-676", "PRD-677", "PRD-679", "PRD-683"],
+      "editorial": ["PRD-678"],
+      "docs": ["PRD-680", "PRD-681"],
+      "july_dry_run": ["RESR-53", "RESR-62", "RESR-63", "RESR-13"],
+      "community": ["PRD-682"]
+    }
+  },
+  "taxonomy": {
+    "initiative": "sustainability-monetization",
+    "tracks": ["july-dry-run", "august-release", "september-community-interface"],
+    "work_types": ["research", "implementation", "docs"],
+    "surfaces": ["contracts", "indexer", "shared", "client", "admin", "docs", "community"],
+    "depends_on_features": []
+  },
+  "notes": [
+    "Commitments are module-native records; EAS gains exactly two schemas (assessment v3, community testimony). No commitment EAS schema.",
+    "CommitmentPoolingModule + non-transferable ERC-1155-style CommitmentRegister; settlement later wraps register classes on the same poolId (PRD-651, gated).",
+    "Clean room: Grassroots Economics paper and public docs only; never the AGPL Sarafu source.",
+    "Out of scope for all lanes: Celo, settlement contracts, Sarafu integration, bridging, G$ movement, leaderboards.",
+    "Agent eligibility (2026-07-03): contracts/indexer/state_api Codex-eligible; ui/editorial/docs Claude-only; qa_pass_1 Codex, qa_pass_2 Claude. Per-issue dispatch stays with Afo.",
+    "status.json is authoritative; branch names are automation signals.",
+    ".plans/ is the durable repo truth; the Linear project mirrors this hub 1:1."
+  ],
+  "lanes": {
+    "contracts": {
+      "owner": "codex",
+      "status": "todo",
+      "branch": "codex/contracts/commitment-pooling",
+      "depends_on": [],
+      "handoff": "handoffs/codex-contracts.md",
+      "linear_issues": ["PRD-671", "PRD-672"],
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": { "command": "", "evidence": "" },
+        "green": { "command": "", "evidence": "" },
+        "note": ""
+      },
+      "skill_tags": ["contracts"]
+    },
+    "indexer": {
+      "owner": "codex",
+      "status": "todo",
+      "branch": "codex/indexer/commitment-pooling",
+      "depends_on": ["contracts"],
+      "handoff": "handoffs/codex-indexer.md",
+      "linear_issues": ["PRD-673"],
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": { "command": "", "evidence": "" },
+        "green": { "command": "", "evidence": "" },
+        "note": ""
+      },
+      "skill_tags": ["indexer"]
+    },
+    "state_api": {
+      "owner": "codex",
+      "status": "todo",
+      "branch": "codex/state-api/commitment-pooling",
+      "depends_on": ["contracts", "indexer"],
+      "handoff": "handoffs/codex-state-api.md",
+      "linear_issues": ["PRD-674", "PRD-679"],
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": { "command": "", "evidence": "" },
+        "green": { "command": "", "evidence": "" },
+        "note": ""
+      },
+      "skill_tags": ["react", "tanstack-query", "data-layer"]
+    },
+    "ui_client": {
+      "owner": "claude",
+      "status": "todo",
+      "branch": "claude/ui-client/commitment-pooling",
+      "depends_on": ["state_api"],
+      "handoff": "handoffs/claude-ui-client.md",
+      "linear_issues": ["PRD-675"],
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": { "command": "", "evidence": "" },
+        "green": { "command": "", "evidence": "" },
+        "note": ""
+      },
+      "skill_tags": ["ui", "design", "react"]
+    },
+    "ui_admin": {
+      "owner": "claude",
+      "status": "todo",
+      "branch": "claude/ui-admin/commitment-pooling",
+      "depends_on": ["state_api"],
+      "handoff": "handoffs/claude-ui-admin.md",
+      "linear_issues": ["PRD-676", "PRD-677", "PRD-679", "PRD-683"],
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": { "command": "", "evidence": "" },
+        "green": { "command": "", "evidence": "" },
+        "note": ""
+      },
+      "skill_tags": ["ui", "design", "react"]
+    },
+    "editorial": {
+      "owner": "claude",
+      "status": "todo",
+      "branch": "claude/editorial/commitment-pooling",
+      "depends_on": ["state_api"],
+      "handoff": "handoffs/claude-editorial.md",
+      "linear_issues": ["PRD-678"],
+      "tdd": {
+        "mode": "optional",
+        "status": "pending",
+        "red": { "command": "", "evidence": "" },
+        "green": { "command": "", "evidence": "" },
+        "note": ""
+      },
+      "skill_tags": ["ui", "design"]
+    },
+    "docs": {
+      "owner": "claude",
+      "status": "todo",
+      "branch": "claude/docs/commitment-pooling",
+      "depends_on": [],
+      "handoff": "handoffs/claude-docs.md",
+      "linear_issues": ["PRD-680", "PRD-681"],
+      "tdd": {
+        "mode": "not_applicable",
+        "status": "not_applicable",
+        "red": { "command": "", "evidence": "" },
+        "green": { "command": "", "evidence": "" },
+        "note": "Docs lane; validation is docs build + vocab lint + anchor check."
+      },
+      "skill_tags": ["docs"]
+    },
+    "july_dry_run": {
+      "owner": "human",
+      "status": "todo",
+      "branch": null,
+      "depends_on": [],
+      "handoff": null,
+      "linear_issues": ["RESR-53", "RESR-62", "RESR-63", "RESR-13"],
+      "tdd": {
+        "mode": "not_applicable",
+        "status": "not_applicable",
+        "red": { "command": "", "evidence": "" },
+        "green": { "command": "", "evidence": "" },
+        "note": "Operational track on existing rails; tracked in the Linear project doc 'July dry run: proto-commitment tracking'."
+      },
+      "skill_tags": ["research"]
+    },
+    "community": {
+      "owner": "claude",
+      "status": "todo",
+      "branch": "claude/community/commitment-pooling",
+      "depends_on": ["state_api"],
+      "handoff": "handoffs/claude-community.md",
+      "linear_issues": ["PRD-682"],
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": { "command": "", "evidence": "" },
+        "green": { "command": "", "evidence": "" },
+        "note": "September track; starts after the August substrate lands."
+      },
+      "skill_tags": ["ui", "react", "design"]
+    },
+    "qa_pass_1": {
+      "owner": "codex",
+      "status": "blocked",
+      "ready_when_dependencies_met": true,
+      "manual_blocked": false,
+      "branch": "codex/qa-pass-1/commitment-pooling",
+      "depends_on": ["ui_client", "ui_admin", "editorial", "state_api", "contracts", "indexer"],
+      "handoff": "handoffs/codex-qa-pass-1.md",
+      "skill_tags": ["testing", "review"]
+    },
+    "qa_pass_2": {
+      "owner": "claude",
+      "status": "blocked",
+      "ready_when_dependencies_met": true,
+      "manual_blocked": false,
+      "branch": "claude/qa-pass-2/commitment-pooling",
+      "branch_trigger": "codex/qa-pass-1/commitment-pooling",
+      "depends_on": ["qa_pass_1"],
+      "handoff": "handoffs/claude-qa-pass-2.md",
+      "skill_tags": ["testing", "review"]
+    }
+  },
+  "history": [
+    {
+      "date": "2026-07-03",
+      "event": "Verification, alignment (27 decisions), and specs authored (corrections-log.md, contract-spec.md, uiux-spec.md)."
+    },
+    {
+      "date": "2026-07-04",
+      "event": "Linear restructure executed: Seasons & Campaigns converted to Green Goods Commitment Pooling; milestones + 15 workstream issues created; legacy season issues composted; HoA records corrected."
+    }
+  ]
+}

--- a/.plans/active/commitment-pooling/uiux-spec.md
+++ b/.plans/active/commitment-pooling/uiux-spec.md
@@ -1,0 +1,461 @@
+# Commitment Pooling: UI/UX Spec (Four Surfaces)
+
+**Feature Slug**: `commitment-pooling`
+**Stage**: `active`
+**Created**: 2026-07-03
+**Scope**: PR-openable UI/UX specification for the August release (client PWA, admin, editorial website) plus the September community interface at wireframe depth. Builds on `corrections-log.md` (verified IA facts) and the 27 locked decisions from the 2026-07-03 alignment session. Contract-facing names (events, fields, module functions) defer to `contract-spec.md` in this folder; where this spec names a module concept it is a reference, not a definition.
+**Grounding rule**: every claim about existing UI carries a repo file path. Everything else is marked NET-NEW.
+
+---
+
+## 0. Component naming and one chrome supersession
+
+This spec names only canonical components per `.claude/skills/design/prompt-contract.md` and `client-prompt-contract.md`. One correction to the session plan's vocabulary: the admin `LeftSheet` / `RightSheet` / `BottomSheet` renderers are **retired**. Every admin overlay is a centered `AdminDialog` (detail/inspection) or an `AdminDialog` `variant="flow"` + `ActionFlowShell` (create/commit flows), per `.claude/skills/design/prompt-contract.md` Layout shell table and `.claude/skills/design/quick-reference.md § Sheet Slot Anatomy` (landed in PRs #610/#613). Flow-to-surface mappings below therefore use: **MainSheet route section** vs **AdminDialog detail** vs **flow AdminDialog**. Admin views compose `CanvasRouteFrame` + `CanvasRouteHeader` + `CanvasRouteContent` (mandated by `.claude/rules/frontend-design.md` Rule 1; verified in `packages/admin/src/views/Garden/Vault.tsx:28-31,151-158`).
+
+Admin wrapper palette (15, filesystem is the count of record, `packages/admin/src/components/`): AdminBadge, AdminButton, AdminCard, AdminCheckbox, AdminDialog, AdminFab, AdminFilterChip, AdminLinearProgress, AdminListItem, AdminSearchToolbar, AdminSortSelect, AdminTabRail, AdminTextField, AdminTooltip, AdminViewActions. Client shared primitives per `client-prompt-contract.md`: DialogShell, Card, StatCard, StatusBadge, Alert, Skeleton, Spinner, HydrationFallback, FileUploadField, ListPrimitives, DatePicker, Surface, SyncStatusBar, AddressDisplay, DomainBadge. Missing primitives are flagged in §9, never invented.
+
+---
+
+## 1. Personas and roles recap (hat-based)
+
+Roles are Hats-tree roles, not app accounts (`IHatsModule.GardenRole`: Owner, Operator, Evaluator, Gardener, Funder, Community; corrections-log §6). Canonical personas per `docs/docs/builders/specs/v1-0.mdx § 3.1`: Gardener, Operator, Evaluator, Funder, Community.
+
+| Persona (hat) | Pool powers (per locked layer permissions) |
+|---|---|
+| Gardener | Create own offers/requests, claim, attach work + evidence, confirm when named counterparty |
+| Operator / Owner | Everything gardeners do, plus: seed campaign commitments, analog capture on behalf of members, cycle management, claims review (approval-gated mode), dispute/override with reason, rewardPaid recording, fallback confirmation with reason |
+| Evaluator | Delta/re-assessment + technical assessment authorship (assessment v3, decision #7); reviews flow through existing WorkApproval rails |
+| Funder | Seed/match garden campaign rewards (reward-source reference only, custody stays with pool owner); read pool story |
+| Community | View pool story, provide priority signal, confirm when named, community testimony attestation (Community Hat) when a commitment is aimed at the community |
+| Protocol team | Operator-equivalent on the root garden's protocol pool (tokenId 1, decision #8); today this maps to the admin `deployer` role gate (`packages/admin/src/routes/views.tsx:270-276`) |
+
+Self-confirmation is blocked everywhere. Counterparty confirmation is the review for SupportService/OperatorCaptured; DomainImpact keeps the full Work then WorkApproval path (decision #20).
+
+## 2. The one-pool UX invariant
+
+One pool UX across capability levels (UX Brief, locked). The base surface every member sees: offer support, request help, submit evidence, confirm promise kept, see open and fulfilled commitments, see readiness plus season/campaign progress. Settlement controls are additive and progressively disclosed later behind the pool's `settlementEnabled` capability flag; they are never a separate product, tab, or app. Every screen in this spec is designed so a settlement row can be added without moving anything.
+
+## 3. Copy system
+
+**Use**: offer, request, promise, promise kept, fulfilled, steward, season, campaign, readiness, confirmation, "take this up", "recorded on your behalf".
+**Avoid** (UX Brief): debt, owed, leaderboard, balance-shaming, market-first or swap-first framing.
+**Banned-vocab lint** (`bun run lint:vocab`, canonical list `docs/docs/reference/glossary-community.md § Banned Vocabulary`): no streak, countdown, leaderboard, FOMO anywhere; admin copy additionally bans hero language; client user copy bans dashboard/KPI/operator-cockpit words.
+Practical consequences baked into this spec: due dates render as calm dates ("runs through March 12"), never ticking timers; per-garden stats never render as ranked lists (cross-garden overview sorts alphabetically, §6.8); small-community rate suppression (§7.2); admin celebration is a quiet confirmation row, only the client PWA gets hero moments (decision #27).
+
+i18n: every new user-facing string ships as en + es + pt keys in `packages/shared/src/i18n/` (en.json verified; a 4-part locale coverage gate enforces parity). This spec proposes key families in §10 and writes no literal strings into code sections.
+
+## 4. State-to-UI mapping tables
+
+Locked state machines from the Lifecycle doc (digest §Locked state machines). Hybrid weight per decision #6: hard states on-chain, Draft and review-soft states app/indexer-derived. "Not surfaced" is an explicit decision, not an omission.
+
+### 4.1 Pool states
+
+| State | Client PWA | Admin | Editorial | Community |
+|---|---|---|---|---|
+| NotReady | Pool tab absent from garden detail | Garden Pool tab shows setup checklist (charter CID, capability flags) | Readiness copy, no stats | Readiness copy |
+| Ready | Pool tab present, readiness banner ("warming up, promises open when the first cycle is seeded"), browse/create disabled | Seed-first-cycle CTA enabled | Readiness copy | Readiness copy |
+| Open | Full base surface live | Full console | Live pool story | Live view + signal |
+| Paused | Banner "paused by stewards" with reason, all writes disabled, browse view-only | Pause reason + resume action | Neutral quiet-period line, aggregates stay | View-only |
+| Closed | View-only history | Compost action available | Aggregate story remains | View-only |
+| Composted | History + "ready for the next season" line | Reopen or new-cycle actions | Past-cycles aggregate | History |
+
+### 4.2 Cycle states (types: season, campaign)
+
+| State | Client PWA | Admin | Editorial | Community |
+|---|---|---|---|---|
+| Draft | Not surfaced | Cycle card, Draft chip, edit + seed actions | Not surfaced | Not surfaced |
+| Seeded | Pool banner "opens soon"; seeded commitments browsable read-only | Seeded list + open-cycle flow (includes allocation policy, §6.10) | Readiness copy ("promises are being prepared") | Read-only preview |
+| Open | Browse + claim + create enabled | Full cycle console | Active cycle progress | View + signal |
+| InProgress | Same chrome as Open, progress bar emphasized (members see one continuous "live" period; only the stage label differs) | Distinct stage on cycle stepper | Cycle progress | View |
+| Reviewing | Banner "stewards are reviewing"; evidence + confirmations still allowed (Reviewing and InProgress interchange) | Review queue emphasized | "In review" line | View |
+| Reconciled | Cycle summary card with promises-kept stats; cycle-close hero fires here (§5.10) | Reconciliation report + compost action | Cycle results in pool story | Results view |
+| Composted | Archived under pool history; next-cycle banner | Archived + start-next-cycle | Rolled into past cycles | Archived |
+| Cancelled | Quiet banner with reason | Cancelled chip + reason | Not surfaced (aggregates count completed cycles only) | Quiet banner |
+
+### 4.3 Commitment states
+
+| State | Client PWA | Admin | Editorial | Community |
+|---|---|---|---|---|
+| Draft | Author-only resume card in creation flow (local IndexedDB, `WorkDraftRecord` precedent `packages/shared/src/types/job-queue.ts:194-209`) | Operator drafts inside seeding console | Never | Never |
+| Offered | Browse card, "Offer" chip, claim CTA per claim mode; owner sees waiting state | Pool list | Counts only | View |
+| Requested | Browse card, "Request" chip, "I can help" CTA | Pool list | Counts only | View |
+| Accepted | Counterparty named on detail; card moves to "matched" filter | Pool list | Counts only | View |
+| Active | Work/evidence attach enabled, unit progress bar | Monitor list | Counted in active aggregate | View |
+| EvidenceSubmitted | Evidence rows on detail, chip | Review queue (work approval rails for DomainImpact) | Not distinct from Active | View |
+| PartiallyApproved | Partial progress bar + chip | Review queue | Not distinct | Not distinct |
+| ReadyForConfirmation | Confirm CTA for named counterparties; pending-confirmations inbox item (§5.8) | Hub Confirm stage (§6.9) + operator fallback | Not distinct | Confirm CTA when named |
+| Fulfilled | Fulfilled hero moment (§5.10), chip, declared-reward row | Reward row + "record payout" action | Fulfilled counts + promiseKeptRate | Testimony CTA when aimed at community |
+| Reconciled | Terminal timeline entry, rolled into cycle summary | Cycle reports | Aggregates | View |
+| Cancelled | Quiet chip + reason on detail, excluded from browse | List with reason | Aggregate counters only, never a public list | Not listed |
+| Expired | Chip + "offer again" CTA for owner (per-cycle renewal, deep-dive L1) | Expiry queue + re-seed | Aggregate only | Not listed |
+| Disputed | Detail banner "under review by stewards", CTAs frozen | Dispute resolution actions with mandatory reason, resolution visible in detail | Never surfaced individually; aggregates unchanged until resolved | Frozen view |
+
+---
+
+## 5. Surface 1: Client PWA (full depth)
+
+### 5.1 Verified IA and placement resolution (decision #9)
+
+Verified IA: bottom `AppBar` has exactly three tabs, Home `/home`, Garden `/home/garden`, Profile `/home/profile` (`packages/client/src/components/Layout/AppBar.tsx:35-59`, routes `packages/client/src/config/pwa-routing.ts:12-16`). The AppBar "Garden" tab is the work submission flow (Intro, Media, Details, Review steps; `packages/client/src/views/Garden/index.tsx` renders the `Work` component with `WorkIntro`/`WorkMedia`/`WorkDetails`/`WorkReview`, lines 46-49). Garden browsing and per-garden life happen in the Home tab: `GardenList` on `/home` (`packages/client/src/views/Home/index.tsx:28,273`) opens the garden detail at `/home/:id` (`packages/client/src/views/Home/Garden/index.tsx`), which carries `StandardTabs` with Work / Insights / Gardeners (`packages/shared/src/hooks/garden/useGardenTabs.ts:3-7`) plus the endowment and conviction drawers (`views/Home/Garden/index.tsx:41,476-478`).
+
+Resolution: decision #9 puts pool/cycle/browse/claim/confirm "inside the Garden tab". The per-garden surface in the verified IA is the garden detail at `/home/:id`, so the pool experience lands there as a NET-NEW fourth `GardenTab` value `Pool` (extend the enum in `packages/shared/src/hooks/garden/useGardenTabs.ts:3-7`; hook stays in shared per the hook boundary). The AppBar Garden tab remains the work flow, gaining only the commitment-linkage context (§5.7). This honors the decision's intent (pool life inside the garden experience, no fourth AppBar tab) with the surface the IA actually has.
+
+NET-NEW routes (client router): `/home/:id/pool` (tab deep link), `/home/:id/pool/:commitmentId` (commitment detail), `/home/:id/pool/new?direction=offer|request` (creation flow). AppBar hide rules extend the existing pattern (AppBar already hides on `/home/garden` and work detail, `AppBar.tsx:17-33`): hide on `/pool/new` (full-screen flow), keep visible on the pool tab and detail.
+
+### 5.2 Pool home (garden detail Pool tab) NET-NEW
+
+Content top to bottom:
+
+1. **Pool state banner**: renders the pool-state row from §4.1. Readiness-only vs live is stated plainly in the banner copy, not implied by chrome (open question 1, §13). Component: shared `Alert` for paused/cancelled tones; a quiet `Surface` band otherwise.
+2. **Cycle progress**: cycle name + type chip (season or campaign), stage stepper (Seeded, Open, InProgress, Reviewing, Reconciled), unit progress (workApprovalProgress = approvedUnits/expectedUnits) via the shared progress primitive (§9), and "runs through {date}" (never a ticking countdown). Cycle-level stats row: offered, accepted, fulfilled counts (`StatCard` grid, two per row).
+3. **Browse: open offers and requests**: filter chips All / Offers / Requests / Matched / Mine (client-local chips; admin `AdminFilterChip` is admin-only). Cards show: type chip (DomainImpact with `DomainBadge`; SupportService plain), title, unit label + target quantity, due date, state chip (`StatusBadge`), claim CTA.
+   - Claim CTA per claim mode (decision #19): OPEN mode renders "Take this up" and enqueues immediately (optimistic Accepted). APPROVAL_GATED renders "Ask to take this up" and enqueues a claim request (optimistic "requested, waiting for steward"). Mode is visible on the card as helper text, not a mode toggle; members never choose the mode.
+   - Protocol-pool commitments surfaced in a garden context show a claim-custody choice for operators only: claim as myself vs claim for this garden (GardenAccount custody; deep-dive L1). Gardeners always claim as themselves. The choice is instrumented (§11).
+4. **My commitments strip**: horizontal cards of the viewer's own offers/requests in this pool with state chips, linking to detail.
+
+Empty pool (Open but zero commitments): planted-seed illustration slot + two primary CTAs "Offer support" / "Request help" and operator-seeded hint text. The two CTAs are the persistent creation entry at the top of the browse section in all non-empty states too (base surface, §2).
+
+### 5.3 Commitment detail NET-NEW (`/home/:id/pool/:commitmentId`)
+
+- Header: title, type chip, state chip, unit label + quantity, due date, claim-mode helper line.
+- **State timeline**: vertical history of state transitions with actor and timestamp (module events via indexer). Uses the NET-NEW shared `StateTimeline` primitive (§9). Overrides and dispute resolutions render here with their reason text (lifecycle rule: overrides visible in member detail).
+- **Evidence list**: rows of lightweight evidence (photo/link/note, IPFS CID) with attach button while Active/EvidenceSubmitted/PartiallyApproved. `ListPrimitives` rows + `FileUploadField` in the attach sheet (`DialogShell`).
+- **Work linkage** (DomainImpact): linked work submissions with their `WorkDisplayStatus` chips (type `packages/shared/src/types/domain.ts:350-358`); "Submit work for this promise" CTA deep-links into the AppBar Garden tab flow with commitment context (§5.7); "Link existing work" opens a picker of the member's approved/pending works (enqueues `workLink`, §5.11).
+- **Confirm CTA**: visible only when the signed-in user is a named counterparty in the confirmer group and state is ReadyForConfirmation. Opens the confirmation flow (§5.6). Self-confirmation never renders the CTA (blocked on-chain; UI mirrors it).
+- **Declared reward row**: reward source (jar or treasury reference) + token + amount, and after Fulfilled a "reward released" or "reward pending" line fed by the module's rewardPaid record (decision #18). No custody or transfer controls on this surface in MVP.
+- Analog-captured commitments carry a "recorded by your operator on your behalf" chip; the member remains the named promise source (§13 question 2).
+
+### 5.4 Offer/request creation flow NET-NEW (`/home/:id/pool/new`)
+
+Full-screen flow reusing the work-flow chrome pattern (`TopNav` + `FormProgress`, verified in `packages/client/src/views/Garden/index.tsx:41-44`). Direction (offer vs request) comes from the entry CTA and stays editable in step 1. Steps:
+
+1. **What**: direction, commitment type (DomainImpact or SupportService for member creation; SeasonCampaign and OperatorCaptured are console-seeded only, §13 question 4), title, note.
+2. **How much**: unit label (free text with suggestions: hours, tasks, meals, rides, plants), target quantity, due date (`DatePicker`) or cycle deadline default.
+3. **Anchors** (DomainImpact only): pick the garden action(s) this promise fulfills through, using the action-selection card grammar the work flow intro already renders (`views/Garden/index.tsx:54-96` skeleton shows the action/garden card rails). SupportService skips this step entirely; its proof is lightweight evidence + confirmation (decision #20).
+4. **Review and promise**: summary + "Make this offer" / "Ask for this help". Submission enqueues the `commitment` job kind (§5.11) and returns to the pool tab with the optimistic card visible.
+
+Drafts persist locally per the existing draft pattern (mirror `WorkDraftRecord` semantics, `packages/shared/src/types/job-queue.ts:194-209`); resume prompt on re-entry (client `DraftDialog` precedent, `views/Garden/index.tsx:42`).
+
+### 5.5 Evidence capture NET-NEW
+
+From commitment detail: attach photo (camera or roll, `FileUploadField` with compression per the work flow's `imageCompressor` precedent in `packages/admin/src/views/Garden/SubmitWork.tsx:12`), a link, or a text note. All become one evidence object uploaded to IPFS at sync time (CID recorded via module event). One evidence object per enqueue; repeatable. Works fully offline: files serialize into IndexedDB (`SerializedFileData` pattern, `packages/shared/src/types/job-queue.ts:114-129`).
+
+### 5.6 Counterparty confirmation flow NET-NEW
+
+Entry points: commitment detail confirm CTA, and the pending-confirmations inbox (§5.8). Flow is a `DialogShell` sheet:
+
+1. Summary of the promise (title, promiser, units, evidence count, linked-work approval status).
+2. Any-N-of-group progress: "2 of 3 confirmations recorded" with the confirmer list (`AddressDisplay` rows; self highlighted). Progress meter needs the shared progress primitive (§9) with a text equivalent for screen readers.
+3. Confirm ("Promise kept") or decline with reason (declining routes to steward attention, it does not cancel; lifecycle keeps rejection non-permanent).
+4. Enqueue `confirmation` job; optimistic tick on the progress meter; if this was the Nth required confirmation, the optimistic state shows Fulfilled pending sync and the hero fires on sync completion (§5.10).
+
+### 5.7 Work linkage through the existing flow
+
+Work submission itself reuses the existing `work` job kind unchanged (task requirement; kinds today are exactly `work` and `approval`, `packages/shared/src/types/job-queue.ts:89-92`). Linkage:
+
+- Deep link from commitment detail sets a commitment context in the work flow store (`useWorkFlowStore` import, `views/Garden/index.tsx:23`), NET-NEW field. The Review step shows a "fulfills: {commitment title}" row. On submit, the `work` job's `meta` carries `commitmentId` (meta is an open record, `packages/shared/src/types/job-queue.ts:26`); the queue enqueues a dependent `workLink` job after the work syncs.
+- Post-hoc linking from commitment detail enqueues `workLink` directly with an existing workUID.
+- The link is module-native (commitment record references work UIDs); WorkApproval rails are untouched.
+
+### 5.8 Wallet dashboard panel: my commitments + pending confirmations
+
+**Found component**: the wallet dashboard is `packages/client/src/views/Home/WalletDrawer/index.tsx`, a `ModalDrawer` opened from the Home header icon (`views/Home/index.tsx:268,302`). It already declares a third tab `id: "pools"` labeled with the existing i18n key `app.wallet.tab.commitments`, currently rendering `ComingSoonStub` (`WalletDrawer/index.tsx:42-47,68-74`).
+
+Decision #9 said "Profile-tab wallet dashboard" with an explicit verify-in-execution clause. Execution verification: the wallet dashboard lives on the Home header, not the Profile tab (Profile is Account/Badges/Help sub-tabs, `packages/client/src/views/Profile/index.tsx:65-127`, with account panels in `views/Profile/Account.tsx`). The personal panel therefore lands in the already-reserved WalletDrawer pools tab; no Profile change ships in MVP (one panel, no duplication). Flagged as a verified deviation from the decision's wording, not its substance.
+
+Panel content (replaces `ComingSoonStub`):
+1. **My pending confirmations** (inbox, top): commitments where I am a named counterparty and state is ReadyForConfirmation, across all my gardens. Row: promiser, title, garden, "confirm" chevron into §5.6. Badge count on the drawer tab mirrors the cookie-jar tab's count pattern (`WalletDrawer/index.tsx:24-36`).
+2. **My commitments**: all my offers/requests across gardens with state chips (`StatusBadge`), grouped by garden, linking into `/home/:id/pool/:commitmentId`.
+3. Queued/unsynced items render with the queued chrome (§5.12) at the top of their group.
+
+### 5.9 Home summary card NET-NEW
+
+At most one card (decision #9): "Promises kept this cycle" on `/home` above `GardenList` (`views/Home/index.tsx:273`), shown only when at least one of the member's gardens has an Open/InProgress/Reviewing cycle. Content: fulfilled count vs due count across my gardens (absolute numbers, no percentage below the small-community threshold, §7.2) + tap-through to the busiest garden's pool tab. `Card` + `StatCard` composition. Not shown when empty; never a second pool card on Home.
+
+### 5.10 Hero moments (client only, decision #27)
+
+Registered against the canonical hero vocabulary (`.claude/skills/design/language.md § Hero Moments`; reference scaffold `packages/client/src/views/HeroMoments.stories.tsx`):
+
+| Moment | Level | Fires where |
+|---|---|---|
+| Commitment Fulfilled | High | (a) confirmation success sheet when the viewer's confirmation was the Nth required (fires on sync completion, not enqueue); (b) once for the promiser on next mount of commitment detail or pool tab after the state flips, tracked by a local seen-marker |
+| Cycle close (Reconciled) and compost | Medium (maps to the existing "seasonal transitions" slot) | Pool tab banner morph + cycle summary card reveal on first view of the Reconciled/Composted cycle |
+
+Full Warm Earth amplification per the scaffold's grammar; `prefers-reduced-motion` collapses to a static celebratory frame. Admin surfaces get a quiet confirmation row for the same events, never hero treatment (`prompt-contract.md § Hero Moments Live in the Client, Not the Cockpit`). Editorial is read-only and celebrates nothing.
+
+### 5.11 Per-action offline behavior (core deliverable)
+
+Queue substrate (verified): IndexedDB + XState, exactly two kinds today (`work`, `approval`; `packages/shared/src/types/job-queue.ts:89-92`), `MAX_RETRIES = 5` (`packages/shared/src/modules/job-queue/index.ts:88,247-248`), kind dispatch is a branch in `processJob` (`index.ts:277-288`), executors in `modules/job-queue/job-executors.ts`. New kinds extend `JobKindMap` and the dispatch branch; naming follows the existing single-noun convention.
+
+NET-NEW job kinds and per-action behavior:
+
+| Action | Kind | Payload sketch (all addresses `Address`) | Optimistic UI | Queued chrome | Retry/failure (MAX_RETRIES 5) | Sync-complete invalidation |
+|---|---|---|---|---|---|---|
+| Create offer / request | `commitment` | `{ poolId, gardenAddress, direction: "offer"\|"request", commitmentType, title, note, unitLabel, targetQuantity, actionUIDs?, assessmentUID?, dueDate?, capturedFor? }` (`capturedFor` = analog capture member source) | Card appears in browse + my-commitments with Offered/Requested chip and queued badge | Queued badge on card; SyncStatusBar count includes it | Failed chip + retry/discard on card after 5 attempts; tap shows lastError parsed via `parseContractError` | `queryKeys.pools.commitments(poolId)`, `queryKeys.pools.mine(userAddress)`, `queryKeys.pools.stats(poolId)` |
+| Claim / accept | `claim` | `{ commitmentId, poolId, gardenAddress, claimantKind: "garden"\|"individual", claimantAccount }` | OPEN mode: card flips to Accepted (matched) locally. APPROVAL_GATED: "waiting for steward" chip | Same queued badge grammar | Optimistic Accepted reverts to Offered/Requested with failed banner on permanent failure | `queryKeys.pools.commitment(commitmentId)`, `queryKeys.pools.commitments(poolId)` |
+| Attach lightweight evidence | `evidence` | `{ commitmentId, gardenAddress, note?, link?, media?: File[] }` (files serialized per `SerializedFileData`) | Evidence row appears with uploading state | Row-level spinner + queued badge; media held in IndexedDB | Row failed state, retry per row; media never silently dropped | `queryKeys.pools.commitment(commitmentId)` |
+| Link work to commitment | `workLink` | `{ commitmentId, workUID, gardenAddress }` (or deferred: `meta.commitmentId` on a `work` job spawns this after work syncs) | Linked-work row appears with pending chip | Chip "linking" | Row failed state + retry; work itself is unaffected | `queryKeys.pools.commitment(commitmentId)`, `queryKeys.works.*` (existing family) |
+| Confirm fulfillment | `confirmation` | `{ commitmentId, gardenAddress, confirmed: boolean, reason?, fallbackByOperator?: boolean }` | Progress meter ticks; inbox row shows "confirmation queued" | Inbox + detail show queued chip; Fulfilled hero deferred to sync completion | Tick reverts + failed banner with retry; never double-enqueue for same commitment (dedupe by commitmentId + userAddress) | `queryKeys.pools.commitment(commitmentId)`, `queryKeys.pools.pendingConfirmations(userAddress)`, `queryKeys.pools.stats(poolId)` |
+| Submit work | `work` (existing, unchanged) | Existing `WorkJobPayload` (`job-queue.ts:57-68`) + optional `meta.commitmentId` | Existing behavior | Existing SyncStatusBar behavior (`packages/shared/src/components/SyncStatusBar.tsx`) | Existing | Existing `worksKeys` + `queryKeys.pools.commitment` when meta carries linkage |
+
+Query-key family: NET-NEW `poolsKeys` module at `packages/shared/src/config/query-keys/pools.ts` (pool, cycles, commitments, commitment, mine, pendingConfirmations, stats), registered in `packages/shared/src/config/query-keys/registry.ts:11-39` as `queryKeys.pools`.
+
+View-only offline (no queueing, cached reads render with staleness note): pool/cycle stats, browse lists refresh, claim-mode metadata, reward status, dispute state. Console-side actions (seeding, cycle management, disputes, curation, rewardPaid) use the same queue plumbing but are online-expected admin actions (deep-dive offline split); the PWA never exposes them.
+
+### 5.12 PWA state list to screen treatment (UX Brief list)
+
+| Brief state | Treatment |
+|---|---|
+| Not ready | Pool tab absent (§4.1 NotReady); garden detail otherwise unchanged |
+| Readiness-only | Pool tab with readiness banner, browse/create disabled, cycle stepper empty (§4.1 Ready) |
+| Empty pool | Offer/Request CTAs + seeded-hint empty state (§5.2) |
+| Active offers/requests | Full browse + claim surface (§5.2) |
+| Queued offline job | Queued badge on the affected card/row + `SyncStatusBar` count above the AppBar (`packages/client/src/components/Layout/AppBar.tsx:63-68`); aria-live announcement (§12) |
+| Pending confirmation | Inbox row (§5.8) + detail CTA (§5.3); confirmer sees progress meter |
+| Fulfilled | Chip + hero moment once (§5.10); reward row updates |
+| Failed/retry | Failed chip after 5 attempts with retry/discard; error text via `parseContractError` + `USER_FRIENDLY_ERRORS` |
+| Disabled | Paused pool banner, controls disabled with explanation (never silently missing) |
+| Settlement-enabled (later) | Reserved rows only; no MVP UI (§2) |
+
+---
+
+## 6. Surface 2: Admin (full depth)
+
+### 6.1 Flow-to-surface map (decision #10)
+
+| Flow | Workspace | Surface |
+|---|---|---|
+| Pool overview + cycle management | Garden | NET-NEW Pool tab on the Garden workspace MainSheet route (`/garden/pool`); tab rail precedent `packages/admin/src/views/Garden/index.tsx:81-98` (overview/activity/settings via `AdminTabRail`) |
+| Operator seeding console | Garden | Flow AdminDialog (`variant="flow"` + `ActionFlowShell`), route `/garden/pool/seed`; precedent `packages/admin/src/views/Hub/CreateAssessment.tsx:12-22` |
+| Claims/review queue (approval-gated) | Garden | Queue list inside Pool tab; row opens AdminDialog detail |
+| Analog capture | Garden | Flow AdminDialog, route `/garden/pool/capture`; extends the Submit Work flow grammar (`packages/admin/src/views/Garden/SubmitWork.tsx:44-52`, route registration `packages/admin/src/routes/views.tsx:114-120`) |
+| Commitment detail, dispute/override, rewardPaid | Garden (and Pools for protocol pool) | AdminDialog detail with workspace `tone` prop |
+| Assessment v3 creation | Hub | Extend the existing flow AdminDialog at `/hub/assess/create` (`packages/admin/src/routes/views.tsx:124-135`, view `packages/admin/src/views/Hub/CreateAssessment.tsx`) |
+| Confirmation queue | Hub | NET-NEW Confirm stage on the existing stage rail (§6.9) |
+| Protocol pool console + cross-garden overview | NET-NEW Pools workspace | MainSheet route `/pools` with `AdminTabRail` (§6.8) |
+| Cycle-open allocation policy | Garden (and Pools) | Step inside the open-cycle flow AdminDialog (§6.10) |
+
+All admin copy stays restrained (no hero language, no gallery moments); celebration is a checkmark row in the cycle report.
+
+### 6.2 Garden workspace: Pool tab + cycle management NET-NEW
+
+Route `/garden/pool` added to the garden branch (`packages/admin/src/routes/views.tsx:168-215`) and to the Garden view's `AdminTabRail` (`packages/admin/src/views/Garden/index.tsx:81-98`). Composition: `CanvasRouteFrame` + `CanvasRouteHeader` (title "Pool", actions via `AdminViewActions`) + `CanvasRouteContent`.
+
+Sections (AdminCard blocks):
+1. **Pool status card**: pool state chip, capability flags (proofEnabled, paused), charter/policy CID link, pause/resume (`AdminButton` + `AdminConfirmDialog`).
+2. **Cycle console**: current cycle card with the full locked state machine as a horizontal stepper (Draft, Seeded, Open, InProgress, Reviewing, Reconciled, Composted). Each transition is a guarded `AdminButton` opening `AdminConfirmDialog` with consequence copy; Cancelled is a destructive action behind a reason field. Reviewing and InProgress interchange renders as a toggle pair. Open-cycle runs the flow in §6.10. Past cycles list below (`AdminListItem` rows, Reconciled/Composted chips, each opening an AdminDialog cycle report: counts, units, workApprovalProgress, promiseKeptRate, cycleCompletionRate).
+3. **Commitments table**: `AdminSearchToolbar` + `AdminFilterChip` row (state, type, direction) + `AdminSortSelect`; rows are `AdminListItem` with `AdminBadge` state chips; row opens the commitment AdminDialog detail (state timeline, evidence, linked work, confirmer rule, reward row, dispute/override actions §6.7).
+4. **Claims queue** (visible when any approval-gated commitments exist): pending claim requests with claimant (`AddressDisplay`), claimantKind chip (garden vs individual), approve/decline with reason. Approving enqueues the accept; declining returns the commitment to browse.
+
+### 6.3 Operator seeding console NET-NEW (`/garden/pool/seed`)
+
+Flow AdminDialog + `ActionFlowShell` steps (stepper precedent `CreateAssessment.tsx:171-177`):
+
+1. **Type and scope**: commitment type (SeasonCampaign, SupportService, DomainImpact, OperatorCaptured), direction (offer or request the pool is seeding), cycle binding, title, note. `AdminTextField` + type cards.
+2. **Requirements**: unit label + target quantity, required approved-work count, required domains/actions where relevant (DomainImpact), optional assessment requirement toggle + assessment picker, due date or cycle-deadline default.
+3. **Confirmation rule and reward**: confirmer rule builder, any N of a named group: address group picker (NET-NEW primitive, §9) + N stepper with validation N <= group size; claim mode toggle (open-claim vs approval-gated) prefilled by context default (protocol pool approval-gated, garden campaign open-claim; decision #19); declared reward: source reference (cookie jar address or treasury ref picker), token, amount (reference only, no custody move; decision #18).
+4. **Review and seed**: summary + seed action. Console actions are online-expected but ride the same queue plumbing (§5.11 note).
+
+### 6.4 Claims/review queue
+
+Covered in §6.2 section 4. Work-approval review for DomainImpact commitments stays on the existing Hub Work stage and `approval` job rails; the commitment detail simply reflects approved-work counts (gates from the Lifecycle doc: attached, approved, assessment-complete when declared, then ReadyForConfirmation; operator waivers surface as visible overrides).
+
+### 6.5 Analog capture NET-NEW (`/garden/pool/capture`)
+
+Extends the Submit Work on-console pattern (flow AdminDialog + `ActionFlowShell`, `SubmitWork.tsx:44-52`). Differences from member creation (§5.4): step 0 selects the member (the social source; `capturedFor` in the `commitment` payload) and the capture kind (offer, request, or confirmation on the member's behalf). Non-custodial phrasing is fixed in the flow header: the record names the member as the promise source and the operator as recorder (§13 question 2). Captured confirmations require the operator to be fallback-eligible and always carry a reason. Writes go through the same job kinds, never direct contract writes from the form (digest analog-capture rule).
+
+### 6.6 Assessment v3 creation (extend, not fork)
+
+Extend `packages/admin/src/views/Hub/CreateAssessment.tsx` (steps today: DomainContextStep, StrategyKernelStep, ActionsHarvestStep, lines 15-17,44-59; orchestrated by shared `useCreateAssessmentWorkflow`, direct EAS attest, online-only, corrections-log §2). NET-NEW in step 1 (domain context): cycle selector (garden's cycles), assessment kind toggle **baseline vs re-assessment (delta)**, and, when delta, a baseline-reference picker listing the garden's prior baseline assessments for the same domain. Per garden per cycle per domain: the form validates one baseline per (garden, cycle, domain) and points duplicates at the existing record. Authorship gating per decision #7: baseline allows evaluator or operator (current resolver behavior, corrections-log §2); delta/re-assessment renders only for Evaluator-hat holders and the resolver enforces it. Remains a direct attest (no offline queue); failure surfaces inline per the existing flow.
+
+### 6.7 Dispute/override and rewardPaid
+
+On the commitment AdminDialog detail:
+- **Dispute**: "Raise dispute" (allowed from Accepted through Expired per §4.3) with mandatory reason; resolution actions (to ReadyForConfirmation, Fulfilled, Cancelled, Expired, or Reconciled) each require reason text. All reasons render in the state timeline for members too.
+- **Override**: requirement waivers (for example waive a rejected work's replacement) carry reason and a visible "override" marker in both admin and member detail (Lifecycle rule).
+- **rewardPaid**: on Fulfilled, the declared-reward row gains "Record payout" (`AdminButton`); `AdminConfirmDialog` captures the executed rail reference (jar withdrawal or treasury tx) and records the module's rewardPaid event (decision #18). The row then shows paid status + reference. No value moves through this UI.
+
+### 6.8 NEW Pools workspace NET-NEW
+
+Registration path (all verified anchor points):
+1. Add `"pools"` to `AdminWorkspaceId` and `ADMIN_WORKSPACE_ROOTS` plus `adminRoutes.pools()` helpers in `packages/shared/src/utils/navigation/admin-routes.ts:3-10,48-56`.
+2. Add the route branch in `packages/admin/src/routes/views.tsx` using the deployer-gated Cookies precedent (`roleGatedBranch(["deployer"], ...)`, lines 269-277). Protocol team maps to the `deployer` role today.
+3. Reach it via the command palette, not a fifth NavigationBar tab: add to `ADMIN_TEAM_COMMAND_ROUTES` (`packages/shared/src/hooks/admin-ui/navigation/workspaceViews.ts:60-68`, Cookies precedent). The NavigationBar keeps its four workspace tabs (`workspaceViews.ts:20-58`; `prompt-contract.md` NavigationBar row).
+4. Tone: workspace tone scoping flows through `data-tone={workspaceId}` on the canvas (`packages/admin/src/components/Layout/CanvasLayout.tsx:453`); non-tone ids fall back to the neutral hub accent (`CanvasLayout.tsx:321-332`). MVP ships Pools on the hub fallback tone; a dedicated tone triple is a later polish item, avoiding an `AdminDialog` tone-union change now.
+
+View at `/pools`: `CanvasRouteFrame` + `AdminTabRail` with two tabs.
+- **Protocol pool tab**: the root-garden pool console (tokenId 1, `rootGarden 0xf401f34378384713222d1d21f63359cc4E8a858a`, corrections-log §6). Same section grammar as §6.2 (pool status, cycle console, commitments table, claims queue) plus: **funding view** (declared reward sources across protocol commitments, co-funded references with owning garden named; ownership stays with the garden pool, deep-dive L2), **claims across gardens** (claimant garden/individual column), and **confirmations queue** (protocol commitments awaiting confirmation, mirroring the Hub Confirm stage grammar §6.9 but scoped to the protocol pool).
+- **Gardens tab (cross-garden overview)**: one `AdminListItem` row per garden with pool state chip, active cycle stage, promiseKeptRate, openExposureUnits (the safety gauge, deep-dive L3). **Sorted alphabetically by garden name, no ranking order by default and no rank column ever** (no-leaderboard invariant). `AdminSortSelect` offers alphabetical and "recently active" only. Row opens that garden's pool detail in an AdminDialog (read-only cross-garden inspection; management stays in the garden's own workspace).
+
+### 6.9 Hub: Confirm stage on the existing rail NET-NEW
+
+The Hub pipeline rail is `AdminTabRail` fed by `PIPELINE_STAGE_CONFIG` with stages work, assess, certify, history (`packages/shared/src/hooks/admin-ui/hub/hub.utils.ts:21,121`; counts and visibility built in `packages/shared/src/hooks/admin-ui/hub/hub.workbenchModel.ts:146-166`; rendered in `packages/admin/src/views/Hub/index.tsx:128-139`). Add stage `confirm` between certify and history: queue of commitments in ReadyForConfirmation where the signed-in account is in the confirmer group or fallback-eligible, across the operator's gardens. Row: promiser, commitment title, garden, N-of-group progress (`AdminLinearProgress` + text), confirm/decline actions opening the AdminDialog detail. Stage count = queue length (stageCounts pattern, `hub.workbenchModel.ts:146-152`). Route `/hub/confirm` added beside the existing hub children (`packages/admin/src/routes/views.tsx:96-166`); stage content branch added to `HubStageContent` (`packages/admin/src/views/Hub/components/HubStageContent.tsx`).
+
+### 6.10 Hypercert allocation policy at cycle open NET-NEW
+
+A step inside the open-cycle flow (§6.2 section 2): allocation-class bps editor with preset picker.
+
+| Preset | gardeners | treasury | operator | evaluator | community | funder |
+|---|---|---|---|---|---|---|
+| Model 1 (default) | 6000 | 1500 | 1000 | 500 | 500 | 500 |
+| Model 2 | 3000 | 4500 | editable remainder split across the four remaining classes | | | |
+| Model 3 | 4000 | 2000 | 2000 | 1000 | editable remainder | |
+
+Presets prefill the custom bps editor (`AdminTextField` numeric row per class); every field stays editable. Validation: sum must equal 10000 (mirror the `InvalidSplitRatio` guard grammar from `packages/contracts/src/resolvers/Yield.sol`, corrections-log §2); soft warning when treasury < 1500 bps (the guidance floor is 15 to 20 percent). The chosen classes snapshot onto the cycle (emitted at cycle open; indexer stores the bps snapshot) and drive the fulfilled-commitment Hypercert allowlist computation at mint time (allowlist/merkle pipeline stays app-side, corrections-log §2). The `CreateHypercert` flow (`packages/admin/src/views/Hub/CreateHypercert.tsx`) gains a bundle-source toggle at cut-over: legacy approved-work bundle vs fulfilled-commitment bundle (work nested as evidence), per contract-spec.
+
+---
+
+## 7. Surface 3: Editorial website (full depth, decision #21)
+
+### 7.1 `/gardens/:id` GardenDialog: pool story section NET-NEW
+
+The dialog today: hero banner, header, four-cell stats strip (`dl` grid, Entries / Hands at work / Assessments / Certificates, `packages/client/src/views/Public/GardenDialog.tsx:249-278`), `FieldNotesSection` (line 280), Impact Certificates section (282-332), operators section (336-360). The pool story inserts **after `FieldNotesSection` and before the Impact Certificates section**: field notes stay the first-scroll content (editorial identity untouched) and the promises narrative flows into certificates ("fulfilled promises become Impact Certificates"), reusing the local `SectionHeading` grammar (`GardenDialog.tsx:404`).
+
+Section content:
+1. **Pool state copy**: one sentence per §4.1 column. Pre-launch (NotReady/Ready) renders readiness copy only, no numbers ("This garden is preparing its first season of promises").
+2. **Active cycle progress**: cycle name + type, stage phrase, "runs through {date}", one thin progress band (units approved vs expected). No timers.
+3. **Promises kept aggregate**: offered and fulfilled counts, promiseKeptRate and cycleCompletionRate as percentages **only above the small-community threshold** (§7.2), otherwise a counts-only sentence ("9 promises made, 7 kept so far"). Rendered with the existing `StatCell` grammar (`GardenDialog.tsx:250-277`) inside the section, not by widening the four-cell strip.
+4. **Hypercert reports tie-in**: when fulfilled-commitment bundles exist, one line linking down to the certificates section ("Fulfilled promises from this cycle are anchored in the certificates below").
+
+The four-cell stats strip itself does not change in MVP. `/gardens` grid cards (`packages/client/src/views/Public/Gardens.tsx`) are untouched.
+
+### 7.2 Small-community sensitivity (answers the digest's open question)
+
+Recommendation, locked for this spec: percentage rates (promiseKeptRate, cycleCompletionRate) render publicly only when the cycle has **at least 5 due commitments and at least 3 distinct promisers**. Below threshold, show absolute counts in sentence form and never a percentage; a single lapsed promise in a three-person pool must not read as a 33 percent failure on a public page. Cancelled and Disputed never appear individually anywhere public (§4.3). The threshold applies to the PWA Home summary card percentage too (§5.9); inside the garden (pool tab), members see their own full numbers.
+
+### 7.3 `/impact`: protocol-wide pool aggregates NET-NEW
+
+Add one editorial section to `packages/client/src/views/Public/Impact.tsx` using its section grammar (EditorialKicker + EditorialHeading + reveal wrapper, verified at lines 290-296 and 367-380): kicker "Promises", heading on aggregate mutual-aid framing (Document B relay vocabulary: promises offered, promises kept, gardens with live pools). Content: protocol totals (gardens with open pools, commitments fulfilled this season, protocol-wide promiseKeptRate subject to §7.2 thresholds aggregated at protocol scale), one line explaining the commitment lifecycle in relay terms, and a link to `/gardens`. No per-garden table on this page (that is the admin overview's job, and public per-garden comparison drifts toward ranking).
+
+### 7.4 Boundaries
+
+Read-only, aggregate-only. No leaderboards, no ranked lists, no participant-level data, no wallet addresses tied to promise outcomes, no dispute or cancellation stories. All pool stats flow from module events via the indexer (EAS is not indexed; corrections-log §2 boundary), so the public surfaces need no easscan reads.
+
+---
+
+## 8. Surface 4: Community interface (September, wireframe + view alignment, decision #3)
+
+### 8.1 Package and shell
+
+NET-NEW package `packages/community`: its own PWA, consumes `@green-goods/shared` (hooks, tokens, primitives), Passkey auth reusing the client login flow pattern (`packages/client/src/views/Login/`). Three-tab bottom navigation mirroring the client AppBar convention (`packages/client/src/components/Layout/AppBar.tsx:35-59`) so shared auth, shell, and sync scaffolding transfer directly.
+
+Proposed tabs and justification:
+- **Home** (garden/community home): the community member belongs to a garden's community; home is that garden's public-plus story. Mirrors the client Home-as-landing convention.
+- **Signals**: the one thing this interface adds to the world (propose and upvote); it earns a dedicated tab rather than hiding under Home.
+- **Profile**: passkey account, my confirmations when named, my testimony history. Mirrors the client Profile tab, letting shared account components reuse.
+
+No work submission, no claiming, no wallet drawer in September scope.
+
+### 8.2 Views (purpose, content blocks, primary actions)
+
+| View | Purpose | Content blocks | Primary actions |
+|---|---|---|---|
+| Home | See the garden pool story + readiness | Pool state banner (§4.1 community column); cycle progress band; aggregate stats (counts, thresholded rates per §7.2); recent fulfilled promises (aggregate cards, no member call-outs) | Tap-through to Signals; "confirm" shortcut appears only when named (badge) |
+| Signals | Provide priority signal feeding the cycle-2 seeding gate | Problem list (open community-raised needs); solution proposals nested under problems; upvote counts; "surfaced to stewards" chip when a signal crosses the surfacing bar | Propose problem; propose solution; upvote where action is needed |
+| Signal detail | One problem and its proposals | Problem statement; proposals with upvotes; status (open, surfaced, seeded as commitment with link) | Upvote; add proposal |
+| Confirmations (inbox in Profile) | Confirm when named counterparty | Pending confirmations list (same grammar as §5.8); commitment summary; N-of-group progress | Confirm promise kept; decline with reason |
+| Testimony (from a fulfilled commitment aimed at the community) | Community testimony attestation (Community Hat, EAS testimony schema) | Commitment summary; short testimony text field; prior testimonies (never averaged, digest rule) | Attest testimony |
+| Profile | Account + history | Passkey account block; my confirmations history; my testimonies; language settings | Sign out; manage passkey |
+
+Signal flow into admin: surfaced signals appear in the operator seeding console (§6.3 step 1) as a "from community signals" picker rail, closing the loop propose, upvote, surface, seed. The priority-signal rail exists at contract level only today (ActionSignalPool, corrections-log H5); the September UX writes signals through it or an app-level store, decided in the contract spec's cycle-2 gate section.
+
+### 8.3 Open claim-flow question (flagged, with recommendation)
+
+Open question: should community members claim commitments directly? **Document A's recommendation stands: stay view/signal/confirm for September.** Claiming implies work rails, evidence custody, and reward exposure the community interface deliberately lacks. Mitigation for real demand: operators capture community offers via analog capture (§6.5), keeping the member the named source. Revisit after one full cycle of signal data.
+
+### 8.4 greenpill-commons divergence table (facts: corrections-log §5)
+
+| Aspect | Reuse or discard | Why |
+|---|---|---|
+| Propose problem then propose solution flow | **Reuse (pattern)** | Verified repo description: "propose problems and solution onchain and upvote where action is needed"; matches the seeding gate's need for structured signal |
+| Upvote where action is needed | **Reuse (pattern)** | Simple, legible priority signal for non-operator members |
+| Signal-to-decision surfacing | **Reuse (pattern)** | Maps to signals surfacing in the operator seeding console (§8.2) |
+| Next.js + Supabase + Privy stack | **Discard** | Green Goods is a Vite + shared-package monorepo with Passkey auth; corrections-log §5 verifies the stack difference |
+| EAS integration | **Discard (nothing to reuse)** | Zero `eas` hits in the repo; the `eas`/`attestations` topics were aspirational |
+| Contract-facing architecture | **Discard** | Predates the current protocol (last commit 2024-03-28; archived 2026-05-08); commitment state is module-native here |
+
+---
+
+## 9. Missing primitives (flag, do not invent)
+
+| Primitive | Needed by | Closest existing thing and the gap |
+|---|---|---|
+| Shared linear progress meter (client-legal) | §5.2 cycle progress, §5.6 N-of-group meter, §7.1 progress band | `AdminLinearProgress` exists but is admin-only M3 (`packages/admin/src/components/AdminLinearProgress.tsx`); client has `FormProgress` (step dots, `packages/client/src/views/Garden/index.tsx:41`) which is not a quantity meter. Propose shared `ProgressMeter` in `packages/shared/src/components/` |
+| State timeline | §5.3, §6.2 commitment detail history | No vertical event-history primitive exists in shared or client; propose shared `StateTimeline` (rows: state, actor, timestamp, reason) |
+| Address group picker with N-of-group stepper | §6.3 confirmer rule builder | `ManageMembers` handles role membership (`packages/admin/src/views/Garden/ManageMembers.tsx`) but there is no reusable multi-address picker + threshold control; propose admin-side `AddressGroupField` composed from `AdminTextField` + `AddressDisplay` rows |
+| Unit quantity field (number + unit label pair) | §5.4 step 2, §6.3 step 2 | Composable from `FormField` + `AdminTextField`/inputs today; flag as a candidate shared field if the composition repeats more than twice |
+
+Tailwind gotcha applies to all new shared components: layout utilities authored in `packages/shared/src/` do not reach admin/client builds; use inline styles for layout in shared components or restate classes in the consumer (CLAUDE.md Known Gotchas; precedent `packages/shared/src/components/Canvas/MainSheet.tsx`).
+
+## 10. i18n key families (requirement, not strings)
+
+Every key ships en + es + pt (`packages/shared/src/i18n/en.json` + sibling locales; 4-part coverage gate). Existing family prefixes verified: `app.*` (client), `public.*` (editorial), `cockpit.*` and `app.admin.*` (admin). The wallet drawer already owns `app.wallet.tab.commitments` and `app.wallet.commitments.comingSoon` (`packages/client/src/views/Home/WalletDrawer/index.tsx:44,71`); the comingSoon key retires when §5.8 ships.
+
+| Family | Surface |
+|---|---|
+| `app.pool.*` | PWA pool tab, creation flow, commitment detail, confirmation flow |
+| `app.wallet.commitments.*` | Wallet drawer panel (§5.8) |
+| `app.home.poolSummary.*` | Home summary card |
+| `cockpit.garden.pool.*` | Admin Garden Pool tab, seeding, capture, claims queue |
+| `cockpit.pools.*` | Pools workspace |
+| `cockpit.hub.confirm.*` | Hub Confirm stage |
+| `public.pool.*` | GardenDialog pool story + `/impact` promises section |
+| `community.*` | `packages/community` (new package, same shared i18n pipeline) |
+
+All copy in these families passes `bun run lint:vocab` (§3).
+
+## 11. Analytics and instrumentation
+
+PostHog project routing per repo rule: client PWA + editorial + community events go to App (163591); admin events to Admin (262122). Event family proposal (snake_case, one family so funnels stay queryable):
+
+- `commitment_created` {direction, commitment_type, pool_type, captured_by_operator: bool}
+- `commitment_claimed` {claim_mode, claimant_kind: "garden"|"individual", pool_type} : **the garden-vs-individual claim custody ratio required by the locked register is the claimant_kind property on this event; dashboard = ratio over time per pool_type**
+- `commitment_evidence_attached` {media_kind}
+- `commitment_work_linked` {via: "deep_link"|"post_hoc"}
+- `commitment_confirmed` {nth_of_group, is_final, fallback_by_operator: bool}
+- `commitment_fulfilled_viewed` {surface} (hero exposure)
+- `cycle_opened` / `cycle_closed` / `cycle_composted` {cycle_type, allocation_preset}
+- `reward_paid_recorded` {rail: "cookie_jar"|"treasury"}
+- `pool_signal_created` / `pool_signal_upvoted` (community interface, September)
+- Offline queue health rides the existing job analytics (`packages/shared/src/modules/job-queue/job-analytics.ts`): new kinds inherit job_added/completed/failed tracking automatically.
+
+Privacy boundary: no counterparty addresses, commitment titles, or reason texts in event properties; counts, enums, and booleans only (matches the Linear/PostHog privacy rule in CLAUDE.md).
+
+## 12. Accessibility notes
+
+- **Confirmation flow focus order**: opening the confirm sheet moves focus to the sheet title; tab order is summary, progress meter (focusable, labeled "2 of 3 confirmations recorded"), reason field, decline, confirm; on close, focus returns to the invoking CTA or its replacement state chip. `DialogShell` and `AdminDialog` own the focus trap; do not hand-roll.
+- **Offline status announcements**: enqueue and sync-complete events get an `aria-live="polite"` announcement region colocated with `SyncStatusBar` (`packages/shared/src/components/SyncStatusBar.tsx`): "Saved on this device, will sync when connected" on job_added while offline; "N promises synced" on completion. Failed jobs use an assertive announcement once, not per retry.
+- **State never by color alone**: all state chips use `StatusBadge` (icon + color, `.claude/rules/frontend-design.md` Rule 12); the state timeline pairs icons with text labels.
+- **Progress meters** always carry text equivalents (units approved of expected; confirmations recorded of required).
+- **Hero moments** respect `prefers-reduced-motion` (static celebratory frame) and never trap focus; dismissible by any input.
+- **Admin rail and tabs** inherit roving tabindex from `AdminTabRail` (quick-reference Tabs table); the new Confirm stage and Pool tab add no custom key handling.
+- **Touch targets**: claim/confirm CTAs meet the 44px minimum on PWA cards; queued/failed badges are not the tap target, the card is.
+
+## 13. Open UX questions from the brief, answered
+
+1. **Readiness-only vs live/onchain explicitness**: state it in banner copy at the glance layer ("warming up" vs live cycle language, §4.1/§5.2); reserve chain-explicit phrasing ("recorded on Arbitrum") for the engage layer (commitment detail timeline footer). Do not put chain vocabulary on browse cards.
+2. **Non-custodial phrasing for operator-assisted capture**: fixed pattern "Recorded by {operator} on your behalf. The promise stays yours." on both the admin capture flow header (§6.5) and the member's commitment detail chip (§5.3). The member is always the named source on the record; the recorder is metadata.
+3. **Public stats for small communities**: threshold rule in §7.2 (rates only at >= 5 due commitments and >= 3 distinct promisers; counts-only sentences below). Applies to editorial and the PWA Home card; in-garden members always see full numbers.
+4. **Which commitment types may live outside a domain action**: SupportService and OperatorCaptured always may (evidence + confirmation is their proof); SeasonCampaign may when seeded as non-impact (deferrable assessment per the Lifecycle gates); DomainImpact never (action linkage is enforced by the creation flow, §5.4 step 3, and the seeding console, §6.3 step 2).
+5. **Where settlement controls will later sit**: behind the pool's `settlementEnabled` flag, additively: admin Garden Pool tab gains a Settlement section (curation/limits/valuing per the GE grammar) below the cycle console; PWA commitment detail's declared-reward row grows settlement rows; the Pools workspace funding view becomes the protocol settlement console. No new tabs, routes stay, one pool UX (§2).
+
+---
+
+## Appendix: verified anchor index (quick lookup)
+
+| Anchor | Path |
+|---|---|
+| PWA tabs + sync bar | `packages/client/src/components/Layout/AppBar.tsx:35-59,63-68` |
+| Work flow (Garden tab) | `packages/client/src/views/Garden/index.tsx` |
+| Garden detail + tabs | `packages/client/src/views/Home/Garden/index.tsx`; `packages/shared/src/hooks/garden/useGardenTabs.ts:3-7` |
+| Wallet dashboard (found) | `packages/client/src/views/Home/WalletDrawer/index.tsx:42-74` |
+| Profile tab | `packages/client/src/views/Profile/index.tsx:65-127` |
+| Job queue kinds + retries | `packages/shared/src/types/job-queue.ts:89-95`; `packages/shared/src/modules/job-queue/index.ts:88,247-288` |
+| Query keys registry | `packages/shared/src/config/query-keys/registry.ts:11-39` |
+| Admin workspace registry | `packages/shared/src/utils/navigation/admin-routes.ts:3-10,48-56`; `packages/shared/src/hooks/admin-ui/navigation/workspaceViews.ts:20-68` |
+| Admin routes | `packages/admin/src/routes/views.tsx` |
+| Hub stage rail | `packages/shared/src/hooks/admin-ui/hub/hub.utils.ts:21,121`; `packages/admin/src/views/Hub/index.tsx:128-139` |
+| Flow dialog precedents | `packages/admin/src/views/Hub/CreateAssessment.tsx:12-22`; `packages/admin/src/views/Garden/SubmitWork.tsx:44-52` |
+| Editorial dialog | `packages/client/src/views/Public/GardenDialog.tsx:249-360` |
+| Editorial impact page | `packages/client/src/views/Public/Impact.tsx:290-296,367-380` |
+| Bps sum guard precedent | `packages/contracts/src/resolvers/Yield.sol` (InvalidSplitRatio, corrections-log §2) |


### PR DESCRIPTION
## Summary

Implementation-readiness package for commitment pooling (August release hard commitment). Docs-only: five files under `.plans/active/commitment-pooling/`, no runtime code.

- **corrections-log.md**: every repo-dependent claim from the spec-direction research resolved as verified / corrected / superseded with file paths. Key corrections: yield split is 4865/4865/270 bps (not 30/40/30), the deployed assessment schema is thin (config-CID pattern), WorkApproval confidence is 0-3, no "Granger" UI exists, the Hypercert marketplace is live on Arbitrum, greenpill-commons contains zero EAS code.
- **contract-spec.md** (1,295 lines): `CommitmentPoolingModule` + companion non-transferable ERC-1155-style `CommitmentRegister`; commitments are module-native (no commitment EAS schema); EAS gains exactly two schemas (assessment v3, community testimony); WorkApprovalResolver bridge + operator fallback; hybrid on-chain state weight; deployment, indexer, and Hypercert cut-over plans; PR-openable interfaces and storage layouts.
- **uiux-spec.md** (461 lines): PWA (Garden tab flows + the already-reserved WalletDrawer commitments tab + Fulfilled/cycle-close hero moments), admin (Garden workspace console + new Pools workspace + Hub confirmation queue, AdminDialog anatomy), editorial (GardenDialog pool story + /impact aggregates, small-community thresholds), September `packages/community` wireframes.
- **plan.todo.md + status.json**: three tracks (July dry run, August release, September community interface) mirroring the Linear project 1:1, lanes with agent eligibility.

## Linear (executed per approved change set)

Project converted in place: [Green Goods Commitment Pooling](https://linear.app/greenpill-dev-guild/project/green-goods-commitment-pooling-4bc53572f354) (was Seasons & Campaigns). Milestones July/August/September created; four legacy season milestones archive-renamed. Workstreams: PRD-671..681 (August, children of PRD-650), RESR-62/63 (July), PRD-682/683 (September). Legacy season issues composted with pointer comments (RESR-48, RESR-7, RESR-5, PRD-349, RESR-3); PRD-344/495/347 rehomed; PRD-649/650 + HoA records corrected.

## Validation

Docs-only change (routine criticality): markdown re-read, zero em dashes, status.json parses, template conformance against `.plans/_templates/feature/`, Linear mirror verified by re-fetching the project roster. No build/test gates apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)