### PR TITLE
fix(ci): restore develop to green (format, lint, story/test drift)

### DIFF
--- a/packages/admin/src/__tests__/components/SubmitWorkDialog.test.tsx
+++ b/packages/admin/src/__tests__/components/SubmitWorkDialog.test.tsx
@@ -351,9 +351,7 @@ describe("SubmitWork dialog", () => {
     await user.type(noteInput, "Mulched the west bed");
 
     await act(async () => {
-      void router?.navigate(
-        "/hub/history?gardenId=0x2222222222222222222222222222222222222222"
-      );
+      void router?.navigate("/hub/history?gardenId=0x2222222222222222222222222222222222222222");
       await Promise.resolve();
     });
 
@@ -395,8 +393,10 @@ describe("SubmitWork dialog", () => {
     ).toBeInTheDocument();
     expect(await screen.findByRole("button", { name: "Next" })).toBeInTheDocument();
     const hookOrderError = consoleError.mock.calls.some((call) =>
-      call.some((arg) =>
-        typeof arg === "string" && arg.includes("Rendered more hooks than during the previous render")
+      call.some(
+        (arg) =>
+          typeof arg === "string" &&
+          arg.includes("Rendered more hooks than during the previous render")
       )
     );
     expect(hookOrderError).toBe(false);

--- a/packages/admin/src/components/Layout/AccountSettingsPanel.stories.tsx
+++ b/packages/admin/src/components/Layout/AccountSettingsPanel.stories.tsx
@@ -101,7 +101,7 @@ export const Default: Story = {
     await expect(await canvas.findByRole("heading", { name: "Language" })).toBeVisible();
     await expect(await canvas.findByRole("heading", { name: "Network" })).toBeVisible();
     await expect(await canvas.findByRole("heading", { name: "About" })).toBeVisible();
-    await expect(canvas.getByRole("button", { name: "English" })).toBeVisible();
+    await expect(canvas.getByRole("radio", { name: "English" })).toBeVisible();
     await expect(canvas.getByRole("link", { name: /Documentation/ })).toBeVisible();
     await expect(canvas.queryByText("Disconnect")).not.toBeInTheDocument();
   },

--- a/packages/admin/src/views/Garden/Vault.tsx
+++ b/packages/admin/src/views/Garden/Vault.tsx
@@ -29,11 +29,7 @@ import {
   CanvasRouteFrame,
   CanvasRouteHeader,
 } from "@/components/Layout/CanvasRouteFrame";
-import {
-  GardenSupporters,
-  PositionCard,
-  VaultEventHistory,
-} from "@/components/Vault";
+import { GardenSupporters, PositionCard, VaultEventHistory } from "@/components/Vault";
 
 type VaultRouteState = {
   returnTo?: string;

--- a/packages/shared/src/__tests__/components/AppBar.test.tsx
+++ b/packages/shared/src/__tests__/components/AppBar.test.tsx
@@ -198,7 +198,7 @@ describe("AppBar", () => {
     for (const btn of buttons) {
       expect(btn.className).toContain("focus-visible:ring-2");
       expect(btn.className).toContain(
-        "focus-visible:ring-[rgb(var(--tone-primary,var(--primary-base)))]"
+        "focus-visible:ring-[rgb(var(--tone-focus-ring,var(--tone-primary,var(--primary-base))))]"
       );
     }
   });

--- a/packages/shared/src/__tests__/components/Primitives.test.tsx
+++ b/packages/shared/src/__tests__/components/Primitives.test.tsx
@@ -317,10 +317,7 @@ describe("Canvas Primitives", () => {
 
     render(
       <FabProvider>
-        <UnstableFabRegistrationProbe
-          onProviderConfig={onProviderConfig}
-          onAction={onAction}
-        />
+        <UnstableFabRegistrationProbe onProviderConfig={onProviderConfig} onAction={onAction} />
       </FabProvider>
     );
 

--- a/packages/shared/src/components/Canvas/NavigationBar.stories.tsx
+++ b/packages/shared/src/components/Canvas/NavigationBar.stories.tsx
@@ -217,8 +217,8 @@ export const MobileSpeedDial: Story = {
     // Opening the dial reveals each action once (no duplicated primary).
     await userEvent.click(opener);
     await expect(opener).toHaveAttribute("aria-expanded", "true");
-    await canvas.findByRole("button", { name: /submit work/i });
-    await canvas.findByRole("button", { name: /create hypercert/i });
+    await canvas.findByRole("menuitem", { name: /submit work/i });
+    await canvas.findByRole("menuitem", { name: /create hypercert/i });
   },
 };
 

--- a/packages/shared/src/components/Canvas/NavigationBar.tsx
+++ b/packages/shared/src/components/Canvas/NavigationBar.tsx
@@ -1,6 +1,5 @@
 import { RiAddLine } from "@remixicon/react";
-import type { CSSProperties } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useIntl } from "react-intl";
 import { cn } from "../../utils/styles/cn";
 import { useCanvasMobileChromeHidden } from "./useCanvasMobileChromeHidden";


### PR DESCRIPTION
## Summary

Restores `develop` to green CI. Four checks were red on `develop`'s own HEAD (`863cb9b59`) — all pre-existing drift that landed via admin-merges past an already-red gate, not caused by any single feature. Surfaced while reviewing #631, which inherited every one of them.

## Root causes fixed

| Red check | Cause | Fix |
|---|---|---|
| `Lint And Build` / `format:check` (Client + Admin) | 3 files committed unformatted | `biome format` — no logic change |
| `Lint And Typecheck` / shared lint | oxlint `no-duplicate-imports` **error**: split `import type` + value imports from `react` in `NavigationBar.tsx` | merged with inline `type` modifier (house style, 100+ uses in shared) |
| `Test` / shared coverage | `AppBar.test` asserted the pre-`--tone-focus-ring` ring class | updated to the standardized ring token (`39b4f5746`) |
| `Storybook` | 2 interaction plays drifted from their components | `AccountSettingsPanel`: Language is now an `AdminChoiceGroup` radiogroup (`role="radio"`), not buttons · `NavigationBar` speed-dial items are `role="menuitem"` inside `role="menu"` |

## Verification

- ✅ `bun run format:check` — exit 0 (1876 files)
- ✅ `oxlint` shared + admin — exit 0
- ✅ pre-push gate (`bun run format` + `bun run lint`, all packages + contracts) passed
- ⏳ The test/story assertions are grounded in exact component source (`role="radio"` / `role="menuitem"` / the literal ring class string) and are executed in CI here — a fresh worktree can't run the browser/jsdom suites locally due to a partial-install dependency gate (`multiformats` resolution / `ERR_REQUIRE_ESM`).

## Risk and rollout

- **Risk level**: Low — formatting + test/story assertion updates, plus one 1-line import merge. **No runtime or product code changed.**
- **Rollout**: merge as-is.

## Notes for reviewer

- Purely CI hygiene: every change realigns a test/story/format with a component that already shipped.
- These landed red because merges bypassed an already-red gate. A **CI-Gate aggregator as a required status check** would prevent this recurrence — worth a follow-up.
- The `pendingJoinsVersion` / `version` `exhaustive-deps` warnings in shared are intentional (the documented optimistic-UI `use<Thing>Version()` pattern) — left as warnings, not "fixed."
