### PR TITLE
docs(claude): move Green Goods routines to Claude Opus 5

### DIFF
--- a/docs/routines/README.md
+++ b/docs/routines/README.md
@@ -60,6 +60,7 @@ Routines @mention Afo only when his action is required (via `DISCORD_USER_ID_AFO
 - All routine branches use `claude/<routine-name>/<topic>`.
 - Loop prevention on `pr-review`: filter on `head_branch` starting with `claude/` (NOT on author — routine PRs carry the user's GitHub author per the docs).
 - **Linear is the durable backlog.** GitHub is for PRs and code review only — routines never file GitHub Issues, never write to GitHub Projects, and never apply GitHub Project iteration/Sprints fields. The retired GitHub Project #4 / Bug Board flows (and the `Sprints` field they depended on) are out of scope for any active routine.
+- **Model tier:** every GG routine runs `claude-opus-5` (moved off `claude-opus-4-8[1m]` on 2026-07-26; same token price, better instruction-following and bug-finding). Each spec names its model in frontmatter, and that frontmatter is documentation of the live trigger, not a control surface: changing it does not change the running model, so re-emit the trigger and edit the spec in the same change. The guild-level tiering rationale, including the two routines on `claude-fable-5`, lives in [`greenpill-dev-guild/.github` → `routines/claude/README.md`](https://github.com/greenpill-dev-guild/.github/blob/main/routines/claude/README.md).
 
 ## Scope discipline
 
@@ -200,7 +201,7 @@ The routine resolves team/label/status IDs by name at the start of every run —
 
 ### Output style (all posting routines)
 
-Green Goods routine posts follow the guild house style: bold headers with blank lines between blocks, lead with what needs a human (🔴 first), a thing appears only if it moved or needs attention (never a "quiet" bullet or empty section), metrics folded into the line they describe, one message per channel per run. Cadences in the portfolio table are UTC (the qa-triage-pulse row's "Wed 21:00 UTC" annotation style is the convention).
+Green Goods routine posts follow the guild house style: bold headers with blank lines between blocks, lead with what needs a human (🔴 first), a thing appears only if it moved or needs attention (never a "quiet" bullet or empty section), metrics folded into the line they describe, one message per channel per run. Get short by cutting content rather than compressing prose: drop anything that would not change what a reader does next, then write what remains in complete sentences (no padding, no fragment-and-arrow shorthand). Cadences in the portfolio table are UTC (the qa-triage-pulse row's "Wed 21:00 UTC" annotation style is the convention).
 
 ## Rebuilding a routine
 

--- a/docs/routines/README.md
+++ b/docs/routines/README.md
@@ -208,5 +208,5 @@ Green Goods routine posts follow the guild house style: bold headers with blank 
 1. Log in to claude.ai/code/routines.
 2. Click **New routine**.
 3. Paste the prompt from the relevant `.md` file (everything after the `# Prompt` heading).
-4. Configure repos, environment, connectors, and triggers as specified in the file's frontmatter.
+4. Configure repos, environment, connectors, triggers, **and the model** as specified in the file's frontmatter. A rebuilt routine left on the platform default silently runs the wrong tier.
 5. Save.

--- a/docs/routines/bug-intake.md
+++ b/docs/routines/bug-intake.md
@@ -26,7 +26,7 @@ connectors:
   - linear  # Linear via the OAuth connector only — no LINEAR_API_KEY is stored (guild rule 2026-07-04); fail closed if unauthenticated
   - posthog  # read-only PostHog connector; primary path for telemetry enrichment
   - vercel  # read-only deploy correlation — surface deploy timing + diff in Customer Need bodies when a recent prod deploy temporally aligns with the report
-model: claude-opus-4-8[1m]
+model: claude-opus-5
 allow-unrestricted-branch-pushes: false  # Linear records only, no PRs, no GitHub issues
 ---
 

--- a/docs/routines/growth-pulse.md
+++ b/docs/routines/growth-pulse.md
@@ -23,7 +23,7 @@ connectors:
   - posthog
   - linear
   - google-calendar
-model: claude-opus-4-8[1m]
+model: claude-opus-5
 status: active  # 2026-05-25 — weekly digest posts to Linear (initiative status update), no GitHub PR. Consolidates metrics digest + guild-weekly-checkin numbers + guild-product-development-synthesis growth signals
 ---
 

--- a/docs/routines/health-watch.md
+++ b/docs/routines/health-watch.md
@@ -25,7 +25,7 @@ connectors:
   - linear
   - posthog
   - vercel
-model: claude-opus-4-8[1m]
+model: claude-opus-5
 ---
 
 # Prompt

--- a/docs/routines/pr-review.md
+++ b/docs/routines/pr-review.md
@@ -18,13 +18,22 @@ env-vars:
 connectors:
   - vercel
   - linear  # OAuth connector only, no key — the primary posting surface
-model: claude-opus-4-8[1m]
+model: claude-opus-5
 ---
 
 # Prompt
 
 
 You are reviewing a pull request on the Green Goods monorepo. Your job is to leave inline comments on specific lines where an invariant is violated, then post one summary comment at the end.
+
+## Scope discipline (read with the posting mechanism below)
+
+Review the diff and report on it. That is the whole job.
+
+- **Never write to GitHub.** No commits, branches, PR comments, reviews, labels, or status checks. This environment holds no GitHub token by design; if you find yourself reaching for one, the answer is no. In-PR line commentary is CodeRabbit's and Codex's lane.
+- **Comments only in Linear.** Never create, close, re-state, re-assign, re-label, or otherwise edit any issue field.
+- **Do not fix what you find.** A review that also repairs the code is a failed review, however small the fix looks.
+- Make routine judgment calls yourself, but do not widen the job to adjacent files, follow-up cleanups, or surfaces this spec does not name. If you think the spec is wrong, say so in one line in the review body and run it as written anyway.
 
 ## Cost controls (check FIRST)
 

--- a/docs/routines/qa-triage-pulse.md
+++ b/docs/routines/qa-triage-pulse.md
@@ -18,7 +18,7 @@ connectors:
   - linear        # Customer Need + Backlog tracking-Issue pre-staging only
   - posthog       # per-surface telemetry cross-reference
   - vercel        # deploy correlation for PostHog-matched items (gated on first_seen)
-model: claude-opus-4-8[1m]
+model: claude-opus-5
 allow-unrestricted-branch-pushes: false  # Customer Needs only; no PRs, no Sheet writes, no GitHub Issues
 last_updated: "2026-06-10"
 last_verified: "2026-05-13"

--- a/docs/routines/release-prep.md
+++ b/docs/routines/release-prep.md
@@ -14,7 +14,7 @@ env-vars:
 connectors:
   - github # read-only: open PRs, commit range, existing releases/tags
   - linear # read-only: the active release project's targetDate drives the Phase 0 gate
-model: claude-opus-4-8[1m]
+model: claude-opus-5
 allow-unrestricted-branch-pushes: false # read + draft only; no commits, no PRs, no tags
 last_updated: "2026-06-23"
 ---


### PR DESCRIPTION
Moves all 6 Green Goods routine specs off `claude-opus-4-8[1m]` to `claude-opus-5`. **The live triggers were already re-emitted**; this PR brings the version-controlled specs in line so the docs and the running config do not drift.

Same token price as the outgoing Opus tier. The gain that matters most here is bug-finding: Opus 5 is documented as high precision *and* high recall on code review, and it stays accurate at lower effort.

| Routine | Model |
|---|---|
| bug-intake, growth-pulse, health-watch, pr-review, qa-triage-pulse, release-prep | `claude-opus-5` |

The guild-level tiering rationale (including the two guild routines that moved to `claude-fable-5`) is in greenpill-dev-guild/.github#51.

## pr-review gains a scope-discipline block

Opus 5's documented behavioral shift is expanding task scope, and this routine's central constraint is a negative one: it holds no GitHub token by design, posts Linear comments only, and must never fix what it finds. That contract was previously stated only inside the posting-mechanism section, two thirds of the way down the spec. It now leads, immediately after the intro:

- Never write to GitHub (no commits, branches, PR comments, reviews, labels, checks).
- Linear comments only, never an issue field edit.
- Do not fix what you find. A review that also repairs the code is a failed review.

## README

Adds a model-tier convention line, including a point worth making explicit: **spec frontmatter documents the live trigger, it does not control it.** Editing `model:` in a spec changes nothing at runtime, so the trigger re-emit and the spec edit have to happen in the same change or the two drift apart. That drift is exactly what the 4.7 → 4.8 sweep left behind last time.

Output-style paragraph gains a conciseness rule (cut content, don't compress prose), since Opus 5 writes longer by default and `effort` does not reliably shorten visible output.

## Verification

Trigger re-emits were diffed against pre-change backups: prompt, cron, enabled flag, connector set, source list, and tool list are byte-identical on all of them. Model strings could not be validated server-side (the routines API accepts model strings without validating them), so **the first fire of each routine is the real check**. `pr-review` is webhook-fired, so the next PR opened against `develop` or `main` exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)