### PR TITLE
docs(releasing): kill the main-deletion back-merge trap

### DIFF
--- a/docs/docs/builders/deployments/releasing.mdx
+++ b/docs/docs/builders/deployments/releasing.mdx
@@ -66,6 +66,7 @@ A production bug mid-month branches from `main` (not `develop`), bumps a patch (
 After every release and every hotfix, merge `main` back into `develop`. **Use the direct-push fast-path** — as a maintainer you push straight to `develop`:
 
 ```bash
+git fetch origin                                      # refresh origin/main after the release merged
 git switch develop && git pull && git merge origin/main && git push
 ```
 
@@ -78,6 +79,7 @@ If the direct push above is somehow unavailable and you must go through a PR, pu
 
 ```bash
 DATE=$(date +%Y-%m-%d)
+git fetch origin                                      # copy the current main, not a stale local ref
 git push origin origin/main:refs/heads/backmerge/main-$DATE
 gh pr create --repo greenpill-dev-guild/green-goods \
   --base develop --head "backmerge/main-$DATE" \

--- a/docs/docs/builders/deployments/releasing.mdx
+++ b/docs/docs/builders/deployments/releasing.mdx
@@ -4,7 +4,7 @@ sidebar_label: Releasing
 slug: /builders/deployments/releasing
 audience: developer
 owner: docs
-last_verified: 2026-06-23
+last_verified: 2026-07-08
 feature_status: Live
 source_of_truth:
   - .github/workflows/release.yml
@@ -49,7 +49,7 @@ git switch -c release/july-2026-v1.2.0 origin/develop   # cut the tested snapsho
 bun run version:bump 1.2.0                           # unify all package versions
 # add the curated changelog entry, then run the gates:
 bun run format:check && bun run lint && bun run test && bun run build
-git commit -am "chore(release): v1.2.0 (July 2026)" && git push -u origin release/july-2026
+git commit -am "chore(release): v1.2.0 (July 2026)" && git push -u origin release/july-2026-v1.2.0
 gh pr create --base main --title "Release July 2026 — v1.2.0"
 # once CI is green and the PR merges, tag the merged main HEAD:
 git switch main && git pull && git tag -a v1.2.0 -m "July 2026" && git push origin v1.2.0
@@ -63,13 +63,27 @@ A production bug mid-month branches from `main` (not `develop`), bumps a patch (
 
 ## Back-merge — every time
 
-After every release and every hotfix, merge `main` back into `develop` (admin fast-path below; otherwise open a quick back-merge PR, since `develop` is protected):
+After every release and every hotfix, merge `main` back into `develop`. **Use the direct-push fast-path** — as a maintainer you push straight to `develop`:
 
 ```bash
 git switch develop && git pull && git merge origin/main && git push
 ```
 
 This keeps `main` an ancestor of `develop` — the check that it worked is an empty `git log origin/develop..origin/main`.
+
+:::danger Never open a back-merge PR whose head is `main`
+The repo has `delete_branch_on_merge: true`, so GitHub deletes a PR's **head** branch when the PR merges. A back-merge PR with `main` as the head therefore **deletes `main`** on merge — the org-admin bypass sails straight past main's `restrict-deletions` rule. This is exactly what deleted `main` during this release's back-merge; it had to be restored from the reflog.
+
+If the direct push above is somehow unavailable and you must go through a PR, push `main` to a **throwaway** branch and PR *that* into `develop` — never `main` itself:
+
+```bash
+DATE=$(date +%Y-%m-%d)
+git push origin origin/main:refs/heads/backmerge/main-$DATE
+gh pr create --repo greenpill-dev-guild/green-goods \
+  --base develop --head "backmerge/main-$DATE" \
+  --title "Back-merge main → develop"
+```
+:::
 
 ## The changelog
 


### PR DESCRIPTION
## What

Rewrites the **Back-merge — every time** section of the release runbook and fixes a truncated command in **Cutting a release**.

`docs/docs/builders/deployments/releasing.mdx`:
- **Back-merge trap removed.** The old text said "otherwise open a quick back-merge PR." With the repo's `delete_branch_on_merge: true`, a back-merge PR whose **head** is `main` deletes `main` on merge (the org-admin bypass sails past main's `restrict-deletions` rule). That is exactly what wiped `main` during this release's back-merge.
  - Mandates the **direct-push fast-path** as the primary route.
  - If a PR is unavoidable, push `main` to a **throwaway** `backmerge/main-<date>` branch and PR *that* into `develop` — never `main` itself.
  - Adds a `:::danger` admonition spelling out the delete-on-merge mechanism.
- **Fixes the truncated release push** (`git push -u origin release/july-2026` → `release/july-2026-v1.2.0`) so it matches the branch cut two lines above.
- Bumps `last_verified` to 2026-07-08.

## Why

`main` was deleted this release by following the old runbook. This closes the trap and points the reader at the safe path.

## Verification

- `bun run build:docs` → `[SUCCESS] Generated static files` (MDX frontmatter, `:::danger` admonition, and code fences all render).
- `check:design-md` is not applicable (it lints `DESIGN.md` files only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)