### PR TITLE
fix(claude): rename agent:* to ai:* in the routine specs main serves

### DIFF
--- a/docs/routines/README.md
+++ b/docs/routines/README.md
@@ -79,17 +79,17 @@ All routine writes use the canonical Linear label scheme. Old vocabularies (`are
 | `package:*` | `package:client`, `package:admin`, `package:shared`, `package:contracts`, `package:indexer`, `package:agent`, `package:docs` | Affected code surface, keyed to the repo (replaces old `area:*`). Orthogonal to `protocol:*` (the product) — one package can serve several products. Apply only to code-touching work; omit if the surface is unknown or the issue isn't code (research / funding / ops). |
 | `activity:*` | Routines apply: `activity:qa` (bug fixes, anomaly review, operational health validation), `activity:maintenance` (polish/cleanup that isn't a user-visible defect). The full Linear taxonomy also includes `activity:research`, `activity:architecture`, `activity:build`, `activity:design` — those are human-applied and not used by GG routines. |
 | `source:*` | `source:discord`, `source:telegram`, `source:drive` | Provenance of the originating signal (Customer Needs always carry this; Issues carry it when the originating provenance still matters). |
-| `agent:*` | `agent:routine` (default) · `agent:codex` (Codex-ready Issues) | Single-value-per-Issue provenance/routing. Default `agent:routine`; swap to `agent:codex` when an accepted Issue clears the Codex-ready bar (see § Codex hand-off). Provenance only, not human priority. |
+| `ai:*` | `ai:routine` (default) · `ai:codex` (Codex-ready Issues) | Single-value-per-Issue provenance/routing. Default `ai:routine`; swap to `ai:codex` when an accepted Issue clears the Codex-ready bar (see § Codex hand-off). Provenance only, not human priority. |
 
 The dispatch labels `automation:claude` / `automation:codex` (legacy GitHub-era handoff flags) and the `work:polish` / `work:customer-need` / `area:*` / `health:*` / `grant:*` labels are not used. GitHub Project #4 and its `automated/claude` + `health:*` label set are retired entirely; no active routine writes to a GitHub Issue surface.
 
 ## Codex hand-off (label + delegate)
 
-Routines that create accepted Issues can route them to Codex in two tiers. The `agent:*` label is **single-value**, so `agent:codex` *replaces* `agent:routine` — never both.
+Routines that create accepted Issues can route them to Codex in two tiers. The `ai:*` label is **single-value**, so `ai:codex` *replaces* `ai:routine` — never both.
 
-- **Tier 1 — label `agent:codex` (the queue).** When an accepted Issue clears the **Codex-ready bar** — *clear behavior + named surface + suggestable fix + a validation command (explicit, or inferable from the repo)* — set `agent:codex` (instead of `agent:routine`) and `Todo`. It now appears in the Codex queue (`label:agent:codex` + `Todo` + undelegated) for a human to delegate.
+- **Tier 1 — label `ai:codex` (the queue).** When an accepted Issue clears the **Codex-ready bar** — *clear behavior + named surface + suggestable fix + a validation command (explicit, or inferable from the repo)* — set `ai:codex` (instead of `ai:routine`) and `Todo`. It now appears in the Codex queue (`label:ai:codex` + `Todo` + undelegated) for a human to delegate.
 - **Tier 2 — also delegate to Codex (auto-build).** When the Issue *also* clears the **autonomous-confident bar** — *a concrete suggested fix + a bounded, non-`critical` surface + mechanical scope + a validation command* — also set the Linear **delegate** to the Codex agent so it builds autonomously, with the human left as assignee/reviewer.
-- **Otherwise** (Codex-ready but not confident, or not Codex-ready) → keep `agent:routine`, undelegated; a human triages/delegates. A vague Issue never clears the bar, so it never auto-reaches Codex — the bar *is* the gate.
+- **Otherwise** (Codex-ready but not confident, or not Codex-ready) → keep `ai:routine`, undelegated; a human triages/delegates. A vague Issue never clears the bar, so it never auto-reaches Codex — the bar *is* the gate.
 
 **Always human-gated, never auto-delegated** regardless of bar: `package:contracts` and shared auth / session / permit / policy and job-queue / work providers (the repo's `critical` set).
 

--- a/docs/routines/bug-intake.md
+++ b/docs/routines/bug-intake.md
@@ -66,7 +66,7 @@ If the Product team, expected Issue statuses, or required canonical labels are m
 
 Codified from the 2026-05-13 `/qa-triage` first-run findings. These three constraints apply to every Linear write this routine makes:
 
-1. **`agent:*` is single-value-per-Issue.** Default to `agent:routine` (cron'd provenance). When an accepted Issue clears the **Codex-ready bar** (clear behavior + named surface + suggestable fix + validation — see [`README.md` § Codex hand-off](README.md)), set `agent:codex` *instead* (single value — never both; Linear rejects multi-value writes to this group), and **delegate** the Issue to the Codex agent when it also clears the **autonomous-confident bar** (the human stays assignee/reviewer).
+1. **`ai:*` is single-value-per-Issue.** Default to `ai:routine` (cron'd provenance). When an accepted Issue clears the **Codex-ready bar** (clear behavior + named surface + suggestable fix + validation — see [`README.md` § Codex hand-off](README.md)), set `ai:codex` *instead* (single value — never both; Linear rejects multi-value writes to this group), and **delegate** the Issue to the Codex agent when it also clears the **autonomous-confident bar** (the human stays assignee/reviewer).
 2. **`package:*` is single-value-per-Issue.** When a bug spans more than one package, pick the **primary surface** as the label and name the secondary package(s) in the Issue body's `## Surface` block. Omit the label entirely when the surface is genuinely unknown.
 3. **Customer Needs cannot be standalone.** Linear's `save_customer_need` API rejects calls without an `issue` (or `project`) parameter — `Exactly one of projectId or issueId must be defined`. Every Customer Need this routine creates must link to an Issue. For items that aren't actionable accepted-bug Issues, the routine creates a **lightweight tracking Issue** (`activity:maintenance` + `Backlog`) and links the Need to it. There is no standalone Need path.
 
@@ -82,7 +82,7 @@ Issues created from Customer Needs (whether accepted bugs or lightweight trackin
 | `package:*` | `package:client`, `package:admin`, `package:shared`, `package:contracts`, `package:indexer`, `package:agent`, `package:docs` | **yes** | Issue. One value only. Pick primary surface; note secondary in body. Omit if surface is genuinely unknown. |
 | `activity:*` | `activity:qa` for confirmed bugs / behavioral defects; `activity:maintenance` for cleanup/polish/ideas/unactionable feedback that still warrants a tracking Issue | **yes** | Issue. One value only. |
 | `source:*` | `source:discord`, `source:telegram`, `source:drive` | n/a (multi-value family — used as provenance flags) | **Always** on every Issue this routine creates, one per origin (Discord→`source:discord`, Telegram→`source:telegram`, Drive→`source:drive`). This stamp is what scopes the Phase 7 triage count to this routine's own writes, so it is non-optional. Never on the Customer Need — Needs carry no labels. |
-| `agent:*` | `agent:routine` (default) · `agent:codex` (Codex-ready accepted bugs) | **yes** | Issue. Default `agent:routine`; swap to `agent:codex` when the accepted bug clears the Codex-ready bar (see [`README.md` § Codex hand-off](README.md)), and delegate to Codex when it also clears the autonomous-confident bar. The `/qa-triage` skill applies the same rule on human promotion. |
+| `ai:*` | `ai:routine` (default) · `ai:codex` (Codex-ready accepted bugs) | **yes** | Issue. Default `ai:routine`; swap to `ai:codex` when the accepted bug clears the Codex-ready bar (see [`README.md` § Codex hand-off](README.md)), and delegate to Codex when it also clears the autonomous-confident bar. The `/qa-triage` skill applies the same rule on human promotion. |
 
 ### Workflow state
 
@@ -347,7 +347,7 @@ Source: the dedicated `#bug-report` channel (`DISCORD_BUGS_CHANNEL_ID`). The ret
    {Discord message URL — same as the Customer Need}
    ```
 
-   Project: leave **unprojected** on the Product team. Apply labels: `protocol:green-goods` + `activity:qa` + `package:<inferred>` (omit if unknown) + `source:discord` + `agent:routine`. Status: `Todo`. Link the Issue to the Customer Need via Linear's relationship surface ("relates to" or the Customer Need's linked-issues field, whichever the Linear API exposes). The Issue body inherits the same privacy boundary — never paste replay URLs, session IDs, distinct IDs, wallet addresses, or reporter identifiers into it.
+   Project: leave **unprojected** on the Product team. Apply labels: `protocol:green-goods` + `activity:qa` + `package:<inferred>` (omit if unknown) + `source:discord` + `ai:routine`. Status: `Todo`. Link the Issue to the Customer Need via Linear's relationship surface ("relates to" or the Customer Need's linked-issues field, whichever the Linear API exposes). The Issue body inherits the same privacy boundary — never paste replay URLs, session IDs, distinct IDs, wallet addresses, or reporter identifiers into it.
 
 7. **Acknowledge on Discord** — reply with the Linear URL and add ✅ reaction in `#bug-report`. When acknowledging, link the Customer Need (not the Issue), because the Customer Need is the user-facing record:
 
@@ -425,9 +425,9 @@ Run the sub-flow below twice — once with `inferred_type=bug` (ack target `#bug
    {Linear-hosted attachment URLs from step 6, or "none provided"}
    ```
 
-   The Customer Need carries **no labels** — `save_customer_need` has no `labels` field. Provenance lives in the body; the canonical labels (`protocol:green-goods` + `source:telegram` + `agent:routine` + `activity:*`) go on the linked Issue created in step 8.
+   The Customer Need carries **no labels** — `save_customer_need` has no `labels` field. Provenance lives in the body; the canonical labels (`protocol:green-goods` + `source:telegram` + `ai:routine` + `activity:*`) go on the linked Issue created in step 8.
 
-8. **Create the linked Issue**. When the report is actionable per the same acceptance bar as Phase 1 step 6, create an accepted-bug Issue. Idea-source captures get a lightweight `activity:maintenance` + `Backlog` tracking Issue. Apply the same canonical labels for Issues (`protocol:green-goods` + `activity:qa` or `activity:maintenance` + `package:<inferred>` + `source:telegram` + `agent:routine`) and privacy boundary.
+8. **Create the linked Issue**. When the report is actionable per the same acceptance bar as Phase 1 step 6, create an accepted-bug Issue. Idea-source captures get a lightweight `activity:maintenance` + `Backlog` tracking Issue. Apply the same canonical labels for Issues (`protocol:green-goods` + `activity:qa` or `activity:maintenance` + `package:<inferred>` + `source:telegram` + `ai:routine`) and privacy boundary.
 
 9. **Mark the captured message triaged**:
    ```
@@ -487,7 +487,7 @@ The `google-drive` connector exposes only `title`, `fullText`, `mimeType`, `modi
 
    Drive notes are mixed-source so judgment is required: include the meeting attendees in `## Reporter context` and prefer the privacy-safe summary over verbatim quotes when in doubt.
 
-7. **Create accepted-bug Issue** only if the doc captures an actionable bug with a clear surface (rare — Drive notes usually need triage first). Apply the same canonical labels (`protocol:green-goods` + `activity:qa` + `package:<inferred>` + `source:drive` + `agent:routine`) and privacy boundary as in Phase 1 step 6.
+7. **Create accepted-bug Issue** only if the doc captures an actionable bug with a clear surface (rare — Drive notes usually need triage first). Apply the same canonical labels (`protocol:green-goods` + `activity:qa` + `package:<inferred>` + `source:drive` + `ai:routine`) and privacy boundary as in Phase 1 step 6.
 
 8. **Reporter acknowledgement** is not applicable for Drive (no per-message back-channel). Drive-sourced records appear in the daily Discord summary as a batch.
 
@@ -498,8 +498,8 @@ After Phases 1–3, before the umbrella check, fold every PostHog match collecte
 1. **Re-run the recurring-pattern probe** (curated question 4 in `## PostHog telemetry enrichment`) over the last 30 days, including matches from before this run.
 2. **Threshold gate**: a hash is a recurring pattern when its 30-day distinct-session count is **≥ 50**. Below threshold, the per-report Customer Needs from Phases 1–3 stand on their own. Do not aggregate.
 3. **Find or create the parent Issue** unprojected on the Product team:
-   - Look for an open Issue carrying `protocol:green-goods` + `agent:routine` + `activity:qa` + a `pattern:posthog-{error-hash-prefix}` label. If the label set is missing on the team, fail loud in the Phase 7 summary and skip aggregation rather than inventing a parent.
-   - If none exists and the threshold is met, create one Issue with title `Recurring: {top-line-error-message-redacted}` (verb-led when possible). Status `Todo`, labels `protocol:green-goods` + `activity:qa` + `package:<inferred>` + `agent:routine` + `pattern:posthog-{error-hash-prefix}`. The parent Issue body uses the safe-summary fields only:
+   - Look for an open Issue carrying `protocol:green-goods` + `ai:routine` + `activity:qa` + a `pattern:posthog-{error-hash-prefix}` label. If the label set is missing on the team, fail loud in the Phase 7 summary and skip aggregation rather than inventing a parent.
+   - If none exists and the threshold is met, create one Issue with title `Recurring: {top-line-error-message-redacted}` (verb-led when possible). Status `Todo`, labels `protocol:green-goods` + `activity:qa` + `package:<inferred>` + `ai:routine` + `pattern:posthog-{error-hash-prefix}`. The parent Issue body uses the safe-summary fields only:
 
      ```markdown
      ## Recurring pattern
@@ -568,18 +568,18 @@ Post one summary message to `#product`:
 POST https://discord.com/api/v10/channels/${DISCORD_PRODUCT_CHANNEL_ID}/messages
 ```
 
-Determine if @mention is needed by counting **this routine's own** open Issues awaiting triage. Every accepted item this routine creates is a Customer Need linked to an Issue (Linear API constraint 3), so the addressable triage signal lives on the Issues — never on the label-less Customer Needs, and there is no team-wide "list Customer Needs" query. Scope the count to bug-intake's writes with the compound filter — `agent:routine` **plus** a `source:{discord|telegram|drive}` origin label **plus** an `activity:{qa|maintenance}` label. That compound is what excludes sibling routines: grant-scout is `activity:research` (so the activity clause drops it even though it also stamps `source:discord`/`source:drive`); health-watch carries no `source:` origin label; qa-triage-pulse uses `source:qa-triage-pulse`, not the three origins.
+Determine if @mention is needed by counting **this routine's own** open Issues awaiting triage. Every accepted item this routine creates is a Customer Need linked to an Issue (Linear API constraint 3), so the addressable triage signal lives on the Issues — never on the label-less Customer Needs, and there is no team-wide "list Customer Needs" query. Scope the count to bug-intake's writes with the compound filter — `ai:routine` **plus** a `source:{discord|telegram|drive}` origin label **plus** an `activity:{qa|maintenance}` label. That compound is what excludes sibling routines: grant-scout is `activity:research` (so the activity clause drops it even though it also stamps `source:discord`/`source:drive`); health-watch carries no `source:` origin label; qa-triage-pulse uses `source:qa-triage-pulse`, not the three origins.
 
 ```
-# list_issues' `label` param is single-value: query by agent:routine, then narrow
+# list_issues' `label` param is single-value: query by ai:routine, then narrow
 # on each result's labels[] for the source-origin and activity clauses below.
 raw_signal_count = count Issues on team=Product where:
-                     labels include agent:routine AND activity:maintenance, AND
+                     labels include ai:routine AND activity:maintenance, AND
                      labels include at least one of source:discord / source:telegram / source:drive, AND
                      state == Backlog
                    # raw signals captured as tracking Issues, awaiting a promotion decision
 accepted_count   = count Issues on team=Product where:
-                     labels include agent:routine AND activity:qa, AND
+                     labels include ai:routine AND activity:qa, AND
                      labels include at least one of source:discord / source:telegram / source:drive, AND
                      state in [Backlog, Todo]
                    # accepted bugs awaiting work

--- a/docs/routines/growth-pulse.md
+++ b/docs/routines/growth-pulse.md
@@ -207,7 +207,7 @@ The status update carries the routine's health read: `onTrack` on a healthy/quie
 
 ### Linear anomaly Issue body
 
-When a growth-side metric crosses an anomaly threshold, the anomaly is **accepted** — open a Linear Issue **unprojected** on the Product team with `protocol:green-goods` + `activity:qa` + `package:<inferred>` (e.g., `package:client` for funnel/retention; `package:admin` for action-template stalls) + `agent:routine`. **Codex hand-off:** swap `agent:routine`→`agent:codex` when the anomaly Issue clears the Codex-ready bar (clear surface + concrete suggested fix + validation; see [`README.md` § Codex hand-off](README.md)), and delegate to Codex when it also clears the autonomous-confident bar — a telemetry-emit gap is the canonical example. Body:
+When a growth-side metric crosses an anomaly threshold, the anomaly is **accepted** — open a Linear Issue **unprojected** on the Product team with `protocol:green-goods` + `activity:qa` + `package:<inferred>` (e.g., `package:client` for funnel/retention; `package:admin` for action-template stalls) + `ai:routine`. **Codex hand-off:** swap `ai:routine`→`ai:codex` when the anomaly Issue clears the Codex-ready bar (clear surface + concrete suggested fix + validation; see [`README.md` § Codex hand-off](README.md)), and delegate to Codex when it also clears the autonomous-confident bar — a telemetry-emit gap is the canonical example. Body:
 
 ```markdown
 ## Anomaly type
@@ -316,7 +316,7 @@ If the status-update write fails (auth, initiative not resolvable, etc.), surfac
 
 Before posting:
 
-1. List every Linear Issue this run created/refreshed and confirm: unprojected on the Product team, expected canonical labels (`protocol:green-goods`, `activity:qa`, `package:*`, one `agent:*` value — `agent:routine` by default or `agent:codex` when the Issue clears the Codex-ready bar), body matches schema, no private fields.
+1. List every Linear Issue this run created/refreshed and confirm: unprojected on the Product team, expected canonical labels (`protocol:green-goods`, `activity:qa`, `package:*`, one `ai:*` value — `ai:routine` by default or `ai:codex` when the Issue clears the Codex-ready bar), body matches schema, no private fields.
 2. Confirm the weekly digest status update: posted to the resolved initiative, body matches the schema, health set, no private fields. Confirm NO GitHub PR, branch, or `docs/metrics/` file was created.
 3. **Privacy grep** across every Linear body (anomaly Issues + the weekly digest status update) and the Discord post for the strings `replay`, `session_id`, `distinct_id`, `0x` (wallet addresses are public on-chain, but treat as suspect — confirm each one is a deliberate `garden_address` reference, not a `distinct_id`), full stack URLs with query strings, and any reporter identifiers. Any unintended hit means the routine leaked private context — fail loud in the `⚠ Failures this run` block and edit the offending body in place to redact before saving.
 4. Confirm the Discord post and `#funding` cross-post fit the schema. Drop excess content rather than expanding sections.

--- a/docs/routines/health-watch.md
+++ b/docs/routines/health-watch.md
@@ -192,9 +192,11 @@ if no open Linear Issue matching the canonical labels + category marker:
     team        = Product
     project     = (none — unprojected)
     title       = "<category marker>: <one-line summary>"
-    labels      = "green-goods", "qa", "routine",   // bare child names or IDs
-                  // only — save_issue rejects the group:child display form
-                  package:<inferred> (when applicable)
+    labels      = "green-goods", "qa", "routine",
+                  <package child, e.g. "indexer"> (when applicable)
+                  // bare child names or IDs only — save_issue rejects the
+                  // group:child display form, including the package label,
+                  // and one bad entry rejects the whole array
     status      = Backlog (exploratory) or Todo (well-scoped)
     body        = <findings>
 else:

--- a/docs/routines/health-watch.md
+++ b/docs/routines/health-watch.md
@@ -38,7 +38,7 @@ The retired GitHub Project #4 / Bug Board / Sprints flow is no longer the routin
 
 - All env vars are loaded; do not read `.env`.
 - `DISCORD_USER_ID_AFO` is Afo's Discord snowflake ID (numeric). Use `<@${DISCORD_USER_ID_AFO}>` in messages to @mention him only on real anomalies.
-- **Linear is the canonical surface for accepted operational health work.** Issues live unprojected on the Product team and carry the canonical scheme (`protocol:green-goods` + `activity:qa` + `package:*` + `agent:routine`). The deprecated `Green Goods` umbrella project is no longer a routing destination. Resolve team/label/status IDs by name at the start of every run; on lookup failure, fail loud in the Discord summary.
+- **Linear is the canonical surface for accepted operational health work.** Issues live unprojected on the Product team and carry the canonical scheme (`protocol:green-goods` + `activity:qa` + `package:*` + `ai:routine`). The deprecated `Green Goods` umbrella project is no longer a routing destination. Resolve team/label/status IDs by name at the start of every run; on lookup failure, fail loud in the Discord summary. Pass labels to `save_issue` as **bare child names** (`["green-goods", "qa", "routine"]`), not the `group:child` display form: the API does not accept the prefixed form, and one unresolvable entry rejects the whole array and files nothing.
 
 ## Threshold philosophy
 
@@ -54,7 +54,7 @@ The previous spec used a 50-block indexer threshold (~12.5s at Arbitrum's 250ms 
 
 Each category maps to a Linear label combination — old `health:*` GitHub labels are retired. Issues are unprojected on the Product team and use the canonical scheme:
 
-| Check | Linear labels (in addition to `protocol:green-goods` + `activity:qa` + `agent:routine`) |
+| Check | Linear labels (in addition to `protocol:green-goods` + `activity:qa` + `ai:routine`) |
 |---|---|
 | Indexer lag/unreachable | `package:indexer` |
 | Vercel deploy/runtime/web-vitals | `package:client` or `package:admin` (whichever Vercel project tripped) |
@@ -62,7 +62,7 @@ Each category maps to a Linear label combination — old `health:*` GitHub label
 | Agent service down/unreachable | `package:agent` |
 | Client-side error spike | `package:client` or `package:admin` (whichever PostHog project surged) |
 
-**Codex hand-off:** most health anomalies are operational (indexer/agent/contract state) and stay `agent:routine` for a human. Only when an accepted health Issue is a **code fix that clears the Codex-ready bar** (clear surface + concrete suggested fix + validation; never `package:contracts` or shared auth — see [`README.md` § Codex hand-off](README.md)) swap `agent:routine`→`agent:codex`, and delegate to Codex when it also clears the autonomous-confident bar.
+**Codex hand-off:** most health anomalies are operational (indexer/agent/contract state) and stay `ai:routine` for a human. Only when an accepted health Issue is a **code fix that clears the Codex-ready bar** (clear surface + concrete suggested fix + validation; never `package:contracts` or shared auth — see [`README.md` § Codex hand-off](README.md)) swap `ai:routine`→`ai:codex`, and delegate to Codex when it also clears the autonomous-confident bar.
 
 ### 1. Indexer
 
@@ -160,7 +160,9 @@ Before opening a new Issue or appending a comment, query Linear for an existing 
 ```
 Linear query (read-only):
   team = Product, type = Issue, state in [Backlog, Todo, In Progress],
-  labels include protocol:green-goods + activity:qa + agent:routine,
+  labels include green-goods + qa,   // bare child names; do NOT require an ai:*
+                                     // child — the Codex hand-off swaps it and this
+                                     // would miss the delegated Issue, opening a dup
   title contains <category marker>
 ```
 
@@ -190,7 +192,8 @@ if no open Linear Issue matching the canonical labels + category marker:
     team        = Product
     project     = (none — unprojected)
     title       = "<category marker>: <one-line summary>"
-    labels      = protocol:green-goods, activity:qa, agent:routine,
+    labels      = "green-goods", "qa", "routine",   // bare child names or IDs
+                  // only — save_issue rejects the group:child display form
                   package:<inferred> (when applicable)
     status      = Backlog (exploratory) or Todo (well-scoped)
     body        = <findings>

--- a/docs/routines/qa-triage-pulse.md
+++ b/docs/routines/qa-triage-pulse.md
@@ -49,7 +49,7 @@ Write Customer Needs on the **Linear Product team**. Mirror [`bug-intake`](./bug
 ### Linear API constraints (must respect on every write)
 
 1. **Customer Needs cannot be standalone.** Linear rejects `save_customer_need` calls without an `issue` (or `project`) parameter — `Exactly one of projectId or issueId must be defined`. Every Customer Need this routine creates must link to a Backlog tracking Issue. The routine never creates standalone "raw signal only" Needs.
-2. **`agent:*` is single-value-per-Issue.** Use `agent:routine` on every Issue this routine creates (cron'd provenance). When a track-only item is later promoted to a delegate (`agent:codex` or `agent:claude`), the interactive `/qa-triage` skill swaps the label — this routine doesn't.
+2. **`ai:*` is single-value-per-Issue.** Use `ai:routine` on every Issue this routine creates (cron'd provenance). When a track-only item is later promoted to a delegate (`ai:codex` or `ai:claude`), the interactive `/qa-triage` skill swaps the label — this routine doesn't.
 3. **`package:*` is single-value-per-Issue.** When the bug spans more than one package, pick the primary surface as the label; name the secondary package(s) in the Issue body's `## Surface` block.
 
 ### Labels applied to the Backlog tracking Issues this routine creates
@@ -59,7 +59,7 @@ Write Customer Needs on the **Linear Product team**. Mirror [`bug-intake`](./bug
 - `activity:qa` for confirmed bugs with a clear surface; `activity:maintenance` for ideas / UX polish / unactionable feedback that still warrant tracking
 - `source:drive` — provenance
 - `source:qa-triage-pulse` — distinguishes routine-pre-staged Issues from `bug-intake`'s Drive-source Issues
-- `agent:routine` — cron'd provenance (single `agent:*` value)
+- `ai:routine` — cron'd provenance (single `ai:*` value)
 - `qa-sync:<YYYY-MM-DD>` — meeting-date slug so `/qa-triage` can resume the right batch (resolve or create on first use)
 
 ### Customer Needs
@@ -148,7 +148,7 @@ For each extracted item:
 Linear requires every Customer Need to link to an Issue. For each non-duplicate item:
 
 1. **First, create the Backlog tracking Issue** on the Product team. Title: prefix with `[tracking]`, then use an action-verb-led one-line distillation (e.g., "[tracking] Investigate PWA install hang on Android" rather than "Install hangs"). Body: Summary + Surface + Suggested fix + Source + safe evidence — no Reproduction/Expected/Actual sections at this routine stage.
-   - Labels: `protocol:green-goods` + ONE `package:*` (primary surface; omit if unknown) + `activity:qa` (clear bug) or `activity:maintenance` (idea / polish / unclear actionability) + `source:drive` + `source:qa-triage-pulse` + `agent:routine` + `qa-sync:<YYYY-MM-DD>`.
+   - Labels: `protocol:green-goods` + ONE `package:*` (primary surface; omit if unknown) + `activity:qa` (clear bug) or `activity:maintenance` (idea / polish / unclear actionability) + `source:drive` + `source:qa-triage-pulse` + `ai:routine` + `qa-sync:<YYYY-MM-DD>`.
    - Status: `Backlog` for all. The routine never claims work as `Todo`; the interactive `/qa-triage` skill promotes selected tracking Issues to `Todo` during the human triage gate.
    - Priority: P3 (Low) by default. P2 (Medium) when PostHog confirms ≥50 sessions in 30d. The routine never sets P0/P1 — humans decide release-blocker status.
 
@@ -222,7 +222,7 @@ The interactive skill's Phase 1 step 0 *Resume from pre-staged Customer Needs* p
 2. If ≥1 exists, offers: "Resume from {N} pre-staged item(s) from {date}'s sync, or run a fresh extract?"
 3. On resume, Phases 1-3 of the skill are skipped (already done by this routine). The triage gate fires immediately with the pre-staged set as the numbered list.
 4. The user's scope-lock decisions:
-   - **Promote** a pre-staged tracking Issue to a main Issue: relabel from `activity:maintenance` → `activity:qa` when needed, move from `Backlog` → `Todo`, set priority, assign, swap `agent:routine` → `agent:claude` or `agent:codex` per the delegation choice, append a Defects-tab row to the QA Sheet via the Apps Script webhook.
+   - **Promote** a pre-staged tracking Issue to a main Issue: relabel from `activity:maintenance` → `activity:qa` when needed, move from `Backlog` → `Todo`, set priority, assign, swap `ai:routine` → `ai:claude` or `ai:codex` per the delegation choice, append a Defects-tab row to the QA Sheet via the Apps Script webhook.
    - **Keep as-is**: leave the tracking Issue in `Backlog` as low-urgency tracked work. The Customer Need stays attached.
    - **Defer**: leave both as-is for the next sync's interactive run to revisit.
 
@@ -240,7 +240,7 @@ This collaboration pattern mirrors how `bug-intake` works today: routine creates
 | Paste Vercel runtime logs into Customer Need bodies | Deploy metadata is public, log content is not — that's `health-watch` territory |
 | Skip the Phase 5 privacy grep | The verbatim-quote field can leak reporter handles if the notes captured them |
 | Try to create a Customer Need without an `issue` parameter | Linear's API rejects with `Exactly one of projectId or issueId must be defined`. This routine ALWAYS creates the Backlog tracking Issue first, then the Customer Need linked to it. There is no standalone Need path. |
-| Apply multiple `agent:*` or `package:*` labels to one Issue | Linear enforces single-value-per-group on these families. The routine uses `agent:routine` (single value) and one `package:*` (primary surface; secondary noted in body). |
+| Apply multiple `ai:*` or `package:*` labels to one Issue | Linear enforces single-value-per-group on these families. The routine uses `ai:routine` (single value) and one `package:*` (primary surface; secondary noted in body). |
 | Push commits | Linear-only — this routine never touches code |
 | Run if notes file is older than 6h | The window is the safety guard against picking up last week's notes |
 | Create >15 Customer Need + Issue pairs in one run | Overflow protection; the user can pick up the rest interactively |


### PR DESCRIPTION
Companion to #666 (which landed on `develop`). Refs PRD-756.

**Without this, the fix does not reach the routines that hit the bug.** Four of the six Green Goods routines read their spec from `origin/main`, not develop:

| Routine | Reads | Writes Linear labels |
|---|---|---|
| bug-intake | `origin/main` | yes |
| growth-pulse | `origin/main` | yes |
| health-watch | `origin/main` | yes |
| qa-triage-pulse | `origin/main` | yes |
| pr-review | `origin/develop` | no (comments only) |
| release-prep | `origin/develop` | no (read + draft only) |

Every label-writing routine is on the `main` side, and `health-watch` is the one that filed PRD-756. Landing only on develop would leave all four reading `agent:*` and failing every write until the next release promote. This is the same main-vs-develop trap as the growth-pulse channel retarget, which needed both #553 and #554 for exactly this reason.

## Scope

Deliberately limited to `docs/routines/`. Main and develop have diverged well beyond this change (`plan-hub.mjs` alone is ~880 lines apart, `CLAUDE.md` ~200), so syncing the wider doc set here would drag in unrelated divergence. This PR is only what the live routines actually read; the rest arrives at the normal promote.

56 label references renamed, plus health-watch's operational create payload and dedupe query, which are the pseudocode blocks the routine follows literally. `package:agent` is untouched in all three files that use it.

## No trigger changes needed

I checked every enabled trigger's prompt: none contains label text. The routines are thin wrappers that read these specs at run time, so merging this is the whole fix, with no re-emit required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)