### PR TITLE
fix(client,admin): emit hidden source maps for the PostHog upload lane

### DIFF
--- a/docs/docs/builders/deployments/admin-deploy.mdx
+++ b/docs/docs/builders/deployments/admin-deploy.mdx
@@ -136,7 +136,7 @@ This starts the unified Storybook that includes stories from all three UI packag
 
 ### Source Maps
 
-Vercel runs `bun run build` only. PostHog source-map upload runs from the GitHub Actions `admin.yml` lane on trusted `main` pushes; its upload credentials are GitHub repository secrets, not Vercel project variables. The admin Vercel project should not carry `GG_ENABLE_SOURCEMAPS` by itself because the current Vite config emits maps only when the Sentry upload path is active.
+Vercel runs `bun run build` only. PostHog source-map upload runs from the GitHub Actions `admin.yml` lane on trusted `main` pushes; its upload credentials are GitHub repository secrets, not Vercel project variables. The admin Vercel project must not carry `GG_ENABLE_SOURCEMAPS`: the flag now makes the production build emit source maps (as `hidden`) and skip the public-map strip, so setting it on Vercel would publish browser source maps. It belongs only to the Actions upload lane, which deletes the maps after uploading them to PostHog.
 
 Set these variables as GitHub repository secrets:
 

--- a/docs/docs/builders/deployments/client-deploy.mdx
+++ b/docs/docs/builders/deployments/client-deploy.mdx
@@ -176,7 +176,7 @@ Set these variables as GitHub repository secrets:
 | `POSTHOG_CLIENT_ENV_ID` | PostHog environment ID for the client app |
 | `POSTHOG_CLI_TOKEN` | PostHog token with source-map upload permissions |
 
-Production Vercel deploys do not require these PostHog variables. The GitHub Actions source-map upload job fails closed if the PostHog source-map variables are missing. `GG_ENABLE_SOURCEMAPS` is an upload-lane flag, not a durable frontend Vercel setting; current Vite source-map emission is still coupled to `SENTRY_AUTH_TOKEN`, so keep client Sentry integration variables only where Sentry upload or log-drain integration is intentionally enabled.
+Production Vercel deploys do not require these PostHog variables. The GitHub Actions source-map upload job fails closed if the PostHog source-map variables are missing. `GG_ENABLE_SOURCEMAPS` is an upload-lane flag, not a durable frontend Vercel setting: the flag now makes the production build emit source maps (as `hidden`) and skip the public-map strip, so it must never be set on a Vercel project — it would publish browser source maps. Keep client Sentry integration variables only where Sentry upload or log-drain integration is intentionally enabled.
 
 ## Resources
 

