### PR TITLE
fix(admin,client): pre-bundle shared deps in optimizeDeps to stop dev reload storm

### DIFF
--- a/packages/admin/vite.config.ts
+++ b/packages/admin/vite.config.ts
@@ -305,7 +305,67 @@ export default defineConfig(async ({ command, mode }): Promise<UserConfig> => {
     },
     // Optimize dependency pre-bundling
     optimizeDeps: {
-      include: ["react", "react-dom", "posthog-js", "@sentry/react", "multiformats"],
+      // `@green-goods/shared` is excluded (served as source for HMR), so Vite's
+      // startup scanner never crawls its bare imports. Without the explicit
+      // include list below, every one of shared's runtime deps is "discovered"
+      // at request time on a cold cache, and each discovery broadcasts
+      // "✨ optimized dependencies changed. reloading" — a full-page reload that
+      // kills whatever in-flight lazy-route navigation the operator just
+      // clicked (the long-standing "Create Assessment flashes and refreshes"
+      // bug). Pre-bundling them at startup makes interaction-time discovery
+      // impossible. Keep in sync with packages/client/vite.config.ts; when a
+      // new bare import lands in shared, add it here (watch the dev log for
+      // "new dependencies optimized" — that line means this list has drifted).
+      include: [
+        "react",
+        "react-dom",
+        "posthog-js",
+        "posthog-js/react",
+        "@sentry/react",
+        "multiformats",
+        // ── @green-goods/shared runtime surface ──
+        "@ethereum-attestation-service/eas-sdk",
+        "@hypercerts-org/contracts",
+        "@hypercerts-org/marketplace-sdk",
+        "@hypercerts-org/sdk",
+        "@radix-ui/react-dropdown-menu",
+        "@radix-ui/react-popover",
+        "@radix-ui/react-select",
+        "@react-spring/web",
+        "@reown/appkit-adapter-wagmi",
+        "@reown/appkit/react",
+        "@storacha/client",
+        "@storacha/client/principal/ed25519",
+        "@storacha/client/proof",
+        "@use-gesture/react",
+        "@wagmi/core",
+        "@xstate/react",
+        "browser-image-compression",
+        "clsx",
+        "ethers",
+        "gql.tada",
+        "graphql-request",
+        // heic-to lives only under shared's node_modules (bun isolated
+        // linker), so it needs the linked-package `>` resolution form.
+        "@green-goods/shared > heic-to/csp",
+        "idb",
+        "idb-keyval",
+        "permissionless",
+        "permissionless/accounts",
+        "permissionless/clients/passkeyServer",
+        "permissionless/clients/pimlico",
+        "react-day-picker",
+        "react-hot-toast",
+        "react-select",
+        "tailwind-merge",
+        "tailwind-variants",
+        "viem/account-abstraction",
+        "viem/chains",
+        "xstate",
+        "zustand",
+        "zustand/middleware",
+        "zustand/react/shallow",
+      ],
       exclude: ["@green-goods/shared"],
     },
     // Fix CommonJS resolution for ESM packages

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -534,13 +534,60 @@ export default defineConfig(async ({ command, mode }) => {
     },
     // Optimize dependency pre-bundling
     optimizeDeps: {
-      // Include CJS packages that need named exports extracted
+      // `@green-goods/shared` is excluded (served as source for HMR), so Vite's
+      // startup scanner never crawls its bare imports. Pre-bundle shared's
+      // runtime dep surface up front — otherwise a cold cache discovers these
+      // at request time and broadcasts "optimized dependencies changed.
+      // reloading", a full-page reload that kills in-flight lazy-route
+      // navigation. Keep in sync with packages/admin/vite.config.ts.
       include: [
         "react",
         "react-dom",
         "posthog-js",
+        "posthog-js/react",
         "@sentry/react",
+        // ── @green-goods/shared runtime surface ──
         "@ethereum-attestation-service/eas-sdk",
+        "@hypercerts-org/contracts",
+        "@hypercerts-org/marketplace-sdk",
+        "@hypercerts-org/sdk",
+        "@radix-ui/react-dropdown-menu",
+        "@radix-ui/react-popover",
+        "@radix-ui/react-select",
+        "@react-spring/web",
+        "@reown/appkit-adapter-wagmi",
+        "@reown/appkit/react",
+        "@storacha/client",
+        "@storacha/client/principal/ed25519",
+        "@storacha/client/proof",
+        "@use-gesture/react",
+        "@wagmi/core",
+        "@xstate/react",
+        "browser-image-compression",
+        "clsx",
+        "ethers",
+        "gql.tada",
+        "graphql-request",
+        // heic-to lives only under shared's node_modules (bun isolated
+        // linker), so it needs the linked-package `>` resolution form.
+        "@green-goods/shared > heic-to/csp",
+        "idb",
+        "idb-keyval",
+        "permissionless",
+        "permissionless/accounts",
+        "permissionless/clients/passkeyServer",
+        "permissionless/clients/pimlico",
+        "react-day-picker",
+        "react-hot-toast",
+        "react-select",
+        "tailwind-merge",
+        "tailwind-variants",
+        "viem/account-abstraction",
+        "viem/chains",
+        "xstate",
+        "zustand",
+        "zustand/middleware",
+        "zustand/react/shallow",
       ],
       // Exclude local packages and ESM-only packages
       exclude: ["@green-goods/shared"],


### PR DESCRIPTION
## Problem

Clicking a Hub action (reported repeatedly for **Create Assessment** → `/hub/assess/create`) makes the admin dev app **flash and refresh** instead of opening the `AdminDialog`. Long-standing local-dev annoyance.

## Root cause (dev-only)

Both `packages/admin/vite.config.ts` and `packages/client/vite.config.ts` set `optimizeDeps.exclude: ["@green-goods/shared"]` with only a tiny `include` list. Excluding shared means Vite never pre-bundles the heavy runtime deps shared pulls in (xstate, ethers, eas-sdk, react-day-picker, react-select, wagmi, appkit, permissionless, storacha, heic-to…). On a cold/invalidated `.vite` cache those deps are **discovered at request time**, and each batch broadcasts `✨ optimized dependencies changed. reloading` — a full-page reload that kills the in-flight lazy-route navigation. The local admin dev log had **3,285** such reload lines.

## Fix

Pre-bundle shared's full runtime dependency surface via `optimizeDeps.include` in both configs, so interaction-time discovery (and its reload) can't happen. `heic-to/csp` uses the linked-package `@green-goods/shared > heic-to/csp` form because it resolves only under shared's `node_modules` (bun isolated linker).

`optimizeDeps.include` is **dev-server only** — Rollup ignores it during `vite build` — so there is **no production-build impact**.

## Verification

- Wiped `packages/admin/node_modules/.vite`, cold-booted with the fix, clicked Create Assessment during the early window that previously caught the reload → probe survived (no reload), dialog opened. Dev log: **zero** `optimized dependencies changed` lines.
- Confirmed the config change applies cleanly and both dev servers boot without resolve errors.

## Honest caveat

This eliminates the dep-discovery reload that matches the "flash and refresh" symptom. It is **not** a Create-Assessment-specific code defect: on a warm cache all three wizard dialogs (Submit Work, Create Hypercert, Create Assessment) open identically. "Isolated to CA" is a usage-timing artifact (it's the flow being actively QA'd, clicked soon after cache-invalidating shared edits). If CA-only failure ever persists after a clean reset, the next suspect is a stale persisted draft (`green-goods:create-assessment`), not the bundler.

## Scope

Two `vite.config.ts` files, +109/-2. Dev-tooling only; no runtime/app code, no production-build change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)