### PR TITLE
docs(claude): plan hub status — plan approved, spec still in progress

### DIFF
--- a/.plans/active/commitment-pooling/plan.todo.md
+++ b/.plans/active/commitment-pooling/plan.todo.md
@@ -2,7 +2,7 @@
 
 **Feature Slug**: `commitment-pooling`
 **Stage**: `active`
-**Status**: `ACTIVE: specs approved, Linear restructured, implementation not started`
+**Status**: `ACTIVE: plan approved, spec in progress, Linear restructured, implementation not started`
 **Created**: `2026-07-03`
 **Last Updated**: `2026-07-04`
 


### PR DESCRIPTION
One-line correction to the commitment-pooling plan hub status.

The contract spec is still being worked; what's approved is the plan and the Linear restructure. The status line previously read "specs approved," which overstated it.

`ACTIVE: specs approved, Linear restructured, …` → `ACTIVE: plan approved, spec in progress, Linear restructured, …`

🤖 Generated with [Claude Code](https://claude.com/claude-code)