--- a/docs/docs/builders/quality/gh-actions.mdx
+++ b/docs/docs/builders/quality/gh-actions.mdx
@@ -138,7 +138,7 @@ The Storybook/design gate runs `check:design-md`, `check:design-generated`, `che
 
 Storybook publication is deliberately outside GitHub Actions. `design.yml` validates and uploads the Storybook artifact for PR review; the standalone public site is deployed by the Vercel project rooted at `packages/shared`, using `packages/shared/vercel.json` to build `@green-goods/shared` and serve `packages/shared/storybook-static`.
 
-Client and admin PostHog source maps are handled by GitHub Actions, not Vercel project environment variables. The `client.yml` and `admin.yml` workflows upload source maps to the app-specific PostHog environment on trusted `main` pushes using GitHub secrets such as `POSTHOG_CLI_TOKEN` and the app environment ID. Vercel runs plain package builds only. `GG_ENABLE_SOURCEMAPS` is an upload-lane flag, not a durable frontend Vercel setting; current Vite source-map emission remains coupled to `SENTRY_AUTH_TOKEN` until the build config is decoupled.
+Client and admin PostHog source maps are handled by GitHub Actions, not Vercel project environment variables. The `client.yml` and `admin.yml` workflows upload source maps to the app-specific PostHog environment on trusted `main` pushes using GitHub secrets such as `POSTHOG_CLI_TOKEN` and the app environment ID. Vercel runs plain package builds only. `GG_ENABLE_SOURCEMAPS` is an upload-lane flag, not a durable frontend Vercel setting: the build emits source maps (as `hidden`) and retains them for upload only when it is set, so it must stay confined to the Actions upload lane and never be set on a Vercel project.
 
 ## Running & Troubleshooting
 

--- a/docs/routines/README.md
+++ b/docs/routines/README.md
@@ -166,8 +166,10 @@ cannot cross-wire the two browser apps.
 
 Frontend source-map ownership is split today: PostHog source-map uploads run from GitHub
 Actions with `POSTHOG_CLI_TOKEN` plus the app-specific PostHog environment ID, while Vite
-currently emits maps only when `SENTRY_AUTH_TOKEN` is present. `GG_ENABLE_SOURCEMAPS` is an
-upload-lane flag, not a durable Vercel project variable. Keep client Sentry integration
+emits maps whenever `GG_ENABLE_SOURCEMAPS=true` (the upload lane sets it) or the Sentry
+upload path is active. `GG_ENABLE_SOURCEMAPS` is an upload-lane flag, not a durable Vercel
+project variable — the app build only strips public `.map` files when it is unset, so setting
+it on a Vercel project would publish browser source maps. Keep client Sentry integration
 variables only where Sentry upload or log-drain integration is intentionally enabled, and do
 not keep orphaned source-map flags on admin.
 

--- a/packages/admin/vite.config.ts
+++ b/packages/admin/vite.config.ts
@@ -158,13 +158,14 @@ export default defineConfig(async ({ command, mode }): Promise<UserConfig> => {
   const shortAppVersion = appVersion.slice(0, 12);
   const sentryAuthToken = envValue("SENTRY_AUTH_TOKEN");
   const shouldUploadSentrySourceMaps = command === "build" && Boolean(sentryAuthToken);
+  // The PostHog upload lane (scripts/ops/upload-sourcemaps.js) sets
+  // GG_ENABLE_SOURCEMAPS so a production build emits maps for server-side upload
+  // even when Sentry is not configured — that is the current production path.
+  // Sentry upload keeps emitting them too. Any other build (Vercel deploy, local
+  // prod build) sets neither flag and ships no maps.
   const requestedSourceMaps = process.env.GG_ENABLE_SOURCEMAPS === "true";
-  if (command === "build" && requestedSourceMaps && !shouldUploadSentrySourceMaps) {
-    console.warn(
-      "GG_ENABLE_SOURCEMAPS was ignored because SENTRY_AUTH_TOKEN is missing; production source maps are only emitted for Sentry upload."
-    );
-  }
-  const enableSourceMaps = shouldUploadSentrySourceMaps;
+  const enableSourceMaps =
+    command === "build" && (requestedSourceMaps || shouldUploadSentrySourceMaps);
   const sentryDsn = resolveAdminSentryDsn();
   const sentryEnvironment = resolveSentryEnvironment(mode);
   // Env-parity gate (PRD-567): a production deploy must ship with a resolvable
@@ -267,7 +268,10 @@ export default defineConfig(async ({ command, mode }): Promise<UserConfig> => {
     envDir: rootDir,
     envPrefix: ["VITE_", "SKIP_"],
     build: {
-      sourcemap: enableSourceMaps,
+      // 'hidden' emits .map files for server-side upload (PostHog / Sentry) but
+      // omits the sourceMappingURL comment, so the maps are never referenced from
+      // — or served to — browsers. The upload lane deletes them after upload.
+      sourcemap: enableSourceMaps ? "hidden" : false,
       chunkSizeWarningLimit: 2000,
       rollupOptions: { output: { manualChunks: splitAdminVendorChunks } },
     },

--- a/packages/client/vite.config.ts
+++ b/packages/client/vite.config.ts
@@ -202,13 +202,14 @@ export default defineConfig(async ({ command, mode }) => {
   const nodeEnv = command === "build" ? "production" : "development";
   const sentryAuthToken = envValue("SENTRY_AUTH_TOKEN");
   const shouldUploadSentrySourceMaps = command === "build" && Boolean(sentryAuthToken);
+  // The PostHog upload lane (scripts/ops/upload-sourcemaps.js) sets
+  // GG_ENABLE_SOURCEMAPS so a production build emits maps for server-side upload
+  // even when Sentry is not configured — that is the current production path.
+  // Sentry upload keeps emitting them too. Any other build (Vercel deploy, local
+  // prod build) sets neither flag and ships no maps.
   const requestedSourceMaps = process.env.GG_ENABLE_SOURCEMAPS === "true";
-  if (command === "build" && requestedSourceMaps && !shouldUploadSentrySourceMaps) {
-    console.warn(
-      "GG_ENABLE_SOURCEMAPS was ignored because SENTRY_AUTH_TOKEN is missing; production source maps are only emitted for Sentry upload."
-    );
-  }
-  const enableSourceMaps = shouldUploadSentrySourceMaps;
+  const enableSourceMaps =
+    command === "build" && (requestedSourceMaps || shouldUploadSentrySourceMaps);
   const sentryDsn = resolveClientSentryDsn();
   const sentryEnvironment = resolveSentryEnvironment(mode);
   // Env-parity gate (PRD-567): a production deploy must ship with a resolvable
@@ -484,7 +485,10 @@ export default defineConfig(async ({ command, mode }) => {
     envDir: rootDir,
     envPrefix: ["VITE_", "SKIP_"],
     build: {
-      sourcemap: enableSourceMaps,
+      // 'hidden' emits .map files for server-side upload (PostHog / Sentry) but
+      // omits the sourceMappingURL comment, so the maps are never referenced from
+      // — or served to — browsers. The upload lane deletes them after upload.
+      sourcemap: enableSourceMaps ? "hidden" : false,
       chunkSizeWarningLimit: 2000,
     },
     define: {

--- a/scripts/dev/remove-public-sourcemaps.js
+++ b/scripts/dev/remove-public-sourcemaps.js
@@ -22,6 +22,21 @@ if (directories.length === 0) {
   process.exit(1);
 }
 
+// The PostHog upload lane (scripts/ops/upload-sourcemaps.js) builds with
+// GG_ENABLE_SOURCEMAPS=true and needs the emitted .map files to survive until it
+// has uploaded them — it deletes them itself afterwards (posthog-cli
+// --delete-after). Stripping them here (this script runs at the tail of every
+// `bun run build`) would leave the uploader with nothing to find ("No source
+// maps found in <dist>"). Every other build — Vercel deploy, local prod build —
+// leaves the flag unset, so this still strips the maps before they can be
+// published. Kept coupled to the same flag the Vite configs read for emission.
+if (process.env.GG_ENABLE_SOURCEMAPS === "true") {
+  console.log(
+    "GG_ENABLE_SOURCEMAPS=true — retaining source maps for the upload lane (deleted after upload)."
+  );
+  process.exit(0);
+}
+
 for (const directory of directories) {
   removeMaps(resolve(directory));
 }


### PR DESCRIPTION
## Problem

On the v1.2.0 `main` push, the Client + Admin **Upload … Source Maps** jobs failed:

```
=== Client Source Maps ===
✗ No source maps found in packages/client/dist
ℹ Make sure your build has sourcemap: true enabled
✗ 1 upload(s) failed
```

Secrets are fine (`POSTHOG_CLI_TOKEN`, `POSTHOG_CLIENT_ENV_ID`). The production build emits **no** source maps, so `scripts/ops/upload-sourcemaps.js` finds none.

## Root cause — two coupled blockers

1. **`vite.config.ts` (client + admin)** tied `enableSourceMaps` to `SENTRY_AUTH_TOKEN`, so `GG_ENABLE_SOURCEMAPS=true` — the flag the upload lane sets — emitted nothing once Sentry upload was retired for PostHog.
2. **The app `build` scripts** run `remove-public-sourcemaps.js` at their tail, and `upload-sourcemaps.js` invokes those same build scripts (no `--skip-build` in CI). So even with maps emitted, they were **stripped before the uploader could read them**.

## Fix

- **`vite.config.ts` (both):** emit `build.sourcemap: 'hidden'` when `GG_ENABLE_SOURCEMAPS` is set **or** the Sentry path is active. `'hidden'` writes `.map` files for server-side upload but omits the `sourceMappingURL` comment — the maps are never referenced from, or served to, browsers. Drops the now-wrong "GG_ENABLE_SOURCEMAPS was ignored" warning.
- **`scripts/dev/remove-public-sourcemaps.js`:** skip stripping when `GG_ENABLE_SOURCEMAPS=true`, so the upload lane's maps survive to the uploader — which deletes them itself via `posthog-cli … --delete-after`. This makes the strip run **after** upload in the upload lane, while every other build still strips as before.
- **Docs** (`routines/README`, `admin-deploy`, `client-deploy`, `gh-actions`): corrected the stale "coupled to `SENTRY_AUTH_TOKEN`" claim, and flagged that the flag now emits+retains maps so it **must stay off Vercel** or it would publish browser maps.

## Why no workflow / Vercel change is needed

- The `sourcemaps` job already delegates build → upload → strip to `upload-sourcemaps.js`, which sets `GG_ENABLE_SOURCEMAPS=true`. No step reorder required.
- Vercel deploys set **neither** flag, so `enableSourceMaps` stays exactly what it was before (`false`) — this diff only adds a truthy branch gated on `GG_ENABLE_SOURCEMAPS`. Vercel's no-flag build is byte-identical to today and ships zero maps; the build-script strip stays as its safety net.

## Verification (local)

`bun run sourcemaps:dry-run` (builds both apps with `GG_ENABLE_SOURCEMAPS=true`, then counts):

```
✓ Found 154 source map files   (client)
✓ Found 136 source map files   (admin)
GG_ENABLE_SOURCEMAPS=true — retaining source maps for the upload lane (deleted after upload).
… would run: posthog-cli sourcemap upload --directory packages/<app>/dist --delete-after
```

- **0** served JS files carry a `//# sourceMappingURL` comment (client + admin) → hidden maps aren't served.
- `bun run format:check` clean; `bun run build:docs` → `[SUCCESS] Generated static files`.

The **live PostHog upload** only runs on the next `main` push (`sourcemaps` job is `if: github.ref == 'refs/heads/main'`), so it isn't exercised by this develop PR — the dry-run above proves the blocker (emission + retention) is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)