### PR TITLE
routines: growth-pulse restyle + GG registry/model tidy (batch 2+3)

### DIFF
--- a/docs/routines/README.md
+++ b/docs/routines/README.md
@@ -12,10 +12,10 @@ Guild-level routines live in [`greenpill-dev-guild/.github/routines/claude/`](ht
 | `health-watch.md` | active | Daily M-F 07:30 | `#engineering` (red only) | Linear Product Issues for accepted operational health work (unprojected) |
 | `growth-pulse.md` | active | Mon 09:00 weekly | `#growth` + `#funding` cross-post | Linear Product Issues for accepted anomalies (unprojected) + weekly digest as a Linear initiative status update (Sustainability & Monetization) |
 | `qa-triage-pulse.md` | active | Wed 21:00 UTC = 13:00 PST / 14:00 PDT (3h after the 10am PST Build Sync start) | `#product` (Discord summary, @mention when there's something to triage) | Linear Customer Needs only (pre-staged, label `source:qa-triage-pulse` + `qa-sync:<date>`); `/qa-triage` promotes them to Issues + QA-sheet rows interactively. Routine id: `trig_01GSagDiEV9Y8QTBzKeZsPSw` |
-| `release-prep.md` | active | 1st 16:00 UTC = 08:00 PST / 09:00 PDT (monthly, release kickoff) | `#engineering` (readiness brief; @mention on decision-needed risk) | none — read + draft only; no Linear/GitHub writes |
+| `release-prep.md` | **spec only — not scheduled** | (drafted for monthly release kickoff; no live trigger yet) | `#engineering` (readiness brief; @mention on decision-needed risk) | none — read + draft only; no Linear/GitHub writes |
 | `pr-review.md` | active | event-driven (PR open) | inline on PR | n/a |
 
-That's it — five scheduled cadences plus one event-driven, all cloud routines hosted at [claude.ai/code/routines](https://claude.ai/code/routines). Anything else previously in this folder (engineering-pulse, plan-executor, hotfix, drift-watch, metrics) has been removed: cut from the portfolio or converted to Claude Code skills (`/plan`, `/debug`).
+That's it — four scheduled cadences plus one event-driven, all cloud routines hosted at [claude.ai/code/routines](https://claude.ai/code/routines). (`release-prep.md` is drafted but has no live trigger yet, so it is not counted among the scheduled cadences.) Anything else previously in this folder (engineering-pulse, plan-executor, hotfix, drift-watch, metrics) has been removed: cut from the portfolio or converted to Claude Code skills (`/plan`, `/debug`).
 
 ## Connector Matrix
 

--- a/docs/routines/bug-intake.md
+++ b/docs/routines/bug-intake.md
@@ -27,7 +27,7 @@ connectors:
   - linear  # use whichever Linear surface the harness provides (MCP, native connector, or LINEAR_API_KEY)
   - posthog  # read-only PostHog connector; primary path for telemetry enrichment
   - vercel  # read-only deploy correlation — surface deploy timing + diff in Customer Need bodies when a recent prod deploy temporally aligns with the report
-model: claude-opus-4-7[1m]
+model: claude-opus-4-8[1m]
 allow-unrestricted-branch-pushes: false  # Linear records only, no PRs, no GitHub issues
 ---
 

--- a/docs/routines/growth-pulse.md
+++ b/docs/routines/growth-pulse.md
@@ -105,41 +105,38 @@ If the PostHog connector is unavailable or the expected project ID env vars are 
 ### Discord post to `#growth` (primary)
 
 ```
-{if any_anomaly_red OR any_novel_failure: "<@${DISCORD_USER_ID_AFO}> "}**Growth Pulse — Week {YYYY-WW}**
+{if any_anomaly_red OR any_novel_failure: "<@${DISCORD_USER_ID_AFO}> "}**📈 Growth Pulse — Week {YYYY-WW}**
 
-📈 **Onboarding funnel ({window})**
-• Registered: {N} ({±N% WoW})
-• Joined a garden: {M} ({register_to_join_pct}%)
-• First work submitted: {F} ({join_to_first_work_pct}%)
+{if any_anomaly_red OR a top conversion-kill is above threshold — this block LEADS; omit it entirely on a clean week:}
+**🔴 Watch**
+- **{red anomaly or worst conversion-kill step}** — {1-line what it is} → {Linear URL}
 
-🔁 **Early retention**
-• First-time users (last 30d): {N}
-• Repeat within 7d: {M} ({repeat_pct}%)
+**Onboarding funnel** ({window})
+- Registered: **{N}** ({±N% WoW})
+- Joined a garden: **{M}** ({register_to_join_pct}%)
+- First work submitted: **{F}** ({join_to_first_work_pct}%)
 
-🌱 **Garden engagement (last 7d)**
-• Active gardens: {A} of {T} known
-• Top 3 by work submitted: {garden_name} ({N work}), …
-• Dormant ≥ 7d: {D7}, ≥ 14d: {D14}, ≥ 30d: {D30}
+**🔁 Early retention**
+- First-time users (30d): **{N}**  ·  repeat within 7d: **{M}** ({repeat_pct}%)
 
-🛠 **Action templates** (on-chain · indexer `Action`)
-• Created last week: {N}
-• 4-week trend: {↑ / → / ↓}
-{if newest Action.createdAt ≥ 21d ago: "• ⚠ no new template in {weeks}w (last: {YYYY-MM-DD})"}
+**🌱 Garden engagement** (7d)
+- Active: **{A}** of {T}  ·  dormant ≥7d **{D7}** · ≥14d **{D14}** · ≥30d **{D30}**
+- Top by work: {garden_name} ({N}), {garden_name} ({N}), {garden_name} ({N})
 
-⚠ **Conversion-kill failures (7d)**
-• {step}: {failure_pct}% ({failed_count}/{total_attempts})
-• … (top 3 by failure_pct)
+**🛠 Action templates** (on-chain · indexer `Action`)
+- Created last week: **{N}**  ·  4-week trend {↑ / → / ↓}
+{if newest Action.createdAt ≥ 21d ago: "- ⚠ no new template in {weeks}w (last {YYYY-MM-DD})"}
 
-📋 **Anomalies (Linear)**
-• {anomaly_count} new this run, {open_count} open on the Product team (`activity:qa` + `protocol:green-goods`)
-{bullets — at most 3 — for new anomalies with Linear URL}
+**⚠️ Conversion-kill (7d)** — top 3 by failure rate
+- {step}: **{failure_pct}%** ({failed_count}/{total_attempts})
 
-{if funnel_thin AND open_p0_qa: "🔎 **Funnel context**: {step(s)} thin — {N} open P0 `activity:qa` defect(s) on {surface} ({PRD-ids}) likely suppress conversion before instrumented steps."}
+**📋 Anomalies** — {anomaly_count} new · {open_count} open (`activity:qa` + `protocol:green-goods`)
+{bullets — at most 3 — new anomalies with Linear URL. Omit this whole block when zero new AND zero open.}
 
-{if intent_verdict != "coherent": "🧭 **Intent**: {drifting|unclear} — {underserved_stage or 'plans glance unavailable'}"}
+{if funnel_thin AND open_p0_qa: "**🔎 Funnel context** — {step(s)} thin; {N} open P0 `activity:qa` defect(s) on {surface} ({PRD-ids}) likely suppress conversion before instrumented steps."}
+{if intent_verdict != "coherent": "**🧭 Intent** — {drifting|unclear}: {underserved_stage or 'plans glance unavailable'}"}
 
-📄 **Full digest (Linear)**: {linear_status_update_url}
-
+**📄 Full digest** → {linear_status_update_url}
 {if any_failure: "⚠ Failures this run: {short list}"}
 ```
 

--- a/docs/routines/growth-pulse.md
+++ b/docs/routines/growth-pulse.md
@@ -24,7 +24,7 @@ connectors:
   - posthog
   - linear
   - google-calendar
-model: claude-opus-4-7[1m]
+model: claude-opus-4-8[1m]
 status: active  # 2026-05-25 — weekly digest posts to Linear (initiative status update), no GitHub PR. Consolidates metrics digest + guild-weekly-checkin numbers + guild-product-development-synthesis growth signals
 ---
 

--- a/docs/routines/health-watch.md
+++ b/docs/routines/health-watch.md
@@ -25,7 +25,7 @@ connectors:
   - linear
   - posthog
   - vercel
-model: claude-opus-4-7[1m]
+model: claude-opus-4-8[1m]
 ---
 
 # Prompt

--- a/docs/routines/pr-review.md
+++ b/docs/routines/pr-review.md
@@ -19,6 +19,7 @@ model: claude-opus-4-8[1m]
 
 # Prompt
 
+
 You are reviewing a pull request on the Green Goods monorepo. Your job is to leave inline comments on specific lines where an invariant is violated, then post one summary comment at the end.
 
 ## Cost controls (check FIRST)
@@ -80,7 +81,21 @@ Pull from Vercel:
 - **Build log URL** when state is `ERROR` or `BUILD_FAILED` (so the author can click into the failure).
 - **Lighthouse delta vs `main`** if the project's Vercel config exposes Lighthouse scores. Flag any regression > 10 points on Performance / Accessibility / Best Practices / SEO.
 
+If the Vercel connector is unwired or unreachable, skip this section silently — preview-deploy commentary is enrichment, never load-bearing.
+
 This is **review commentary**, not an invariant. Don't `REQUEST_CHANGES` based on Vercel state — just surface the link + status so the human reviewer can click and test on a real device.
+
+## Sentry production errors (when applicable)
+
+If the PR touches a Green Goods runtime surface, check the matching Sentry project (org `greenpill`, regionUrl `https://us.sentry.io`) for **open** issues on that surface so the reviewer knows whether this code path is currently throwing in production:
+
+- `packages/client/` (or shared code used by the client) -> project `green-goods-client`
+- `packages/admin/` -> project `green-goods-admin`
+- `packages/agent/` (bot / messaging runtime) -> project `green-goods-agent`
+
+Query `search_issues` with `is:unresolved` (sort `freq`), optionally narrowing by a filename or culprit token drawn from the diff. Surface up to 3 of the most frequent open issues whose `culprit` plausibly overlaps a file the PR changes -- report issue title, culprit, event/user counts, and the issue URL. This is most decision-relevant when the PR claims to fix an error or edits a known culprit file.
+
+**Privacy + scope**: this is review commentary, never an invariant -- do NOT `REQUEST_CHANGES` on Sentry state. Sentry **issue** metadata (title, culprit, level, counts, issue URL) is safe to quote; do NOT paste event-level detail (user emails, IPs, request bodies, breadcrumbs) into PR comments. If the Sentry connector is unwired or unreachable, skip this section silently -- like the Vercel section, it is enrichment, never load-bearing.
 
 ## Summary comment format
 
@@ -93,10 +108,12 @@ At the end, post one summary comment:
 **Inline flags:** N (see comments above)
 **Verdict:** [APPROVE | REQUEST_CHANGES | COMMENT_ONLY]
 
-{if frontend touched: "**Preview deploy:** ✅ ready · {preview_url}   _OR_   ❌ failed · {build_log_url}   _OR_   🟡 building"}
+{if frontend touched + Vercel reachable: "**Preview deploy:** ✅ ready · {preview_url}   _OR_   ❌ failed · {build_log_url}   _OR_   🟡 building"}
 {if lighthouse delta available: "**Lighthouse vs `main`:** Performance {±N}, Accessibility {±N}, Best Practices {±N}, SEO {±N}"}
+{if runtime surface touched + Sentry reachable: "**Open Sentry issues (this surface):** N -- top: {issue_title} ({events} events / {users} users) {issue_url}"}
 
 Notes: …
 ```
 
 Use `COMMENT_ONLY` unless there is a hard-invariant violation (items 1, 2, 5). Items 3, 4, 6, 7, 8 are `REQUEST_CHANGES`-worthy only if the author has been told about them before in this PR thread — otherwise `COMMENT_ONLY`.
+

--- a/docs/routines/pr-review.md
+++ b/docs/routines/pr-review.md
@@ -14,7 +14,7 @@ environment: green-goods-routines
 network-access: trusted
 connectors:
   - vercel
-model: claude-opus-4-7[1m]
+model: claude-opus-4-8[1m]
 ---
 
 # Prompt

--- a/docs/routines/qa-triage-pulse.md
+++ b/docs/routines/qa-triage-pulse.md
@@ -18,7 +18,7 @@ connectors:
   - linear        # Customer Need + Backlog tracking-Issue pre-staging only
   - posthog       # per-surface telemetry cross-reference
   - vercel        # deploy correlation for PostHog-matched items (gated on first_seen)
-model: claude-opus-4-7[1m]
+model: claude-opus-4-8[1m]
 allow-unrestricted-branch-pushes: false  # Customer Needs only; no PRs, no Sheet writes, no GitHub Issues
 last_updated: "2026-06-10"
 last_verified: "2026-05-13"

--- a/docs/routines/release-prep.md
+++ b/docs/routines/release-prep.md
@@ -13,7 +13,7 @@ env-vars:
   - DISCORD_USER_ID_AFO
 connectors:
   - github # read-only: open PRs, commit range, existing releases/tags
-model: claude-opus-4-7[1m]
+model: claude-opus-4-8[1m]
 allow-unrestricted-branch-pushes: false # read + draft only; no commits, no PRs, no tags
 last_updated: "2026-06-23"
 ---


### PR DESCRIPTION
Part of the routines revamp (Discord house style). Restyles the growth-pulse `#growth` post: leads with a **Watch** block, bolds key numbers, tightens retention/garden lines to fewer rows, markdown bullets, sections omit when empty. **No metric is removed.** Paired PR targets the other branch (`main` reads the spec at runtime; `develop` promotes into it, per the channel-move precedent). GG-scoped, so no Coop/TAS scope drop needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)