### PR TITLE
docs(routines): mirror quiet-Discord routine specs to main (live wrapper surface)

### DIFF
--- a/docs/routines/README.md
+++ b/docs/routines/README.md
@@ -2,20 +2,20 @@
 
 Source-of-truth prompts and configurations for Claude Code routines operating on Green Goods. Each routine's active configuration lives at [claude.ai/code/routines](https://claude.ai/code/routines) under Afo's personal Anthropic Pro account; the files here exist so the setup is rebuildable if routines are lost or the research-preview API surface changes.
 
-Guild-level routines live in [`greenpill-dev-guild/.github/routines/claude/`](https://github.com/greenpill-dev-guild/.github/tree/main/routines/claude). This directory holds only the green-goods-scoped routines.
+Guild-level routines live in [`greenpill-dev-guild/.github/routines/claude/`](https://github.com/greenpill-dev-guild/.github/tree/main/routines/claude). This directory holds only the green-goods-scoped routines. Every posting routine follows the guild **house style v2** (one message per post, lede first, one-line all-clear on quiet runs) defined in [`routines/claude/README.md`](https://github.com/greenpill-dev-guild/.github/blob/main/routines/claude/README.md#house-style-v2-applies-to-every-posting-routine).
 
 ## Portfolio
 
 | File | Status | Cadence | Channel | Issue surface |
 |---|---|---|---|---|
-| `bug-intake.md` | active | M/W/F 04:00 | `#bug-report` (per-capture acks for bug-source) + `#product` (idea-source acks + daily summary) | Linear Customer Needs (raw signal); accepted bugs become unprojected Linear Product Issues |
-| `health-watch.md` | active | Daily M-F 07:30 | `#engineering` (red only) | Linear Product Issues for accepted operational health work (unprojected) |
+| `bug-intake.md` | active | M/W/F 04:00 | `#bug-report` (in-thread ack + ✅ on the reporter's message) + `#product` (one digest when something was captured; quiet run = one line) | Linear Customer Needs (raw signal); accepted bugs become unprojected Linear Product Issues |
+| `health-watch.md` | active | Mon/Wed/Fri 14:30 UTC (= 07:30 PT; reduced from daily 2026-07-18) | `#engineering` (all-green = one line; per-check breakdown only on non-green or state change; @mention red only) | Linear Product Issues for accepted operational health work (unprojected) |
 | `growth-pulse.md` | active | Mon 09:00 weekly | `#growth` + `#funding` cross-post | Linear Product Issues for accepted anomalies (unprojected) + weekly digest as a Linear initiative status update (Sustainability & Monetization) |
-| `qa-triage-pulse.md` | active | Wed 21:00 UTC = 13:00 PST / 14:00 PDT (3h after the 10am PST Build Sync start) | `#product` (Discord summary, @mention when there's something to triage) | Linear Customer Needs only (pre-staged, label `source:qa-triage-pulse` + `qa-sync:<date>`); `/qa-triage` promotes them to Issues + QA-sheet rows interactively. Routine id: `trig_01GSagDiEV9Y8QTBzKeZsPSw` |
-| `release-prep.md` | **spec only — not scheduled** | (drafted for monthly release kickoff; no live trigger yet) | `#engineering` (readiness brief; @mention on decision-needed risk) | none — read + draft only; no Linear/GitHub writes |
-| `pr-review.md` | active | event-driven (PR open) | inline on PR | n/a |
+| `qa-triage-pulse.md` | active | Wed 21:00 UTC = 13:00 PST / 14:00 PDT (3h after the 10am PST Build Sync start) | `#product` (item-led summary when items exist; no-sync day = one line; @mention when there's something to triage) | Linear Customer Needs only (pre-staged, label `source:qa-triage-pulse` + `qa-sync:<date>`) from Build Sync notes **plus the biweekly Engineering Sync notes** (2026-07-18 extension; off-weeks skip silently); `/qa-triage` promotes them to Issues + QA-sheet rows interactively. Routine id: `trig_01GSagDiEV9Y8QTBzKeZsPSw` |
+| `release-prep.md` | active (2026-07-18) | Weekdays 16:00 UTC, **self-gating**: full brief posts 3 days before the Linear release project's target date (or on target-moved / Monday cadence-slip / any manual run); other runs exit quietly. Routine id: `trig_01FA23vPDQ1aYaBbZwdJ8gb1` | `#engineering` (readiness brief; @mention on decision-needed risk) | none — read + draft only; no Linear/GitHub writes |
+| `pr-review.md` | active | event-driven (PR opened / ready_for_review) | **Linear comment** on the issue(s) referenced in the PR body (OAuth connector, no stored tokens — steward decision 2026-07-18); PRs with **no Linear reference** get one `#engineering` flag line | one idempotent review comment per referenced Linear issue; never writes GitHub |
 
-That's it — four scheduled cadences plus one event-driven, all cloud routines hosted at [claude.ai/code/routines](https://claude.ai/code/routines). (`release-prep.md` is drafted but has no live trigger yet, so it is not counted among the scheduled cadences.) Anything else previously in this folder (engineering-pulse, plan-executor, hotfix, drift-watch, metrics) has been removed: cut from the portfolio or converted to Claude Code skills (`/plan`, `/debug`).
+That's it — five scheduled cadences plus one event-driven, all cloud routines hosted at [claude.ai/code/routines](https://claude.ai/code/routines). Anything else previously in this folder (engineering-pulse, plan-executor, hotfix, drift-watch, metrics) has been removed: cut from the portfolio or converted to Claude Code skills (`/plan`, `/debug`).
 
 ## Connector Matrix
 
@@ -25,8 +25,8 @@ That's it — four scheduled cadences plus one event-driven, all cloud routines 
 | `health-watch` | Google Calendar, Linear, PostHog, Vercel; Sentry-ready when connector/API access exists | Calendar = context that adjusts severity · Linear = accepted operational health Issues (unprojected Product) · PostHog = client-side `$exception` spike detection + error correlation · Sentry = release regression and agent/API crash context · Vercel = deploy/runtime/web-vitals signal feeding `activity:qa` Issues. Also probes the agent's unauthenticated `/health` via `BOT_API_URL` (env var, not a connector). |
 | `growth-pulse` | Google Calendar, Linear, PostHog | Calendar = WoW context · Linear = accepted-anomaly Issue surface (unprojected Product) · PostHog = product/growth metrics via curated questions. Drive and Miro are intentionally not wired here; Vercel is also intentionally not wired because Vercel Web Analytics overlaps with PostHog and would create dual-source drift. |
 | `qa-triage-pulse` | Google Drive, Linear, PostHog, Vercel | Drive = the Wed Build Sync's Gemini notes · Linear = Customer Need pre-stage surface (raw signal, unprojected) · PostHog = per-surface telemetry cross-reference · Vercel = deploy correlation gated on PostHog-matched items only (anchored to `first_seen`, skipped for items without telemetry signal). |
-| `release-prep` | GitHub (read-only) | GitHub = open PRs + commit range (`main..develop`) + existing releases/tags. No Linear/Drive/PostHog — a pure readiness draft; reads the release runbook live from the checkout. |
-| `pr-review` | Vercel | Preview deployment status + Lighthouse delta. Inline review commentary, not a hard invariant. |
+| `release-prep` | GitHub (read-only), Linear (read-only) | GitHub = open PRs + commit range (`main..develop`) + existing releases/tags · Linear = the active release project's targetDate drives the self-gating window (brief posts at target − 3 days). No Drive/PostHog — a pure readiness draft; reads the release runbook live from the checkout. |
+| `pr-review` | Vercel, Linear (OAuth, the posting surface), Sentry | Vercel = preview deployment status + Lighthouse delta (commentary, not an invariant) · Linear = where the review posts (one idempotent comment per issue referenced in the PR body; no stored GitHub token by steward decision) · Sentry = open-issue context on touched surfaces. |
 
 Gmail is intentionally NOT wired on any GG routine (personal-inbox pollution risk).
 
@@ -34,12 +34,12 @@ Gmail is intentionally NOT wired on any GG routine (personal-inbox pollution ris
 
 | Channel | Used by | Why |
 |---|---|---|
-| `#bug-report` (DISCORD_BUGS_CHANNEL_ID) | bug-intake (Phase 1 ingest source + per-capture acks for bug-source records) | dedicated bug-report feed; reporter ack surface for Telegram bug-topic captures |
-| `#product` (DISCORD_PRODUCT_CHANNEL_ID) | bug-intake (idea-source per-capture acks + daily summary), qa-triage-pulse (Wed pre-stage summary) | user-facing concerns + ideas |
+| `#bug-report` (DISCORD_BUGS_CHANNEL_ID) | bug-intake (Phase 1 ingest source + in-thread acks on reporters' messages) | dedicated bug-report feed |
+| `#product` (DISCORD_PRODUCT_CHANNEL_ID) | bug-intake (digest, quiet run = one line), qa-triage-pulse (Wed pre-stage summary, no-sync = one line) | user-facing concerns + ideas |
 | `#growth` (DISCORD_GROWTH_CHANNEL_ID) | growth-pulse (weekly digest highlights) | growth / funnel / retention / action-template pulse |
-| `#engineering` (DISCORD_ENGINEERING_CHANNEL_ID) | health-watch (red only) | operational health status — engineering-focused (indexer / Vercel / contracts / agent uptime / client errors) |
+| `#engineering` (DISCORD_ENGINEERING_CHANNEL_ID) | health-watch (one-line green; breakdown on change; @mention red only) | operational health status — engineering-focused (indexer / Vercel / contracts / agent uptime / client errors) |
 | `#funding` (DISCORD_FUNDING_CHANNEL_ID) | growth-pulse cross-post (when grant-relevant) | grant relevance only |
-| inline on PR | pr-review | review surface |
+| Linear comment (referenced issue) | pr-review | review surface — one idempotent comment per issue the PR body references; `#engineering` gets a one-line flag when a PR references no Linear issue |
 
 `#engineering` is health-watch's home channel (operational health status — indexer / Vercel / contracts / agent uptime / client errors). Other code-local engineering signals still come from the user reading PRs and Linear, not from a routine.
 
@@ -52,7 +52,7 @@ Routines @mention Afo only when his action is required (via `DISCORD_USER_ID_AFO
 - `growth-pulse` — when an anomaly is opened in Linear OR a setup failure needs attention
 - `qa-triage-pulse` — when ≥1 Customer Need was pre-staged from the Wednesday Build Sync (signal that `/qa-triage` is ready to run) OR a Linear/Drive setup failure needs attention. Silent on quiet weeks.
 
-`pr-review` posts inline on the PR; the GitHub mention surface is already explicit and no Discord ping is needed. Healthy weekly heartbeats with zero anomalies = no @mention.
+`pr-review` posts its review to Linear (the referenced issue), never to GitHub — in-PR commentary is CodeRabbit's and Codex's lane; its only Discord output is the `#engineering` missing-issue flag line. Healthy weekly heartbeats with zero anomalies = no @mention.
 
 ## Conventions
 
@@ -60,6 +60,7 @@ Routines @mention Afo only when his action is required (via `DISCORD_USER_ID_AFO
 - All routine branches use `claude/<routine-name>/<topic>`.
 - Loop prevention on `pr-review`: filter on `head_branch` starting with `claude/` (NOT on author — routine PRs carry the user's GitHub author per the docs).
 - **Linear is the durable backlog.** GitHub is for PRs and code review only — routines never file GitHub Issues, never write to GitHub Projects, and never apply GitHub Project iteration/Sprints fields. The retired GitHub Project #4 / Bug Board flows (and the `Sprints` field they depended on) are out of scope for any active routine.
+- **Model tier:** every GG routine runs `claude-opus-5` (moved off `claude-opus-4-8[1m]` on 2026-07-26; same token price, better instruction-following and bug-finding). Each spec names its model in frontmatter, and that frontmatter is documentation of the live trigger, not a control surface: changing it does not change the running model, so re-emit the trigger and edit the spec in the same change. The guild-level tiering rationale, including the routines on `claude-fable-5`, lives in [`greenpill-dev-guild/.github` → `routines/claude/README.md`](https://github.com/greenpill-dev-guild/.github/blob/main/routines/claude/README.md).
 
 ## Scope discipline
 
@@ -80,6 +81,8 @@ All routine writes use the canonical Linear label scheme. Old vocabularies (`are
 | `activity:*` | Routines apply: `activity:qa` (bug fixes, anomaly review, operational health validation), `activity:maintenance` (polish/cleanup that isn't a user-visible defect). The full Linear taxonomy also includes `activity:research`, `activity:architecture`, `activity:build`, `activity:design` — those are human-applied and not used by GG routines. |
 | `source:*` | `source:discord`, `source:telegram`, `source:drive` | Provenance of the originating signal (Customer Needs always carry this; Issues carry it when the originating provenance still matters). |
 | `ai:*` | `ai:routine` (default) · `ai:codex` (Codex-ready Issues) | Single-value-per-Issue provenance/routing. Default `ai:routine`; swap to `ai:codex` when an accepted Issue clears the Codex-ready bar (see § Codex hand-off). Provenance only, not human priority. |
+
+**Writing these through the API:** `group:child` is display shorthand, not accepted input. `save_issue` resolves labels by **bare child name or ID**, so pass `["green-goods", "qa", "routine"]`, not `["protocol:green-goods", "activity:qa", "ai:routine"]`. One unresolvable entry rejects the whole array and the routine files nothing, so a stale label name is a silent no-write rather than a partial write. The `ai:*` group was written `agent:*` in docs before 2026-07-27; `agent` exists only as `package:agent`, which is unrelated.
 
 The dispatch labels `automation:claude` / `automation:codex` (legacy GitHub-era handoff flags) and the `work:polish` / `work:customer-need` / `area:*` / `health:*` / `grant:*` labels are not used. GitHub Project #4 and its `automated/claude` + `health:*` label set are retired entirely; no active routine writes to a GitHub Issue surface.
 
@@ -102,7 +105,7 @@ Routines that consume Telegram captures need the agent API surface only:
 | `BOT_API_URL` | Public URL of the Green Goods agent (e.g., `https://agent.greengoods.app`) |
 | `BOT_API_TOKEN` | Bearer token for authenticating API requests to the agent |
 
-Used by: `bug-intake` (read + claim + status updates via `/api/messages?inferred_type=bug|idea` — needs `BOT_API_TOKEN`; no Telegram-side ack, reporters get acknowledged via the per-capture Discord post in `#bug-report` or `#product`). `health-watch` uses **only** the unauthenticated `/health` + `/ready` endpoints for an uptime probe — no token, never `/api/*`.
+Used by: `bug-intake` (read + claim + status updates via `/api/messages?inferred_type=bug|idea` — needs `BOT_API_TOKEN`; no Telegram-side ack; Telegram captures surface as item lines in bug-intake's `#product` digest). `health-watch` uses **only** the unauthenticated `/health` + `/ready` endpoints for an uptime probe — no token, never `/api/*`.
 
 Capture scope is **agent-side only** (two Fly.io secrets — one per topic type):
 
@@ -166,14 +169,18 @@ cannot cross-wire the two browser apps.
 
 Frontend source-map ownership is split today: PostHog source-map uploads run from GitHub
 Actions with `POSTHOG_CLI_TOKEN` plus the app-specific PostHog environment ID, while Vite
-currently emits maps only when `SENTRY_AUTH_TOKEN` is present. `GG_ENABLE_SOURCEMAPS` is an
-upload-lane flag, not a durable Vercel project variable. Keep client Sentry integration
+emits maps whenever `GG_ENABLE_SOURCEMAPS=true` (the upload lane sets it) or the Sentry
+upload path is active. `GG_ENABLE_SOURCEMAPS` is an upload-lane flag, not a durable Vercel
+project variable — the app build only strips public `.map` files when it is unset, so setting
+it on a Vercel project would publish browser source maps. Keep client Sentry integration
 variables only where Sentry upload or log-drain integration is intentionally enabled, and do
 not keep orphaned source-map flags on admin.
 
 Active routines are Sentry-ready, not Sentry-dependent: when a Sentry connector/API surface is available, include Sentry safe-summary evidence beside PostHog evidence. When it is unavailable, continue without it. Do not add Sentry MCP entries or routine API-key fallbacks unless the user explicitly asks.
 
 ## Linear environment
+
+The workspace has five teams as of 2026-07-14 (Product `PRD`, Research `RESR`, Community `COM`, Growth `GROW`, Marketing `MAR`; charters in [`greenpill-dev-guild/.github` → `docs/teams/`](https://github.com/greenpill-dev-guild/.github/tree/main/docs/teams)). **Green Goods routines write only to the Product team** — the funding pipeline lives on Growth (guild grant-scout's turf), marketing briefs on Marketing, cohort work on Community.
 
 Three routines write to Linear:
 
@@ -190,20 +197,18 @@ Three routines write to Linear:
 
 ### Auth
 
-All three routines share the same auth surface. The cloud routine env exposes Linear access via:
+All routines reach Linear through the **native Linear OAuth connector wired into the cloud routine environment — no `LINEAR_API_KEY` is stored** (standing guild rule as of 2026-07-04; the connector can lapse between runs and is re-authorized by a human, never replaced with a key). If the connector is unauthenticated or unreachable, the routine **fails closed**: it surfaces the failure in its Discord summary and skips Linear writes — it never scans or writes blind.
 
-| Variable / surface | Description |
-|---|---|
-| `LINEAR_API_KEY` | Personal API key with read/write access — fallback when no connector is configured |
-| Linear connector | Native Linear connector wired into the cloud routine environment |
-| Linear MCP | Linear MCP server exposed to the routine |
+The routine resolves team/label/status IDs by name at the start of every run — IDs are never hardcoded in the prompt. If the lookup fails, the routine surfaces the failure in its daily Discord summary instead of skipping records silently.
 
-Whichever surface is wired up, the routine resolves team/label/status IDs by name at the start of every run — IDs are never hardcoded in the prompt. If the lookup fails, the routine surfaces the failure in its daily Discord summary instead of skipping records silently.
+### Output style (all posting routines)
+
+Green Goods routine posts follow the guild house style: bold headers with blank lines between blocks, lead with what needs a human (🔴 first), a thing appears only if it moved or needs attention (never a "quiet" bullet or empty section), metrics folded into the line they describe, one message per channel per run. Get short by cutting content rather than compressing prose: drop anything that would not change what a reader does next, then write what remains in complete sentences (no padding, no fragment-and-arrow shorthand). Cadences in the portfolio table are UTC (the qa-triage-pulse row's "Wed 21:00 UTC" annotation style is the convention).
 
 ## Rebuilding a routine
 
 1. Log in to claude.ai/code/routines.
 2. Click **New routine**.
 3. Paste the prompt from the relevant `.md` file (everything after the `# Prompt` heading).
-4. Configure repos, environment, connectors, and triggers as specified in the file's frontmatter.
+4. Configure repos, environment, connectors, triggers, **and the model** as specified in the file's frontmatter. A rebuilt routine left on the platform default silently runs the wrong tier.
 5. Save.

--- a/docs/routines/bug-intake.md
+++ b/docs/routines/bug-intake.md
@@ -9,8 +9,8 @@ environment: green-goods
 network-access: full
 env-vars:
   - DISCORD_BOT_TOKEN
-  - DISCORD_BUGS_CHANNEL_ID  # dedicated #bug-report channel — Phase 1 ingest + per-capture acks for bug-source records
-  - DISCORD_PRODUCT_CHANNEL_ID  # idea-source acks land here per Phase 6 routing; Phase 7 daily summary posts here
+  - DISCORD_BUGS_CHANNEL_ID  # dedicated #bug-report channel — Phase 1 ingest + in-thread acks on the reporter's message
+  - DISCORD_PRODUCT_CHANNEL_ID  # Phase 7 digest posts here
   - DISCORD_USER_ID_AFO
   - BOT_API_URL
   - BOT_API_TOKEN
@@ -21,21 +21,20 @@ env-vars:
   - SENTRY_CLIENT_PROJECT
   - SENTRY_ADMIN_PROJECT
   - SENTRY_AGENT_PROJECT
-  - LINEAR_API_KEY  # personal API key OR Linear MCP/connector access; cloud env wires whichever the harness exposes
 connectors:
   - google-drive
-  - linear  # use whichever Linear surface the harness provides (MCP, native connector, or LINEAR_API_KEY)
+  - linear  # Linear via the OAuth connector only — no LINEAR_API_KEY is stored (guild rule 2026-07-04); fail closed if unauthenticated
   - posthog  # read-only PostHog connector; primary path for telemetry enrichment
   - vercel  # read-only deploy correlation — surface deploy timing + diff in Customer Need bodies when a recent prod deploy temporally aligns with the report
-model: claude-opus-4-8[1m]
+model: claude-opus-5
 allow-unrestricted-branch-pushes: false  # Linear records only, no PRs, no GitHub issues
 ---
 
 # Prompt
 
-You are the bug-intake routine for Green Goods. You harvest user-reported bugs, ideas, and operator feedback from three sources — Discord `#bug-report`, Telegram capture topics in the Green Goods chat, and Google Drive meeting notes — and route them into **Linear** as the team's product-management substrate. Per Linear's API constraints (see § "Linear API constraints" below), every validated user/community signal becomes a **Customer Need + Issue pair** — the Need carries the verbatim report and Reporter context in its body, and links to an Issue that gets the labels. Accepted bugs with clear behavior + named surface + suggestable fix get an `activity:qa` + `Todo` Issue. Everything else (ideas, operator pain, unclear actionability) gets a lightweight `activity:maintenance` + `Backlog` tracking Issue. You acknowledge each accepted record with a per-capture Discord post in the appropriate channel (`#bug-report` for bug-source, `#product` for idea-source), then post a single daily summary to `#product`.
+You are the bug-intake routine for Green Goods. You harvest user-reported bugs, ideas, and operator feedback from three sources — Discord `#bug-report`, Telegram capture topics in the Green Goods chat, and Google Drive meeting notes — and route them into **Linear** as the team's product-management substrate. Per Linear's API constraints (see § "Linear API constraints" below), every validated user/community signal becomes a **Customer Need + Issue pair** — the Need carries the verbatim report and Reporter context in its body, and links to an Issue that gets the labels. Accepted bugs with clear behavior + named surface + suggestable fix get an `activity:qa` + `Todo` Issue. Everything else (ideas, operator pain, unclear actionability) gets a lightweight `activity:maintenance` + `Backlog` tracking Issue. You acknowledge Discord-source reports in place (a threaded reply + ✅ reaction on the reporter's own message), and post ONE digest to `#product` when the run captured something; a quiet run posts a single all-clear line. Standalone per-capture ack messages were retired 2026-07-30 as the largest source of routine Discord noise.
 
-You do NOT create GitHub issues — GitHub is for PRs and code review only, not a durable backlog. You do NOT touch any GitHub Project, the retired `Bug Board #18`, or any GitHub Issue. You do NOT audit code, you do NOT open PRs, you do NOT touch repo files. You do NOT post acks to Telegram (no DMs, no group replies). Your sole role is intake → Linear Customer Need + linked Issue → per-capture Discord ack → daily Discord summary.
+You do NOT create GitHub issues — GitHub is for PRs and code review only, not a durable backlog. You do NOT touch any GitHub Project, the retired `Bug Board #18`, or any GitHub Issue. You do NOT audit code, you do NOT open PRs, you do NOT touch repo files. You do NOT post acks to Telegram (no DMs, no group replies). Your sole role is intake → Linear Customer Need + linked Issue → in-thread ack (Discord-source) → one `#product` digest.
 
 ## Setup
 
@@ -43,10 +42,10 @@ You do NOT create GitHub issues — GitHub is for PRs and code review only, not 
 - `DISCORD_USER_ID_AFO` is Afo's Discord snowflake ID. Use `<@${DISCORD_USER_ID_AFO}>` to @mention.
 - Google Drive connector is available for reading shared documents.
 - Discord channels:
-  - `DISCORD_BUGS_CHANNEL_ID` is the dedicated `#bug-report` channel. Phase 1 reads from it. Phase 6 posts per-capture bug acks here.
-  - `DISCORD_PRODUCT_CHANNEL_ID` is the `#product` channel. Phase 6 posts per-capture **idea** acks here. Phase 7 daily summary posts here.
+  - `DISCORD_BUGS_CHANNEL_ID` is the dedicated `#bug-report` channel. Phase 1 reads from it and acks in-thread there (step 7).
+  - `DISCORD_PRODUCT_CHANNEL_ID` is the `#product` channel. The Phase 7 digest posts here.
 - Telegram source: forum-topics in the Green Goods chat. The agent reads two Fly secrets — `TELEGRAM_BUGS_TOPIC` and `TELEGRAM_IDEAS_TOPIC`, each holding `<chat_id>_<thread_id>` — and tags captured rows with `inferred_type=bug|idea` accordingly. The routine queries `/api/messages?inferred_type=bug|idea` and never hardcodes thread or chat ids. Adding a new topic type later means a one-line code change in the agent's `CAPTURE_TYPE_ENV_VARS` map plus the new Fly secret.
-- Linear access is whatever the cloud environment exposes (`LINEAR_API_KEY`, the Linear connector, or the Linear MCP server). Use it to look up team/project/label IDs at run time — **never hardcode IDs**. If the lookup fails, log the failure, skip Linear writes, and surface the failure in the Discord summary so the user can fix the wiring.
+- Linear access is the **OAuth Linear connector only** — no API key exists in this environment (standing guild rule). Use it to look up team/project/label IDs at run time — **never hardcode IDs**. If the connector is unauthenticated or a lookup fails, fail closed: log the failure, skip Linear writes, and surface the failure in the Discord summary so the user can re-authorize the connector.
 
 ## Linear surface
 
@@ -84,6 +83,8 @@ Issues created from Customer Needs (whether accepted bugs or lightweight trackin
 | `source:*` | `source:discord`, `source:telegram`, `source:drive` | n/a (multi-value family — used as provenance flags) | **Always** on every Issue this routine creates, one per origin (Discord→`source:discord`, Telegram→`source:telegram`, Drive→`source:drive`). This stamp is what scopes the Phase 7 triage count to this routine's own writes, so it is non-optional. Never on the Customer Need — Needs carry no labels. |
 | `ai:*` | `ai:routine` (default) · `ai:codex` (Codex-ready accepted bugs) | **yes** | Issue. Default `ai:routine`; swap to `ai:codex` when the accepted bug clears the Codex-ready bar (see [`README.md` § Codex hand-off](README.md)), and delegate to Codex when it also clears the autonomous-confident bar. The `/qa-triage` skill applies the same rule on human promotion. |
 
+Pass labels to `save_issue` as **bare child names** (`["green-goods", "qa", "routine"]`), not the `group:child` display form: the API does not accept the prefixed form, and one unresolvable entry rejects the whole array and files nothing.
+
 ### Workflow state
 
 - Customer Needs have no workflow state — they're body-only records linked to an Issue.
@@ -112,7 +113,7 @@ The default for ambiguous items is `activity:maintenance` + `Backlog` — captur
 
 When the Discord/Linear native integration is enabled, prefer the integration's link surface (it preserves the message reference). When it isn't available, fall back to including the source URL in the record body. Either way, the source URL must appear in the Customer Need body so the original report is one click away.
 
-> Linear's native Discord integration does not currently surface project-update notifications. The per-capture posts in Phase 6 and the daily `#product` summary in Phase 7 handle that gap.
+> Linear's native Discord integration does not currently surface project-update notifications. The in-thread acks (Phase 1 step 7) and the `#product` digest (Phase 7) handle that gap.
 
 ## PostHog telemetry enrichment
 
@@ -168,7 +169,7 @@ Issue these against the PostHog connector and keep the responses in private rout
 | Distinct ID | | ✅ |
 | Wallet / smart-account address | | ✅ |
 | Reporter identifier (Discord username, Telegram handle, email, Telegram numeric user id) | | ✅ — even though the source URL appears in `## Source`, do not duplicate the identifier into the PostHog evidence block |
-| Reporter **display name** (Telegram first name, Discord display name) | ✅ — appears in `## Source` of the Customer Need and in the per-capture Discord post (`by **Alice**`). Intentional: the team needs reporter context to follow up, and the name is already visible to anyone in the source channel. Do **not** use it in the PostHog evidence block. | |
+| Reporter **display name** (Telegram first name, Discord display name) | ✅ — appears in `## Source` of the Customer Need and in the Phase 7 digest item line. Intentional: the team needs reporter context to follow up, and the name is already visible to anyone in the source channel. Do **not** use it in the PostHog evidence block. | |
 | Full stack frames (paths, query strings, search params) | | ✅ — they can re-identify a user via deep-link state |
 | Any field not listed above that could fingerprint a user (IP, UA, geo) | | ✅ |
 
@@ -372,7 +373,7 @@ If `BOT_API_URL` is not configured, skip this phase silently.
 
 Only an unset `BOT_API_URL` is a silent skip; a configured-but-failing endpoint always surfaces in the Phase 7 summary so the wiring can be fixed. Telegram-side reporters have no other acknowledgement surface, so a dark intake path is high-priority signal, not a quiet no-op.
 
-The agent persists every freeform message posted in allowlisted forum topics into its `chat_messages` table, tagging each row with `inferredType` derived from which Fly secret (`TELEGRAM_BUGS_TOPIC` → `bug`, `TELEGRAM_IDEAS_TOPIC` → `idea`) matched the message's chat+thread. The bot stays silent in the Green Goods chat — it never replies, reacts, or DMs reporters. Acknowledgement happens entirely via the per-capture Discord post in Phase 6 below; **do NOT call any `/api/notify`-style endpoint**, and do NOT reply in the Telegram topic.
+The agent persists every freeform message posted in allowlisted forum topics into its `chat_messages` table, tagging each row with `inferredType` derived from which Fly secret (`TELEGRAM_BUGS_TOPIC` → `bug`, `TELEGRAM_IDEAS_TOPIC` → `idea`) matched the message's chat+thread. The bot stays silent in the Green Goods chat — it never replies, reacts, or DMs reporters. Team-facing acknowledgement happens via the Phase 7 digest; **do NOT call any `/api/notify`-style endpoint**, and do NOT reply in the Telegram topic.
 
 Run the sub-flow below twice — once with `inferred_type=bug` (ack target `#bug-report`), once with `inferred_type=idea` (ack target `#product`):
 
@@ -386,7 +387,7 @@ Run the sub-flow below twice — once with `inferred_type=bug` (ack target `#bug
    GET ${BOT_API_URL}/api/messages?inferred_type=${TYPE}&status=processing&limit=100
    Authorization: Bearer ${BOT_API_TOKEN}
    ```
-   For `processing` rows, only attempt recovery when `updatedAt` is more than 6 hours old. The response is `{ messages: [...], count }`. Each message carries `id`, `chatId`, `threadId`, `senderPlatformId`, `senderDisplayName`, `text`, `inferredType`, `postedAt`, `updatedAt`, and `attachments[]` with embedded `downloadUrl`s. `chatId` and `threadId` are informational (useful for constructing `t.me/c/<chat>/<thread>/<message>` deep links in the Phase 6 ack post) — do not hardcode them.
+   For `processing` rows, only attempt recovery when `updatedAt` is more than 6 hours old. The response is `{ messages: [...], count }`. Each message carries `id`, `chatId`, `threadId`, `senderPlatformId`, `senderDisplayName`, `text`, `inferredType`, `postedAt`, `updatedAt`, and `attachments[]` with embedded `downloadUrl`s. `chatId` and `threadId` are informational (useful for constructing `t.me/c/<chat>/<thread>/<message>` deep links in Linear bodies and digest item lines) — do not hardcode them.
 
 2. **Claim before processing** — for every candidate, immediately claim it before any PostHog, Linear, Discord, or media-upload work:
    ```
@@ -398,9 +399,9 @@ Run the sub-flow below twice — once with `inferred_type=bug` (ack target `#bug
 
 3. **Filter actionable reports** — apply the same filter as Phase 1 step 2 (skip reactions / "me too" / general discussion). Pure media-only messages are kept if they look like reports (a screenshot in the bug topic almost always is). Non-actionable claimed messages should be marked `rejected`, not returned to `new`.
 
-4. **Dedupe against Linear** — list open Customer Needs on the Product team that carry `protocol:green-goods` + `source:telegram`, match on `chat_messages.id`, the message-id segment of it, garden context, and described behavior. When a duplicate exists, comment on the existing record with the safe display name (or `anonymous`), source message reference, and one-sentence quote; do not include `senderPlatformId`, Telegram handles, or numeric IDs. Do not create a new Customer Need. Carry the existing Customer Need URL forward to Phase 6 so the duplicate capture still gets a Discord acknowledgement.
+4. **Dedupe against Linear** — list open Customer Needs on the Product team that carry `protocol:green-goods` + `source:telegram`, match on `chat_messages.id`, the message-id segment of it, garden context, and described behavior. When a duplicate exists, comment on the existing record with the safe display name (or `anonymous`), source message reference, and one-sentence quote; do not include `senderPlatformId`, Telegram handles, or numeric IDs. Do not create a new Customer Need. Carry the existing Customer Need URL forward to Phase 7 so the duplicate capture is still visible in the digest's merged-duplicates line.
 
-5. **Enrich with PostHog + optional Sentry (private context)** — same procedure as Phase 1 step 4. Treat `senderPlatformId` as private. `senderDisplayName` is allowed only in the Customer Need `## Source` block and the Phase 6 per-capture Discord post; do not use it in the PostHog or Sentry evidence block or telemetry lookup unless the reporter explicitly consented.
+5. **Enrich with PostHog + optional Sentry (private context)** — same procedure as Phase 1 step 4. Treat `senderPlatformId` as private. `senderDisplayName` is allowed only in the Customer Need `## Source` block and the Phase 7 digest item line; do not use it in the PostHog or Sentry evidence block or telemetry lookup unless the reporter explicitly consented.
 
 6. **Upload media to Linear (when present)** — for each attachment in `message.attachments`, fetch:
    ```
@@ -437,7 +438,7 @@ Run the sub-flow below twice — once with `inferred_type=bug` (ack target `#bug
    ```
    On dedupe-detected duplicates, mark `triaged` too — the message has been processed, just not into a new record.
 
-10. **No Telegram-side ack.** The Discord per-capture post in Phase 6 is the only acknowledgement.
+10. **No Telegram-side ack.** The Phase 7 digest is the only team-facing acknowledgement of Telegram captures.
 
 ## Phase 3: Google Drive notes
 
@@ -531,38 +532,25 @@ After Phases 1–4, before posting the summary:
 2. List every linked Issue this run created (per-report and recurring-pattern parent) and confirm it has the expected labels, status, source URL, and Customer Need link.
 3. List every duplicate detection — every existing Customer Need or Issue this run commented on — and confirm the comment landed.
 4. List every rejection — every signal you read but did not act on — and the reason.
-5. Run a privacy grep across every body created or edited this run **and across every captured `chat_messages.text` and attachment caption that this run consumed** for the strings `replay`, `session_id`, `distinct_id`, `0x`, the reporter identifiers seen this run, and any other token from the "private" column of the privacy-boundary table. Any hit in a Linear body means the routine leaked private context — fail loud in Phase 7's `⚠ Failures this run` block and edit the offending body in place to redact before the run completes. Hits in raw `chat_messages.text` or captions cause the run to drop that record from the Discord per-capture post in Phase 6 (Linear still records it, scrubbed) — never leak the raw text downstream.
+5. Run a privacy grep across every body created or edited this run **and across every captured `chat_messages.text` and attachment caption that this run consumed** for the strings `replay`, `session_id`, `distinct_id`, `0x`, the reporter identifiers seen this run, and any other token from the "private" column of the privacy-boundary table. Any hit in a Linear body means the routine leaked private context — fail loud in Phase 7's `⚠ Failures this run` block and edit the offending body in place to redact before the run completes. Hits in raw `chat_messages.text` or captions cause the run to drop that record's quote from the Phase 7 digest (Linear still records it, scrubbed) — never leak the raw text downstream.
 
-Carry these into Phase 6 + Phase 7 so the per-capture posts and daily summary are verifiable.
+Carry these into Phase 7 so the digest is verifiable.
 
-## Phase 6: Per-capture Discord posts
+## Phase 6: Acknowledgements (in-thread only — 2026-07-30)
 
-For every accepted Customer Need this run (Discord-source from Phase 1, Telegram-source from Phase 2, or Drive-source from Phase 3), and for every Telegram duplicate capture merged into an existing Customer Need in Phase 2, post a per-capture message into the appropriate Discord channel:
+Standalone per-capture ack messages are retired; they were the single largest source of routine noise on Discord (up to 8 extra messages per run on top of the digest). Acknowledgement now works like this:
 
-- **Bug-source records** (Discord `#bug-report`, Telegram bug topic, Drive notes flagged as bugs) → `DISCORD_BUGS_CHANNEL_ID`.
-- **Idea-source records** (Telegram idea topic, Drive notes flagged as ideas) → `DISCORD_PRODUCT_CHANNEL_ID`.
+- **Discord-source reports**: the Phase 1 step 7 threaded `Tracked → {customer_need_url}` reply + ✅ reaction on the reporter's own message in `#bug-report` IS the acknowledgement — the reporter sees it attached to their message, and the channel gains no standalone posts. Duplicates get the same threaded reply pointing at the existing record (Phase 1 step 3).
+- **Telegram- and Drive-source records** (including Telegram duplicates merged into existing records): no standalone Discord message. They are acknowledged as item lines in the Phase 7 digest, which posts whenever anything was captured and carries what the old ack did (type, source, one-line summary, Linear link).
+- The bot stays silent in Telegram either way (no DMs, no group replies — unchanged).
 
-Post format (per accepted Customer Need; one Discord message each):
+If a threaded reply or ✅ reaction fails for a Discord-source report, surface it in Phase 7's failures block — the reporter otherwise gets nothing back. If the Phase 5 grep flagged private tokens in a source text that cannot be cleanly redacted, keep that record's quote out of the digest (Linear records it scrubbed) and note it in the failures block.
 
-```
-{🐛 if bug, 💡 if idea} **{Bug | Idea} from {Discord | Telegram | Drive}** by **{display name or "anonymous"}**
-> {first 280 chars of source text — verbatim, scrubbed of private tokens per Phase 5}
-{if attachments: render up to 4 of the Linear-hosted attachment URLs as Discord embeds; the {N+}-overflow note if any}
-{source link: t.me message URL when constructable, else the bare topic name; for Discord-source the message URL}
-→ Linear: <{customer_need_url}> {append "(existing)" when this was a duplicate capture merged into an existing Customer Need}
-```
+## Phase 7: Digest to #product
 
-Do not include reporter identifiers (Telegram `senderPlatformId`, Discord username when not the display name, Drive meeting attendee names beyond the speaker), wallet addresses, or PostHog replay/session/distinct IDs. The Phase 5 grep applies here too — re-grep the Discord post body before sending.
+**House style v2** (see [`routines/claude/README.md` in `.github`](https://github.com/greenpill-dev-guild/.github/blob/main/routines/claude/README.md#house-style-v2-applies-to-every-posting-routine)): ONE message, a lede first, items over counts, ~900 chars target.
 
-Skip the per-capture post entirely (and surface in Phase 7's failures block) when:
-- The Phase 5 grep flagged any private token in the source text and you cannot cleanly redact while preserving meaning.
-- The Discord channel id env var is unset.
-
-This is where reporters and the team see acknowledgement — Telegram-side reporters have no other ack surface, so failing to post here means they get nothing back. Treat per-capture-post failure as a high-priority issue, log it, and include it in Phase 7's failures block.
-
-## Phase 7: Daily summary to #product
-
-Post one summary message to `#product`:
+Post to `#product`:
 
 ```
 POST https://discord.com/api/v10/channels/${DISCORD_PRODUCT_CHANNEL_ID}/messages
@@ -574,43 +562,44 @@ Determine if @mention is needed by counting **this routine's own** open Issues a
 # list_issues' `label` param is single-value: query by ai:routine, then narrow
 # on each result's labels[] for the source-origin and activity clauses below.
 raw_signal_count = count Issues on team=Product where:
-                     labels include ai:routine AND activity:maintenance, AND
+                     labels include maintenance (bare child names; do not require
+                       an ai:* child — delegation swaps it), AND
                      labels include at least one of source:discord / source:telegram / source:drive, AND
                      state == Backlog
                    # raw signals captured as tracking Issues, awaiting a promotion decision
 accepted_count   = count Issues on team=Product where:
-                     labels include ai:routine AND activity:qa, AND
+                     labels include qa (bare child names; do not require
+                       an ai:* child — delegation swaps it), AND
                      labels include at least one of source:discord / source:telegram / source:drive, AND
                      state in [Backlog, Todo]
                    # accepted bugs awaiting work
 ```
 
-Message format:
+**When the run captured or merged anything, or anything failed:**
 
 ```
-{if raw_signal_count + accepted_count > 3 OR any_failure: "<@${DISCORD_USER_ID_AFO}> "}**Bug Intake — {YYYY-MM-DD}**
+{if raw_signal_count + accepted_count > 3 OR any_failure: "<@${DISCORD_USER_ID_AFO}> "}**🐛 Bug Intake · {YYYY-MM-DD}**
 
-📥 **New today (Linear)**
-• Discord #bug-report: {N} reports → {M} Customer Needs, {I} linked Issues, {K} duplicates merged
-• Telegram bug topic: {N} captured → {M} Customer Needs, {I} linked Issues, {K} duplicates
-• Telegram idea topic: {N} captured → {M} Customer Needs, {K} duplicates
-• Drive notes: {N} docs reviewed, {M} Customer Needs, {I} linked Issues, {R} rejected (out-of-scope)
-• Discord per-capture acks posted: {B} to #bug-report, {D} to #product
-• PostHog enrichment: {E} reports matched, {P} recurring-pattern parents created or refreshed
-• Sentry enrichment: {S} reports matched, {U} issue links added (if connector available)
+{Lede: 1–2 sentences a teammate would write — what came in and what matters most. e.g. "Three new reports; the passkey-register failure from Telegram matches live telemetry and is the one to look at."}
 
-📋 **Triage queue**: {raw_signal_count} raw signals awaiting promotion · {accepted_count} accepted bugs in `Backlog`/`Todo`
-{if raw_signal_count + accepted_count > 3: "→ open the Linear Product team's unprojected `protocol:green-goods` view, decide which raw-signal tracking Issues are worth promoting to accepted bugs, and review the open accepted-bug Issues."}
+{New records · up to 3, most significant first (clear bug > operator pain > idea), one line each:}
+- {🐛|💡} **{one-line summary}** · {source} · {surface}{ · telemetry: {n} sessions/7d} → <{customer_need_url}>
+{if more than 3: "…plus {n} more captured, all in Linear."}
+{if duplicates merged: "{K} duplicate report(s) merged into existing records."}
 
-🆕 Top new Customer Needs:
-1. [{title}]({customer_need_url}) — {source} · {area}
-2. [{title}]({customer_need_url}) — {source} · {area}
-3. [{title}]({customer_need_url}) — {source} · {area}
-
-{if any_failure: "⚠ Failures this run: {short list — e.g. Linear project lookup failed, label missing, posthog: unreachable, privacy grep flagged a body}"}
+{if raw_signal_count + accepted_count > 3: "📋 Triage queue · {raw_signal_count} raw signals + {accepted_count} accepted bugs → the Product team's unprojected `protocol:green-goods` view."}
+{if any_failure: "⚠ {short failure list — e.g. Linear project lookup failed, posthog unreachable, in-thread ack failed for <msg url>, privacy grep flagged a body}"}
 ```
 
-This summary message is **public**. Replay URLs, session IDs, distinct IDs, wallet/user identifiers, and reporter identifiers must not appear here. If a private replay link needs to reach Afo, send it via DM to `<@${DISCORD_USER_ID_AFO}>` in a separate message — never inline in this `#product` summary.
+Source-by-source count breakdowns, ack tallies, and enrichment telemetry stay OUT of the digest — the records themselves are in Linear, which is the count that matters.
+
+**Quiet run (zero captured, zero merged, zero failures): exactly one line, no mention** — never a skeleton of zero-count bullets:
+
+```
+🐛 Bug intake · {YYYY-MM-DD}: quiet run · nothing new in #bug-report, Telegram, or Drive.
+```
+
+This digest is **public**. Replay URLs, session IDs, distinct IDs, wallet/user identifiers, and reporter identifiers must not appear here. If a private replay link needs to reach Afo, send it via DM to `<@${DISCORD_USER_ID_AFO}>` in a separate message — never inline in this `#product` digest.
 
 The @mention only fires when triage is piling up OR a setup failure needs human attention. This keeps Discord notifications signal-heavy and matches the existing notification policy.
 
@@ -629,5 +618,5 @@ The @mention only fires when triage is piling up OR a setup failure needs human 
 - **No duplicate of `/linear issue` records.** When a teammate already filed via the Linear/Discord integration, the Linear record exists; this routine merges context but does not create a parallel record.
 - **1-hour runtime cap.** Intake is lightweight. If the run takes longer than an hour, something is wrong.
 - **Project routing discipline.** Customer Needs and accepted-bug Issues live unprojected on the Product team. Never route into the retired `Green Goods`, `Coop`, `Network Website`, `Cookie Jar`, or `Story Board` projects. Graduate to a bounded active project only when one already exists for this work.
-- **Acknowledge every accepted record via the Phase 6 Discord post.** Discord-source bug reports also get the inline `Tracked → ${linear_url}` reply + ✅ reaction in `#bug-report` (Phase 1 step 7). Telegram reporters get NO Telegram-side ack — no DM, no group reply — by design; Phase 6's per-capture Discord post is their only acknowledgement. Drive-only signals are surfaced via Phase 6 too.
+- **Acknowledgement model (2026-07-30).** Discord-source reports are acknowledged with the inline `Tracked → ${linear_url}` threaded reply + ✅ reaction in `#bug-report` (Phase 1 step 7) — never with standalone ack messages. Telegram and Drive records are acknowledged as item lines in the Phase 7 digest; Telegram reporters get NO Telegram-side ack — no DM, no group reply — by design.
 - **Fail loud, not silent.** A missing Linear project, a missing label, a 401 from Linear, or a 401/503 from the agent messages API (`${BOT_API_URL}/api/messages`, per the Phase 2 preflight) must appear in the Discord summary so the user can fix the wiring. Do not skip records to keep the run "green."

--- a/docs/routines/growth-pulse.md
+++ b/docs/routines/growth-pulse.md
@@ -18,13 +18,12 @@ env-vars:
   - DISCORD_GROWTH_CHANNEL_ID
   - DISCORD_FUNDING_CHANNEL_ID
   - DISCORD_USER_ID_AFO
-  - LINEAR_API_KEY
-  - LINEAR_DIGEST_INITIATIVE_ID  # initiative for the weekly digest status update; falls back to the "Sustainability & Monetization" initiative by name if unset
+  - LINEAR_DIGEST_INITIATIVE_ID  # initiative for the weekly digest status update; falls back to the "Sustainability & Monetization" initiative by name if unset; Linear itself via the OAuth connector only (no API key, guild rule 2026-07-04)
 connectors:
   - posthog
   - linear
   - google-calendar
-model: claude-opus-4-8[1m]
+model: claude-opus-5
 status: active  # 2026-05-25 — weekly digest posts to Linear (initiative status update), no GitHub PR. Consolidates metrics digest + guild-weekly-checkin numbers + guild-product-development-synthesis growth signals
 ---
 
@@ -42,7 +41,7 @@ This routine writes **NO GitHub artifacts** — no Issues, no PRs, no branches, 
 
 This routine reads from:
 
-- **PostHog** via the connector, using only named questions from `.claude/skills/posthog-questions/SKILL.md` and the `POSTHOG_PROJECT_ID_*` env vars for project selection.
+- **PostHog** via the connector, using only named questions from `docs/routines/posthog-questions.md` and the `POSTHOG_PROJECT_ID_*` env vars for project selection.
 - **Indexer**: `ENVIO_INDEXER_URL` for on-chain action volume, garden activity, vault history.
 - **Chain**: `ARBITRUM_RPC_URL` for raw on-chain reads when the indexer is lagging.
 - **Dune API** for queries tagged `[routine]` only — never modify user-owned queries.
@@ -75,7 +74,7 @@ If a query against the App project returns zero events for a 30d window, that's 
 
 ### SKILL v1.1.0 (2026-05-09): person_id stitching + failures question
 
-The funnel HogQL was rewritten in `posthog-questions/SKILL.md` v1.1.0 to:
+The funnel HogQL was rewritten in `posthog-questions.md` v1.1.0 to:
 
 1. **Join by `person_id`** instead of `distinct_id`. PostHog assigns an anonymous UUID `distinct_id` before `posthog.identify()` and switches to the wallet/passkey identifier after auth. The previous SKILL joined by raw `distinct_id` and produced 0% conversion across the auth boundary even when conversions were happening (verified empirically 2026-05-09: 7 person registers + 6 person joins in 30d, 0 overlap with the old query, correct numbers with the new one).
 2. **Document the cohort caveat**: `funnel.onboarding` legitimately reports 0% when the new-user cohort within `{window}` hasn't completed the next step yet, even though returning users (registered > window ago) are joining gardens fine. Verify against raw `garden_join_success` counts before filing a "funnel breakage" anomaly — see Phase 2 thresholds below.
@@ -84,7 +83,7 @@ The new `failures.conversion-kill` question makes the failure-rate signal first-
 
 ### Curated questions
 
-This routine references the following curated questions from `.claude/skills/posthog-questions/SKILL.md`:
+This routine references the following curated questions from `docs/routines/posthog-questions.md`:
 
 - `funnel.onboarding` — passkey register → garden join → first work submission. Drives the conversion narrative. (Person_id-stitched as of SKILL v1.1.0.)
 - `funnel.work-repeat` — first work → second work within 7d. Drives the early-retention signal. (Person_id-stitched.)
@@ -92,11 +91,11 @@ This routine references the following curated questions from `.claude/skills/pos
 - `gardens.engagement-summary` — per-garden 7d active members + 7d work submitted/approved. Drives the per-garden table.
 - `gardens.dormant` — gardens with zero work in 7d/14d/30d. Drives the dormancy alert and any anomaly Linear Issues.
 - `gardens.operator-activity` — work approvals per operator per week, aggregated. Drives the operator-load section.
-- ~~`actions.template-creation-rate`~~ — **BLOCKED (do not run):** its event `admin_action_create_success` is defined but unwired (no tracker, no call site) and never fires. The action-template trend now comes from the **indexer** `Action` entity (`createdAt`); see Phase 1 step 8. (Marked BLOCKED in `posthog-questions/SKILL.md` v1.2.0.)
+- ~~`actions.template-creation-rate`~~ — **BLOCKED (do not run):** its event `admin_action_create_success` is defined but unwired (no tracker, no call site) and never fires. The action-template trend now comes from the **indexer** `Action` entity (`createdAt`); see Phase 1 step 8. (Marked BLOCKED in `posthog-questions.md` v1.2.0.)
 
-All seven are public-safe-default. (As of 2026-W21 `actions.template-creation-rate` is **BLOCKED** and not consumed — the action-template signal comes from the indexer; see Phase 1 step 8.) The digest status update, the Discord posts, and the Linear anomaly bodies receive only allowlisted fields per the SKILL's privacy boundary table — never replay URLs, session IDs, distinct IDs, wallet addresses, or reporter identifiers.
+All seven are public-safe-default. (As of 2026-W21 `actions.template-creation-rate` is **BLOCKED** and not consumed — the action-template signal comes from the indexer; see Phase 1 step 8.) The digest status update, the Discord posts, and the Linear anomaly bodies receive only allowlisted fields per the library's privacy boundary table — never replay URLs, session IDs, distinct IDs, wallet addresses, or reporter identifiers.
 
-**Concrete invocation**: there is no `posthog.run_question(name, vars)` RPC yet. For each question above, paste the HogQL block from `posthog-questions/SKILL.md` for that question into the PostHog connector's `query-run` call with privacy mode `public`. Reference the question by name in the routine's reasoning ("running `funnel.onboarding` over a 30d window"); reference the actual HogQL block by its location in the SKILL file. The HogQL must match verbatim — any divergence is a `routine-self-audit` violation.
+**Concrete invocation**: there is no `posthog.run_question(name, vars)` RPC yet. For each question above, paste the HogQL block from `posthog-questions.md` for that question into the PostHog connector's `query-run` call with privacy mode `public`. Reference the question by name in the routine's reasoning ("running `funnel.onboarding` over a 30d window"); reference the actual HogQL block by its location in the library file. The HogQL must match verbatim — any divergence is a `routine-self-audit` violation.
 
 If the PostHog connector is unavailable or the expected project ID env vars are missing, there is no API-key fallback for growth/BD questions in the Claude routine today; log `posthog: growth questions unreachable` in the digest's `⚠ Failures this run` block and drop the affected sections rather than fabricating numbers.
 
@@ -104,43 +103,35 @@ If the PostHog connector is unavailable or the expected project ID env vars are 
 
 ### Discord post to `#growth` (primary)
 
+**House style v2** (see [`routines/claude/README.md` in `.github`](https://github.com/greenpill-dev-guild/.github/blob/main/routines/claude/README.md#house-style-v2-applies-to-every-posting-routine)): ONE message (~900 chars target, ~1,500 ceiling — cut content rather than chunk), a lede before any bullets, and only metrics that **moved** appear as bullets. The Linear status update carries every full table; Discord carries what changed and what it means.
+
 ```
-{if any_anomaly_red OR any_novel_failure: "<@${DISCORD_USER_ID_AFO}> "}**📈 Growth Pulse — Week {YYYY-WW}**
+{if any_anomaly_red OR any_novel_failure: "<@${DISCORD_USER_ID_AFO}> "}**📈 Growth Pulse · week {YYYY-WW}**
 
-{if any_anomaly_red OR a top conversion-kill is above threshold — this block LEADS; omit it entirely on a clean week:}
+{Lede: 1–2 plain sentences on what the week means — e.g. "Steady week: onboarding held and no anomalies fired." or "Work submissions jumped after the template fix; one retention signal is worth watching." Not a metrics recital.}
+
+{if any_anomaly_red OR a top conversion-kill is above threshold — this block leads; omit entirely on a clean week:}
 **🔴 Watch**
-- **{red anomaly or worst conversion-kill step}** — {1-line what it is} → {Linear URL}
+- **{red anomaly or worst conversion-kill step}** · {1-line what it is} → <{Linear URL}>
 
-**Onboarding funnel** ({window})
-- Registered: **{N}** ({±N% WoW})
-- Joined a garden: **{M}** ({register_to_join_pct}%)
-- First work submitted: **{F}** ({join_to_first_work_pct}%)
+**Moved this week** {only metrics that moved (threshold crossed, >10% relative WoW on the headline number, or feeding 🔴 Watch) · max 3 bullets · fold the number and the delta into one line each}
+- {e.g. "First work submitted: **12** (+50% WoW) · the template fix landed Tuesday"}
 
-**🔁 Early retention**
-- First-time users (30d): **{N}**  ·  repeat within 7d: **{M}** ({repeat_pct}%)
-
-**🌱 Garden engagement** (7d)
-- Active: **{A}** of {T}  ·  dormant ≥7d **{D7}** · ≥14d **{D14}** · ≥30d **{D30}**
-- Top by work: {garden_name} ({N}), {garden_name} ({N}), {garden_name} ({N})
-
-**🛠 Action templates** (on-chain · indexer `Action`)
-- Created last week: **{N}**  ·  4-week trend {↑ / → / ↓}
-{if newest Action.createdAt ≥ 21d ago: "- ⚠ no new template in {weeks}w (last {YYYY-MM-DD})"}
-
-**⚠️ Conversion-kill (7d)** — top 3 by failure rate
-- {step}: **{failure_pct}%** ({failed_count}/{total_attempts})
-
-**📋 Anomalies** — {anomaly_count} new · {open_count} open (`activity:qa` + `protocol:green-goods`)
-{bullets — at most 3 — new anomalies with Linear URL. Omit this whole block when zero new AND zero open.}
-
-{if funnel_thin AND open_p0_qa: "**🔎 Funnel context** — {step(s)} thin; {N} open P0 `activity:qa` defect(s) on {surface} ({PRD-ids}) likely suppress conversion before instrumented steps."}
-{if intent_verdict != "coherent": "**🧭 Intent** — {drifting|unclear}: {underserved_stage or 'plans glance unavailable'}"}
+{if anomaly_count > 0: "**📋 Anomalies** · {anomaly_count} new{, {open_count} open} · {IDs with <Linear URLs>}"}
+{if funnel_thin AND open_p0_qa: "**🔎 Context** · {step(s)} thin; {N} open P0 defect(s) on {surface} ({PRD-ids}) likely suppress conversion."}
+{if intent_verdict != "coherent": "**🧭 Intent** · {drifting|unclear}: {underserved_stage or 'plans glance unavailable'}"}
 
 **📄 Full digest** → {linear_status_update_url}
-{if any_failure: "⚠ Failures this run: {short list}"}
+{if any_failure: "⚠ {short failure list}"}
 ```
 
-Caps: 3 anomaly bullets, 3 top-garden bullets, 3 conversion-kill bullets. Prose paragraphs forbidden — bulleted only.
+Everything that did NOT move stays out of the post entirely — no funnel block, no retention block, no engagement block, no per-section skeleton. The reader who wants the steady numbers clicks the digest link.
+
+**Steady week (nothing moved, no anomalies, no failures):** exactly one line —
+
+```
+📈 Growth Pulse · week {YYYY-WW}: steady · funnel {headline}, {A}/{T} gardens active, no anomalies. Full digest → {linear_status_update_url}
+```
 
 ### Cross-post to `#funding` (only when grant-relevant)
 
@@ -207,7 +198,7 @@ The status update carries the routine's health read: `onTrack` on a healthy/quie
 
 ### Linear anomaly Issue body
 
-When a growth-side metric crosses an anomaly threshold, the anomaly is **accepted** — open a Linear Issue **unprojected** on the Product team with `protocol:green-goods` + `activity:qa` + `package:<inferred>` (e.g., `package:client` for funnel/retention; `package:admin` for action-template stalls) + `ai:routine`. **Codex hand-off:** swap `ai:routine`→`ai:codex` when the anomaly Issue clears the Codex-ready bar (clear surface + concrete suggested fix + validation; see [`README.md` § Codex hand-off](README.md)), and delegate to Codex when it also clears the autonomous-confident bar — a telemetry-emit gap is the canonical example. Body:
+When a growth-side metric crosses an anomaly threshold, the anomaly is **accepted** — open a Linear Issue **unprojected** on the Product team with `protocol:green-goods` + `activity:qa` + `package:<inferred>` (e.g., `package:client` for funnel/retention; `package:admin` for action-template stalls) + `ai:routine`. **Codex hand-off:** swap `ai:routine`→`ai:codex` when the anomaly Issue clears the Codex-ready bar (clear surface + concrete suggested fix + validation; see [`README.md` § Codex hand-off](README.md)), and delegate to Codex when it also clears the autonomous-confident bar — a telemetry-emit gap is the canonical example. Pass labels to `save_issue` as **bare child names** (`["green-goods", "qa", "routine"]`), not the `group:child` display form: the API does not accept the prefixed form, and one unresolvable entry rejects the whole array and files nothing. Body:
 
 ```markdown
 ## Anomaly type
@@ -233,7 +224,7 @@ When a growth-side metric crosses an anomaly threshold, the anomaly is **accepte
 - Sample timestamp: {YYYY-MM-DDTHH:MM:SSZ}
 ```
 
-The Issue body **never** carries replay URLs, session IDs, distinct IDs, wallet addresses, or any other field marked private in `posthog-questions/SKILL.md`. The privacy grep in Phase 4 catches violations before the body is saved.
+The Issue body **never** carries replay URLs, session IDs, distinct IDs, wallet addresses, or any other field marked private in `posthog-questions.md`. The privacy grep in Phase 4 catches violations before the body is saved.
 
 ## Phase 0: Load prior baseline
 
@@ -259,7 +250,7 @@ Switch to project `163591` (App) first, run the consumer questions, then switch 
 
 **Switch to Admin (262122):**
 7. `failures.conversion-kill` — `{ window: "7d" }`. Merge the `work_approval` row with the App-side row (App typically sees the `_failed` events, Admin sees the `_success` events) before applying anomaly thresholds.
-8. ~~`actions.template-creation-rate`~~ — **BLOCKED, do not run.** The required event `admin_action_create_success` is unwired (no tracker, no call site; the whole `admin_action_*` family is orphaned constants — see `posthog-questions/SKILL.md` v1.2.0), so it returns zero forever. Instead read the **indexer** `Action` entity (epoch field `createdAt`, id `${chainId}-${n}`) for the action-template signal: (a) count of `Action` with `createdAt` in the last 7d (Discord "created last week"), (b) per-week counts over 12 weeks (the digest trend table), (c) the max `createdAt` across all `Action` entities (Phase 2 stall check). This is on-chain truth and sidesteps the emit-side gap.
+8. ~~`actions.template-creation-rate`~~ — **BLOCKED, do not run.** The required event `admin_action_create_success` is unwired (no tracker, no call site; the whole `admin_action_*` family is orphaned constants — see `posthog-questions.md` v1.2.0), so it returns zero forever. Instead read the **indexer** `Action` entity (epoch field `createdAt`, id `${chainId}-${n}`) for the action-template signal: (a) count of `Action` with `createdAt` in the last 7d (Discord "created last week"), (b) per-week counts over 12 weeks (the digest trend table), (c) the max `createdAt` across all `Action` entities (Phase 2 stall check). This is on-chain truth and sidesteps the emit-side gap.
 
 Cache the JSON outputs for the run; pass the same data into Phase 2 (digest), Phase 3 (status-update body), and Phase 4 (anomaly detection).
 
@@ -323,7 +314,7 @@ Before posting:
 
 ## Phase 5: Discord post + cross-post
 
-Post the primary message to `#growth` per the schema — it carries the week's **highlights inline** (funnel, retention, garden engagement, action templates, conversion-kill, anomalies) **and** the `📄 Full digest (Linear)` line linking the Phase 3 status-update URL. Never reduce the post to a bare link, and never drop the link — highlights live in Discord, the full digest lives in the linked Linear status update. If grant-relevance criteria are met, post the cross-post to `#funding`. Channel guard at every post: if the env var is unset, log and skip; never pick an alternate channel.
+Post the primary message to `#growth` per the schema — a lede saying what the week means, then ONLY the metrics that moved (max 3 bullets), the 🔴 Watch block when something is red, and the `📄 Full digest (Linear)` line linking the Phase 3 status-update URL. On a steady week the post is the single steady-week line. Never drop the digest link — meaning lives in Discord, numbers live in the linked Linear status update. If grant-relevance criteria are met, post the cross-post to `#funding`. Channel guard at every post: if the env var is unset, log and skip; never pick an alternate channel.
 
 `<@${DISCORD_USER_ID_AFO}>` mention only on (a) a **red/P2 anomaly**, or (b) a **novel** setup failure — one not already listed in the prior digest's `## Known setup failures` (loaded in Phase 0). A known, persistent gap (e.g. an unprovisioned connector already flagged in a prior run) is listed in `⚠ Failures this run` **without** a ping, to avoid weekly alert fatigue. Healthy weeks post without mention.
 
@@ -334,8 +325,8 @@ Post the primary message to `#growth` per the schema — it carries the week's *
 - **Cap: 2 hours runtime**. Timeout → write partial digest with `⚠ Failures this run: timed out at phase X`.
 - **No GitHub writes at all**. Linear is the only durable surface: the weekly digest is a Linear initiative status update and anomalies are Linear Issues (unprojected on Product). Do not open or update GitHub Issues, PRs, branches, Project items, or iteration/Sprints fields.
 - **Project routing discipline**. Anomaly Issues stay unprojected on the Product team. Never route into the retired `Green Goods`, `Coop`, `Network Website`, `Cookie Jar`, or `Story Board` projects.
-- **No ad hoc HogQL** in the routine prompt. Every PostHog read goes through a curated question name and the canonical HogQL block in `.claude/skills/posthog-questions/SKILL.md`. Adding a new question requires editing that library first.
-- **Privacy boundary is non-negotiable**. See `posthog-questions/SKILL.md` allowlist. If unsure, treat as private.
+- **No ad hoc HogQL** in the routine prompt. Every PostHog read goes through a curated question name and the canonical HogQL block in `docs/routines/posthog-questions.md`. Adding a new question requires editing that library first.
+- **Privacy boundary is non-negotiable**. See `posthog-questions.md` allowlist. If unsure, treat as private.
 - **Channel guards** at every Discord post. Fail loud, never silently substitute.
 - **Mention rule**: `<@${DISCORD_USER_ID_AFO}>` only on red/P2 anomalies or **novel** setup failures (not gaps already in the prior digest's `## Known setup failures`).
 - **Intent check is status-only** (Phase 2c). It appends the `## Intent check` section to the weekly status update (+ ≤1 optional Discord `🧭 Intent` line on `drifting`/`unclear`) and nothing else — no Issue, no new initiative, no new @mention trigger. The `.plans/active` read is bounded (`status.json` + `brief.md` top of active hubs only) and graceful-degrades to a Linear+PostHog-only verdict of `unclear` if the repo isn't readable.

--- a/docs/routines/health-watch.md
+++ b/docs/routines/health-watch.md
@@ -1,7 +1,7 @@
 ---
 routine-name: health-watch
 trigger:
-  schedule: "30 7 * * 1-5"  # 07:30 local, Mon-Fri
+  schedule: "30 14 * * 1,3,5"  # Mon/Wed/Fri 14:30 UTC (= 07:30 PT) — reduced from daily 2026-07-18; red-only posting unchanged, Sentry alerting covers off-days
 repos:
   - green-goods
 environment: green-goods-routines-extended
@@ -25,12 +25,12 @@ connectors:
   - linear
   - posthog
   - vercel
-model: claude-opus-4-8[1m]
+model: claude-opus-5
 ---
 
 # Prompt
 
-You are the health-watch routine for Green Goods. Run the five health checks below. Open or update **Linear Product Issues** (unprojected, accepted operational health work) only for **real anomalies** — be conservative about what counts. Most days, this routine should post a green Discord summary and create no Issues.
+You are the health-watch routine for Green Goods. Run the five health checks below. Open or update **Linear Product Issues** (unprojected, accepted operational health work) only for **real anomalies** — be conservative about what counts. Most days, this routine should post a one-line all-green summary and create no Issues.
 
 The retired GitHub Project #4 / Bug Board / Sprints flow is no longer the routing destination. GitHub is for PRs and code review only — health-watch never writes GitHub Issues, never adds Project items, and never sets iteration/Sprints fields.
 
@@ -160,9 +160,11 @@ Before opening a new Issue or appending a comment, query Linear for an existing 
 ```
 Linear query (read-only):
   team = Product, type = Issue, state in [Backlog, Todo, In Progress],
-  labels include green-goods + qa,   // bare child names; do NOT require an ai:*
-                                     // child — the Codex hand-off swaps it and this
-                                     // would miss the delegated Issue, opening a dup
+  labels include green-goods + qa,   // bare child names; do NOT require an
+                                     // ai:* child here — the Codex hand-off
+                                     // swaps routine->codex, and matching on
+                                     // it would miss the delegated Issue and
+                                     // open a duplicate
   title contains <category marker>
 ```
 
@@ -195,8 +197,7 @@ if no open Linear Issue matching the canonical labels + category marker:
     labels      = "green-goods", "qa", "routine",
                   <package child, e.g. "indexer"> (when applicable)
                   // bare child names or IDs only — save_issue rejects the
-                  // group:child display form, including the package label,
-                  // and one bad entry rejects the whole array
+                  // group:child display form, and one bad entry rejects all
     status      = Backlog (exploratory) or Todo (well-scoped)
     body        = <findings>
 else:
@@ -234,20 +235,28 @@ After all checks, post to `#engineering`:
 POST https://discord.com/api/v10/channels/${DISCORD_ENGINEERING_CHANNEL_ID}/messages
 ```
 
-Message format:
-```
-**Health Watch — {YYYY-MM-DD}**
-🟢 Indexer: OK (lag: {N} blocks)              # 🟡 if 500-2000, 🔴 if >2000 or unreachable
-🟢 Vercel: {N}/{M} production projects ready  # 🔴 with project name(s) + deploy/runtime Issue
-🟢 Contracts: vaults stable                   # or "deferred — indexer unhealthy"
-🟢 Agent: up (/health 200)                    # 🔴 if unreachable/non-200 · "skipped" if BOT_API_URL unset
-🟢 Client errors: {N} App / {M} Admin (24h)   # 🟡 elevated · 🔴 ≥30 App or ≥15 Admin
+**All-green run (every check 🟢, no Issues created/updated, no recoveries): post exactly one line** — this is most runs (house style v2, see [`routines/claude/README.md` in `.github`](https://github.com/greenpill-dev-guild/.github/blob/main/routines/claude/README.md#house-style-v2-applies-to-every-posting-routine)):
 
-{if any anomaly created/updated: "→ {N} Linear Issue(s) created/updated"}
-{if recovery: "✓ {category} recovered — Linear Issue {url} moved to Done"}
+```
+🩺 Health watch · {YYYY-MM-DD}: all green · indexer, deploys, contracts, agent, client errors all OK{, {K} Issue(s) still open <links>}
 ```
 
-**@mention rule**: if any check is 🔴, prefix the message with `<@${DISCORD_USER_ID_AFO}>`. If everything is 🟢 or 🟡 with no new Issues, no mention. Recovery-only runs (where the only change is auto-close) also get no mention — just the line in the summary.
+**Anything non-green, or any state change (new/updated Issue, recovery): post the per-check breakdown**, non-green lines first, 🟢 lines folded into one:
+
+```
+{if any 🔴: "<@${DISCORD_USER_ID_AFO}> "}**🩺 Health Watch · {YYYY-MM-DD}**
+
+{Lede: 1 sentence on what changed — e.g. "The indexer fell 3,400 blocks behind overnight; everything else is healthy."}
+
+🔴 {check}: {what + number}                    # one line per 🔴, then per 🟡
+🟡 {check}: {what + number}
+🟢 {remaining checks folded}: {e.g. "Vercel, contracts, agent, client errors all OK"}
+
+{if any anomaly created/updated: "→ {N} Linear Issue(s) created/updated · <links>"}
+{if recovery: "✓ {category} recovered · Linear Issue <{url}> moved to Done"}
+```
+
+**@mention rule**: if any check is 🔴, prefix the message with `<@${DISCORD_USER_ID_AFO}>`. If everything is 🟢 or 🟡 with no new Issues, no mention. Recovery-only runs (where the only change is auto-close) also get no mention — just the breakdown with its ✓ line.
 
 If Discord is unreachable, continue — Linear Issues are the primary output.
 

--- a/docs/routines/posthog-questions.md
+++ b/docs/routines/posthog-questions.md
@@ -1,0 +1,692 @@
+# PostHog Curated Questions
+
+> Canonical curated-question library for PostHog reads across Green Goods routines and
+> skills. Two lenses (product/quality, growth/BD), one privacy boundary, one shared answer
+> per question. Formerly `.claude/skills/posthog-questions/SKILL.md` — moved here in the
+> 2026-07 round-2 consolidation because it is a data dictionary, not a procedure.
+
+Single source of truth for every PostHog read a routine or interactive skill should need. Routines reference questions **by name** (`errors.recent`, `funnel.onboarding`, etc.) — never paste raw HogQL into a routine prompt. When a question's underlying query needs to evolve, edit it here once and every consumer picks up the change.
+
+## When to use this library
+
+- Authoring or editing a routine that needs PostHog data — pick a named question instead of writing HogQL.
+- Authoring or editing a skill that pulls PostHog evidence (e.g. `debug`) — reference the same library so privacy boundaries match.
+- Reviewing a routine for compliance — every PostHog call should resolve to a name in this file. Raw HogQL outside this file is a `routine-self-audit` violation.
+- Designing a new metric — propose a new question entry here first, then wire routines.
+
+Treat this file as the registry of allowed question names, privacy modes, output fields, and current invocation paths.
+
+Default flow:
+
+1. Pick the existing named question that answers the need.
+2. Use the concrete invocation path documented below.
+3. Keep public/shared outputs limited to fields marked public in the question schema.
+4. Add a new question here before wiring a new PostHog read elsewhere.
+
+## Question index
+
+All 17 questions at a glance. Names are the stable identifiers consumers reference; each links to its full entry (HogQL, bind variables, output schema, consumers) below. ⚠️ = private-only default, 🚫 = blocked (do not run).
+
+| Question | Lens | Privacy default | Answers |
+|---|---|---|---|
+| [`errors.recent`](#errorsrecent) | product-quality | public-safe (aggregates) | Recent JS exceptions grouped by message + URL with affected-session counts |
+| [`errors.detail`](#errorsdetail) | product-quality | ⚠️ private-only | Full detail for one error hash incl. top stack frame + replay links |
+| [`errors.recurring`](#errorsrecurring) | product-quality | public-safe | Distinct-session count per error hash over 30 days (bug-intake roll-up input) |
+| [`errors.match-bug-report`](#errorsmatch-bug-report) | product-quality | ⚠️ private-only | Fuzzy match between a verbatim bug-report quote and recent errors/events |
+| [`replay.user-sessions`](#replayuser-sessions) | product-quality | ⚠️ private-only | Recent sessions for a known reporter with replay links |
+| [`release.error-rate-delta`](#releaseerror-rate-delta) | product-quality | public-safe | Error rate per 1k events, 24h before vs after a deploy |
+| [`release.sync-success-rate-delta`](#releasesync-success-rate-delta) | product-quality | public-safe | Offline-job success rate before vs after a deploy |
+| [`quality.top-failures`](#qualitytop-failures) | product-quality | public-safe | Top 10 errors ranked by affected-user count |
+| [`funnel.onboarding`](#funnelonboarding) | growth-bd | public-safe | Passkey register → garden join → first work submission funnel |
+| [`funnel.work-repeat`](#funnelwork-repeat) | growth-bd | public-safe | % of first-time submitters who submit a second work within 7 days |
+| [`retention.curve`](#retentioncurve) | growth-bd | public-safe | D1/D7/D30 retention by weekly cohort |
+| [`gardens.engagement-summary`](#gardensengagement-summary) | growth-bd | public-safe | Per-garden 7-day active members + work submitted |
+| [`gardens.dormant`](#gardensdormant) | growth-bd | public-safe | Gardens with zero work in the last 7/14/30 days |
+| [`gardens.operator-activity`](#gardensoperator-activity) | growth-bd | public counts / ⚠️ private operator identity | Work approvals per operator per week, as anonymous aggregates |
+| [`actions.template-creation-rate`](#actionstemplate-creation-rate) | growth-bd | 🚫 blocked | Action-template creation rate (required event never fires — do not run) |
+| [`failures.conversion-kill`](#failuresconversion-kill) | growth-bd | public-safe | Per-step failure rate for `*_failed` vs `*_success` event pairs |
+| [`web.acquisition-summary`](#webacquisition-summary) | growth-bd | public-safe | Sessions by source/UTM medium for grant/BD reporting |
+
+## Architecture (Option C, locked)
+
+Each question has:
+
+- **Name** — `lens.subject` identifier consumers reference (e.g. `funnel.onboarding`).
+- **Lens** — `product-quality` (private-default) or `growth-bd` (public-safe-default).
+- **Default privacy** — what crosses into a shared surface (Linear body, Discord summary, PR body, public doc) by default.
+- **HogQL** — the canonical query string. Used directly by `scripts/agents/posthog-query.ts` and as the source of truth when promoting to a PostHog Saved Insight.
+- **Saved-Insight ID** — populated when a human has created a tunable Insight in the PostHog UI for this question. When present, the connector path prefers the Insight; the script path still uses HogQL.
+- **Output schema** — exact field names + which fields are public-safe vs private-only.
+- **Required emit-side events** — the events the question depends on. If any are absent in production, the question is `blocked` and consumers must skip it gracefully.
+- **Used by** — list of routines/skills that reference this question. Updated as new consumers wire in.
+
+> **Promotion rule**: every question starts as HogQL-only. Promote to a Saved Insight only when a human actually wants to tune the underlying query in the PostHog UI. Don't pre-create Insights nobody is going to maintain.
+
+## Calling pattern (for routines and skills)
+
+**There is no `posthog.run_question(name, vars)` RPC and no `script ask <name>` subcommand.** The concrete invocation a routine actually writes:
+
+- **Claude routines and interactive Claude Code work**: use the PostHog connector as the primary path. Switch to the right project (`POSTHOG_PROJECT_ID_APP`, `POSTHOG_PROJECT_ID_ADMIN`, or `POSTHOG_PROJECT_ID_AGENT`) and run the HogQL block from this file verbatim through connector `query-run`. The routine prompt should reference the question by name in its `## PostHog usage` section and point to this file as the source of the HogQL.
+  ```
+  Run question `funnel.onboarding` (window 30d) via the PostHog connector's
+  query-run, using the HogQL block defined under that name in
+  docs/routines/posthog-questions.md. Privacy mode: public.
+  ```
+- **Local/Codex/non-Claude fallback only**: product/quality questions that match a script command (`errors.recent` → `errors`, `errors.detail` → `error-detail`, `errors.recurring` → `recurring`, `errors.match-bug-report` → `match-bug-report`, `replay.user-sessions` → `user-sessions`) may use `scripts/agents/posthog-query.ts` when the connector is unavailable and the local environment explicitly provides `POSTHOG_PROJECT_API_KEY`, single-project `POSTHOG_PROJECT_ID`, and `POSTHOG_HOST`.
+  ```bash
+  bun scripts/agents/posthog-query.ts errors --recent 24h --privacy public
+  bun scripts/agents/posthog-query.ts error-detail <error-hash> --window 7d
+  ```
+
+Reviewing a routine: any HogQL block must match a HogQL block in this file verbatim, or it's a `routine-self-audit` violation.
+
+## Privacy boundary
+
+> ⚠️ **Hard boundary — non-negotiable.** Applies to every question below and every consumer (routine, skill, agent), on every shared surface (Linear body, Discord, PR, doc). A question's `public-safe` default never overrides this table. When unsure, treat a field as private.
+
+The same boundary the bug-intake routine uses, applied to every consumer. Never violate this even when a question's default privacy is `public-safe`.
+
+| Field class | Allowed in shared surface (Linear body, Discord, PR, doc) | Private-only |
+|---|---|---|
+| Aggregate counts (sessions, users, events, conversions, %) | ✅ | |
+| Aggregate timestamps (first/last seen, cohort week) | ✅ | |
+| Error message (top line, redacted) | ✅ | |
+| Normalized top stack frame (no query strings, no path params) | ✅ | |
+| App surface (`client` / `admin`) | ✅ | |
+| PostHog error hash | ✅ | |
+| Garden address / name (when the surface is a per-garden routine that already discloses it) | ✅ | |
+| Replay URL | | ✅ |
+| Session ID | | ✅ |
+| Distinct ID | | ✅ |
+| Wallet / smart-account address | | ✅ |
+| User name / email / handle | | ✅ |
+| Reporter identifier (Discord username, Telegram handle) | | ✅ |
+| Full stack frames with paths/query strings | | ✅ |
+| IP, UA, geo | | ✅ |
+| Any field not explicitly above | | ✅ (default to private when unsure) |
+
+If a question's output would name a single user (one row per `distinct_id`), it is private-only by definition. Aggregations over ≥ 5 users are public-safe.
+
+---
+
+## Product/quality lens
+
+Private-default. The eight bug-intake / debug / release-health questions.
+
+### `errors.recent`
+
+- **Lens**: product-quality
+- **Default privacy**: public-safe (aggregate counts only)
+- **What it answers**: recent JS exceptions grouped by message + URL with affected-session counts.
+- **HogQL**:
+  ```sql
+  SELECT
+    cityHash64(toString(properties.$exception_message), toString(properties.$current_url)) AS error_hash,
+    properties.$exception_type AS exception_type,
+    properties.$exception_message AS message,
+    properties.$current_url AS current_url,
+    count(DISTINCT $session_id) AS affected_sessions,
+    count(DISTINCT distinct_id) AS affected_users,
+    min(timestamp) AS first_seen,
+    max(timestamp) AS last_seen
+  FROM events
+  WHERE event = '$exception' AND timestamp > now() - interval {window:String}
+  GROUP BY error_hash, exception_type, message, current_url
+  ORDER BY affected_sessions DESC
+  LIMIT 50
+  ```
+- **Bind variables**: `{ window: "24h" | "7d" | "30d" }` (default `24h`)
+- **Output schema**:
+  - `error_hash`, `exception_type`, `message`, `current_url` — public
+  - `affected_sessions`, `affected_users` — public
+  - `first_seen`, `last_seen` — public
+- **Required emit-side events**: `$exception` (PostHog auto-captures via `posthog.captureException`)
+- **Used by**: `bug-intake` (Phase 1 enrichment), `/debug`
+
+### `errors.detail`
+
+- **Lens**: product-quality
+- **Default privacy**: private-only (returns replay URLs and per-session rows)
+- **What it answers**: full detail for one error hash including a sample of the top stack frame plus per-session replay links.
+- **HogQL**:
+  ```sql
+  WITH matches AS (
+    SELECT *
+    FROM events
+    WHERE event = '$exception'
+      AND timestamp > now() - interval {window:String}
+      AND cityHash64(toString(properties.$exception_message), toString(properties.$current_url)) = {error_hash:UInt64}
+  )
+  SELECT
+    properties.$exception_type AS exception_type,
+    properties.$exception_message AS message,
+    properties.$current_url AS current_url,
+    count(DISTINCT $session_id) AS affected_sessions,
+    count(DISTINCT distinct_id) AS affected_users,
+    min(timestamp) AS first_seen,
+    max(timestamp) AS last_seen,
+    any(properties.$exception_stack_trace_raw) AS sample_stack,
+    arrayDistinct(groupArray(($session_id, distinct_id))) AS sessions
+  FROM matches
+  GROUP BY exception_type, message, current_url
+  ```
+- **Bind variables**: `{ window: "7d", error_hash: 12345 }`
+- **Output schema**:
+  - `exception_type`, `message`, `current_url`, `affected_sessions`, `affected_users`, `first_seen`, `last_seen` — public
+  - `sample_stack` (top frame only, normalized) — public
+  - `sessions[].session_id`, `sessions[].distinct_id`, `sessions[].replay_url` — private
+- **Required emit-side events**: `$exception`, `$session_id` autoassigned
+- **Used by**: `bug-intake` (Phase 1 enrichment), `/debug`
+
+### `errors.recurring`
+
+- **Lens**: product-quality
+- **Default privacy**: public-safe
+- **What it answers**: distinct-session count per error hash over a 30-day window — the input to bug-intake's recurring-pattern roll-up (≥50 sessions threshold).
+- **HogQL**:
+  ```sql
+  SELECT
+    cityHash64(toString(properties.$exception_message), toString(properties.$current_url)) AS error_hash,
+    properties.$exception_message AS message,
+    count(DISTINCT $session_id) AS sessions_30d,
+    count(DISTINCT distinct_id) AS users_30d,
+    min(timestamp) AS first_seen,
+    max(timestamp) AS last_seen
+  FROM events
+  WHERE event = '$exception' AND timestamp > toDateTime({since:String})
+  GROUP BY error_hash, message
+  HAVING sessions_30d >= {threshold:UInt32}
+  ORDER BY sessions_30d DESC
+  ```
+- **Bind variables**: `{ since: "2026-04-07", threshold: 50 }`
+- **Output schema**: all fields public.
+- **Required emit-side events**: `$exception`
+- **Used by**: `bug-intake` (Phase 4 recurring-pattern roll-up)
+
+### `errors.match-bug-report`
+
+- **Lens**: product-quality
+- **Default privacy**: private-only (matches may include single-user evidence)
+- **What it answers**: free-text fuzzy match between a verbatim bug-report quote and recent error messages or event names.
+- **HogQL**:
+  ```sql
+  SELECT
+    cityHash64(toString(properties.$exception_message), toString(properties.$current_url)) AS error_hash,
+    properties.$exception_message AS message,
+    properties.$current_url AS current_url,
+    count(DISTINCT $session_id) AS affected_sessions,
+    max(timestamp) AS last_seen,
+    positionUTF8(lower(properties.$exception_message), lower({snippet:String})) AS confidence_signal
+  FROM events
+  WHERE event = '$exception'
+    AND timestamp > now() - interval 14 day
+    AND positionUTF8(lower(properties.$exception_message), lower({snippet:String})) > 0
+  GROUP BY error_hash, message, current_url
+  ORDER BY affected_sessions DESC
+  LIMIT 20
+  ```
+- **Bind variables**: `{ snippet: "stack frame text" }`
+- **Output schema**:
+  - `error_hash`, `message`, `current_url`, `affected_sessions`, `last_seen`, `confidence_signal` — public
+- **Required emit-side events**: `$exception`
+- **Used by**: `bug-intake` (Drive Phase 3 fuzzy match), `/debug`
+
+### `replay.user-sessions`
+
+- **Lens**: product-quality
+- **Default privacy**: private-only (every field re-identifies a user)
+- **What it answers**: recent sessions for a known reporter (distinct ID or wallet) with replay links.
+- **HogQL**:
+  ```sql
+  SELECT
+    $session_id AS session_id,
+    distinct_id,
+    min(timestamp) AS session_start,
+    max(timestamp) AS session_end,
+    countIf(event = '$exception') AS errors_observed,
+    concat('{posthog_host}/replay/', toString($session_id)) AS replay_url
+  FROM events
+  WHERE timestamp > now() - interval {window:String}
+    AND (distinct_id = {user:String} OR properties.wallet_address = {user:String})
+  GROUP BY session_id, distinct_id
+  ORDER BY session_start DESC
+  LIMIT 25
+  ```
+- **Bind variables**: `{ window: "7d", user: "<distinct-id-or-wallet>" }`
+- **Output schema**: every field private. Never copy any of these into a shared surface.
+- **Required emit-side events**: any tracked event with `distinct_id`. `wallet_address` person property is set on identify.
+- **Used by**: `bug-intake` (Phase 1/2 reporter lookup, when consented), `/debug`
+
+### `release.error-rate-delta`
+
+- **Lens**: product-quality
+- **Default privacy**: public-safe
+- **What it answers**: error rate per 1k events for a 24h window before vs after a given deploy timestamp.
+- **HogQL**:
+  ```sql
+  WITH
+    {deploy_at:String} AS deploy_at,
+    toDateTime(deploy_at) - interval 24 hour AS before_start,
+    toDateTime(deploy_at) AS deploy_dt,
+    toDateTime(deploy_at) + interval 24 hour AS after_end
+  SELECT
+    sumIf(1, event = '$exception' AND timestamp >= before_start AND timestamp < deploy_dt) AS errors_before,
+    sumIf(1, timestamp >= before_start AND timestamp < deploy_dt) AS events_before,
+    sumIf(1, event = '$exception' AND timestamp >= deploy_dt AND timestamp < after_end) AS errors_after,
+    sumIf(1, timestamp >= deploy_dt AND timestamp < after_end) AS events_after,
+    if(events_before > 0, errors_before * 1000.0 / events_before, 0) AS rate_per_1k_before,
+    if(events_after > 0, errors_after * 1000.0 / events_after, 0) AS rate_per_1k_after,
+    rate_per_1k_after - rate_per_1k_before AS delta_per_1k
+  FROM events
+  WHERE timestamp >= before_start AND timestamp < after_end
+  ```
+- **Bind variables**: `{ deploy_at: "2026-05-07T12:00:00Z" }`
+- **Output schema**: every field public.
+- **Required emit-side events**: `$exception` plus any tracked event for the volume denominator.
+- **Used by**: deferred to follow-up `release-health` plan; documented here so the question is ready when needed.
+
+### `release.sync-success-rate-delta`
+
+- **Lens**: product-quality
+- **Default privacy**: public-safe
+- **What it answers**: offline-job success rate before vs after a deploy. Companion to `release.error-rate-delta` for the offline-first pipeline.
+- **HogQL**:
+  ```sql
+  WITH
+    {deploy_at:String} AS deploy_at,
+    toDateTime(deploy_at) - interval 24 hour AS before_start,
+    toDateTime(deploy_at) AS deploy_dt,
+    toDateTime(deploy_at) + interval 24 hour AS after_end
+  SELECT
+    countIf(event = 'offline_job_processed' AND timestamp >= before_start AND timestamp < deploy_dt) AS processed_before,
+    countIf(event IN ('offline_job_failed','offline_job_permanently_failed') AND timestamp >= before_start AND timestamp < deploy_dt) AS failed_before,
+    countIf(event = 'offline_job_processed' AND timestamp >= deploy_dt AND timestamp < after_end) AS processed_after,
+    countIf(event IN ('offline_job_failed','offline_job_permanently_failed') AND timestamp >= deploy_dt AND timestamp < after_end) AS failed_after,
+    if(processed_before + failed_before > 0, processed_before * 100.0 / (processed_before + failed_before), 0) AS success_pct_before,
+    if(processed_after + failed_after > 0, processed_after * 100.0 / (processed_after + failed_after), 0) AS success_pct_after,
+    success_pct_after - success_pct_before AS delta_pct
+  FROM events
+  WHERE timestamp >= before_start AND timestamp < after_end
+  ```
+- **Bind variables**: `{ deploy_at: "2026-05-07T12:00:00Z" }`
+- **Output schema**: every field public.
+- **Required emit-side events**: `offline_job_processed`, `offline_job_failed`, `offline_job_permanently_failed` (all present today, `packages/shared/src/modules/job-queue/job-analytics.ts`).
+- **Used by**: deferred to follow-up `release-health` plan.
+
+### `quality.top-failures`
+
+- **Lens**: product-quality
+- **Default privacy**: public-safe
+- **What it answers**: the top 10 errors in a window, ranked by affected-user count rather than session count (better signal for prioritization).
+- **HogQL**:
+  ```sql
+  SELECT
+    cityHash64(toString(properties.$exception_message), toString(properties.$current_url)) AS error_hash,
+    properties.$exception_type AS exception_type,
+    properties.$exception_message AS message,
+    properties.$current_url AS current_url,
+    count(DISTINCT distinct_id) AS affected_users,
+    count(DISTINCT $session_id) AS affected_sessions,
+    min(timestamp) AS first_seen,
+    max(timestamp) AS last_seen
+  FROM events
+  WHERE event = '$exception' AND timestamp > now() - interval {window:String}
+  GROUP BY error_hash, exception_type, message, current_url
+  ORDER BY affected_users DESC
+  LIMIT 10
+  ```
+- **Bind variables**: `{ window: "7d" }`
+- **Output schema**: every field public.
+- **Required emit-side events**: `$exception`
+- **Used by**: deferred (`health-watch` or a future release-health digest).
+
+---
+
+## Growth/BD lens
+
+Public-safe-default. Aggregates only — never names a single user.
+
+### `funnel.onboarding`
+
+- **Lens**: growth-bd
+- **Default privacy**: public-safe
+- **What it answers**: passkey register → garden join → first work submission funnel over a window.
+- **Identity stitching note**: PostHog assigns an anonymous UUID `distinct_id` on first page-load and switches it to the wallet/passkey-credential `distinct_id` after `posthog.identify()` in the auth flow. **Joins must be by `person_id`** (which stitches anonymous + identified IDs at the person level), not raw `distinct_id` — joining by `distinct_id` produces 0% conversion across the auth boundary even when conversions are happening. Verified empirically 2026-05-09 against the App project (163591): 7 person registers + 6 person joins in 30d, 0 overlap when joined by `distinct_id`; correct number when joined by `person_id`.
+- **HogQL**:
+  ```sql
+  WITH
+    register_users AS (
+      SELECT person_id, min(timestamp) AS register_at
+      FROM events
+      WHERE event = 'auth_passkey_register_success'
+        AND timestamp > now() - interval {window:String}
+      GROUP BY person_id
+    ),
+    join_users AS (
+      SELECT r.person_id, min(e.timestamp) AS join_at
+      FROM register_users r
+      JOIN events e ON e.person_id = r.person_id
+      WHERE e.event IN ('garden_join_success', 'garden_auto_join_success')
+        AND e.timestamp >= r.register_at
+      GROUP BY r.person_id
+    ),
+    first_work AS (
+      SELECT j.person_id, min(e.timestamp) AS first_work_at
+      FROM join_users j
+      JOIN events e ON e.person_id = j.person_id
+      WHERE e.event = 'work_submission_success'
+        AND e.timestamp >= j.join_at
+      GROUP BY j.person_id
+    )
+  SELECT
+    (SELECT count() FROM register_users) AS registered,
+    (SELECT count() FROM join_users) AS joined_garden,
+    (SELECT count() FROM first_work) AS submitted_first_work,
+    if((SELECT count() FROM register_users) > 0, (SELECT count() FROM join_users) * 100.0 / (SELECT count() FROM register_users), 0) AS register_to_join_pct,
+    if((SELECT count() FROM join_users) > 0, (SELECT count() FROM first_work) * 100.0 / (SELECT count() FROM join_users), 0) AS join_to_first_work_pct
+  ```
+- **Bind variables**: `{ window: "30d" }`
+- **Output schema**: every field public.
+- **Required emit-side events**: `auth_passkey_register_success`, `garden_join_success`, `garden_auto_join_success`, `work_submission_success` (all present today, `packages/shared/src/modules/app/analytics-events.ts`).
+- **Cohort caveat**: this funnel only tracks the new-user cohort within `{window}`. Returning users (registered before the window) who join gardens during the window are intentionally excluded — that's a different question. If `registered > 0` but `register_to_join_pct == 0`, verify by comparing to the raw `garden_join_success` count over the same window: a non-zero raw count with a zero funnel percentage usually means joiners are returning users from outside the window, not a product breakage.
+- **Used by**: `growth-pulse` (App project, id 163591).
+
+### `funnel.work-repeat`
+
+- **Lens**: growth-bd
+- **Default privacy**: public-safe
+- **What it answers**: of users whose first work submission was in the past 30 days, what percentage submitted a second work within 7 days?
+- **Identity stitching note**: same as `funnel.onboarding` — joins are by `person_id` so anonymous→identified transitions don't break the cohort.
+- **HogQL**:
+  ```sql
+  WITH first_subs AS (
+    SELECT person_id, min(timestamp) AS first_at
+    FROM events
+    WHERE event = 'work_submission_success'
+      AND timestamp > now() - interval 60 day
+    GROUP BY person_id
+    HAVING first_at > now() - interval 30 day
+  ),
+  repeat_subs AS (
+    SELECT f.person_id
+    FROM first_subs f
+    JOIN events e ON e.person_id = f.person_id
+    WHERE e.event = 'work_submission_success'
+      AND e.timestamp > f.first_at
+      AND e.timestamp <= f.first_at + interval 7 day
+    GROUP BY f.person_id
+  )
+  SELECT
+    (SELECT count() FROM first_subs) AS first_time_users,
+    (SELECT count() FROM repeat_subs) AS repeat_within_7d,
+    if((SELECT count() FROM first_subs) > 0, (SELECT count() FROM repeat_subs) * 100.0 / (SELECT count() FROM first_subs), 0) AS repeat_pct
+  ```
+- **Bind variables**: none (window is fixed at 30d / 7d to keep the metric stable across runs).
+- **Output schema**: every field public.
+- **Required emit-side events**: `work_submission_success`.
+- **Used by**: `growth-pulse` (App project, id 163591).
+
+### `retention.curve`
+
+- **Lens**: growth-bd
+- **Default privacy**: public-safe
+- **What it answers**: D1 / D7 / D30 retention by weekly cohort — what percentage of users from cohort week W returned in the N-day window after their first session?
+- **HogQL**:
+  ```sql
+  WITH first_seen AS (
+    SELECT distinct_id, min(toDate(timestamp)) AS first_day
+    FROM events
+    WHERE timestamp > now() - interval 60 day
+    GROUP BY distinct_id
+  ),
+  cohorts AS (
+    SELECT
+      toMonday(first_day) AS cohort_week,
+      distinct_id,
+      first_day
+    FROM first_seen
+  )
+  SELECT
+    c.cohort_week,
+    count(DISTINCT c.distinct_id) AS cohort_size,
+    countDistinctIf(c.distinct_id, e_d1.distinct_id != '') AS returned_d1,
+    countDistinctIf(c.distinct_id, e_d7.distinct_id != '') AS returned_d7,
+    countDistinctIf(c.distinct_id, e_d30.distinct_id != '') AS returned_d30
+  FROM cohorts c
+  LEFT JOIN events e_d1 ON e_d1.distinct_id = c.distinct_id
+    AND toDate(e_d1.timestamp) > c.first_day AND toDate(e_d1.timestamp) <= c.first_day + 1
+  LEFT JOIN events e_d7 ON e_d7.distinct_id = c.distinct_id
+    AND toDate(e_d7.timestamp) > c.first_day AND toDate(e_d7.timestamp) <= c.first_day + 7
+  LEFT JOIN events e_d30 ON e_d30.distinct_id = c.distinct_id
+    AND toDate(e_d30.timestamp) > c.first_day AND toDate(e_d30.timestamp) <= c.first_day + 30
+  GROUP BY c.cohort_week
+  ORDER BY c.cohort_week DESC
+  LIMIT 8
+  ```
+- **Bind variables**: none.
+- **Output schema**: every field public. (HogQL above is a sketch — promote to Saved Insight when tuning is needed; PostHog has a native retention insight that may be cleaner.)
+- **Required emit-side events**: any tracked event with `distinct_id`.
+- **Used by**: deferred (follow-up routines / dashboards).
+
+### `gardens.engagement-summary`
+
+- **Lens**: growth-bd
+- **Default privacy**: public-safe (per-garden numbers; garden addresses are already public on-chain)
+- **What it answers**: per-garden 7-day active members + 7-day work submitted.
+- **HogQL**:
+  ```sql
+  SELECT
+    properties.garden_address AS garden_address,
+    properties.garden_name AS garden_name,
+    count(DISTINCT distinct_id) AS active_members_7d,
+    countIf(event = 'work_submission_success') AS work_submitted_7d,
+    countIf(event = 'work_approval_success') AS work_approved_7d
+  FROM events
+  WHERE timestamp > now() - interval 7 day
+    AND properties.garden_address IS NOT NULL
+    AND event IN ('work_submission_success', 'work_approval_success', 'garden_join_success', 'garden_auto_join_success')
+  GROUP BY garden_address, garden_name
+  ORDER BY work_submitted_7d DESC
+  ```
+- **Bind variables**: none.
+- **Output schema**:
+  - `garden_address`, `garden_name`, `active_members_7d`, `work_submitted_7d`, `work_approved_7d` — public
+- **Required emit-side events**: `work_submission_success`, `work_approval_success`, `garden_join_success`, `garden_auto_join_success` (all present; all carry `garden_address`).
+- **Used by**: `growth-pulse` (App project, id 163591).
+
+### `gardens.dormant`
+
+- **Lens**: growth-bd
+- **Default privacy**: public-safe
+- **What it answers**: gardens with zero work submitted in the last 7 / 14 / 30 days. Drives the `#498` dormancy signal and Season-One health awareness.
+- **HogQL**:
+  ```sql
+  WITH known_gardens AS (
+    SELECT DISTINCT properties.garden_address AS garden_address, properties.garden_name AS garden_name
+    FROM events
+    WHERE event = 'admin_garden_create_success' OR event IN ('garden_join_success', 'garden_auto_join_success')
+  ),
+  recent_work AS (
+    SELECT
+      properties.garden_address AS garden_address,
+      max(timestamp) AS last_work_at
+    FROM events
+    WHERE event = 'work_submission_success'
+    GROUP BY garden_address
+  )
+  SELECT
+    g.garden_address,
+    g.garden_name,
+    coalesce(toString(rw.last_work_at), 'never') AS last_work_at,
+    if(rw.last_work_at IS NULL OR rw.last_work_at < now() - interval 30 day, '30d+',
+       if(rw.last_work_at < now() - interval 14 day, '14d+',
+          if(rw.last_work_at < now() - interval 7 day, '7d+', 'active'))) AS dormancy_band
+  FROM known_gardens g
+  LEFT JOIN recent_work rw ON rw.garden_address = g.garden_address
+  WHERE dormancy_band != 'active'
+  ORDER BY dormancy_band DESC, last_work_at ASC
+  ```
+- **Bind variables**: none.
+- **Output schema**: all public.
+- **Required emit-side events**: `admin_garden_create_success`, `garden_join_success`, `garden_auto_join_success`, `work_submission_success`.
+- **Used by**: `growth-pulse` (App project, id 163591).
+
+### `gardens.operator-activity`
+
+- **Lens**: growth-bd
+- **Default privacy**: public-safe (counts), private-only (operator wallet/address)
+- **What it answers**: work approvals per operator per week, surfaced as `gardens × operator-count × approvals` aggregates without naming the operator.
+- **HogQL**:
+  ```sql
+  SELECT
+    properties.garden_address AS garden_address,
+    count(DISTINCT distinct_id) AS active_operators_7d,
+    countIf(event = 'work_approval_success') AS approvals_7d,
+    countIf(event = 'work_rejection_success') AS rejections_7d
+  FROM events
+  WHERE timestamp > now() - interval 7 day
+    AND event IN ('work_approval_success', 'work_rejection_success')
+  GROUP BY garden_address
+  ORDER BY approvals_7d DESC
+  ```
+- **Bind variables**: none.
+- **Output schema**: all public. (Per-operator detail must be queried with `replay.user-sessions` and stays private.)
+- **Required emit-side events**: `work_approval_success`, `work_rejection_success`.
+- **Used by**: `growth-pulse` (App project, id 163591).
+
+### `actions.template-creation-rate`
+
+> 🚫 **BLOCKED (2026-05-24)** — do not consume. Its required event `admin_action_create_success` is defined at `packages/shared/src/modules/app/analytics-events.ts:111` but has **no tracker factory and no call site** (the entire `admin_action_*` constant family is orphaned), so it has never fired and the HogQL returns zero forever. Consumers (e.g. `growth-pulse`) must **not** run this question or fire an "action template stall" threshold from it. Unblock by either wiring `trackAdminActionCreateSuccess` (a `createTracker` factory) + calling it in `packages/admin/src/views/Actions/CreateAction.tsx`, **or** repointing the signal at the Envio indexer `Action` entity (`createdAt`), the on-chain source of truth. `growth-pulse` uses the indexer substitute as of 2026-W21.
+
+- **Lens**: growth-bd
+- **Default privacy**: public-safe
+- **What it answers**: action-template creation rate over time — the signal behind `#473` (zero new action templates in 23 days).
+- **HogQL**:
+  ```sql
+  SELECT
+    toMonday(toDate(timestamp)) AS week,
+    count() AS templates_created
+  FROM events
+  WHERE event = 'admin_action_create_success'
+    AND timestamp > now() - interval 12 week
+  GROUP BY week
+  ORDER BY week DESC
+  ```
+- **Bind variables**: none.
+- **Output schema**: all public.
+- **Required emit-side events**: `admin_action_create_success`.
+- **Used by**: `growth-pulse` (Admin project, id 262122).
+
+### `failures.conversion-kill`
+
+- **Lens**: growth-bd
+- **Default privacy**: public-safe
+- **What it answers**: per-step failure rate for the conversion-killing events (`*_failed` paired with `*_success`). Surfaces product breakages that vanish from a success-only funnel. Empirically (2026-05-09, App project) the strongest growth signal in the dataset: `garden_join` ~75% failure rate, `work_submission` ~70%, `work_approval` 100% (zero successes), `auth_passkey_register` ~27%.
+- **HogQL**:
+  ```sql
+  SELECT
+    multiIf(
+      event LIKE 'garden_join_%', 'garden_join',
+      event LIKE 'work_submission_%', 'work_submission',
+      event LIKE 'work_approval_%', 'work_approval',
+      event LIKE 'auth_passkey_register_%', 'auth_passkey_register',
+      NULL
+    ) AS step,
+    countIf(event LIKE '%_success') AS success_count,
+    countIf(event LIKE '%_failed') AS failed_count,
+    countIf(event LIKE '%_success' OR event LIKE '%_failed') AS total_attempts,
+    if(
+      countIf(event LIKE '%_success' OR event LIKE '%_failed') > 0,
+      countIf(event LIKE '%_failed') * 100.0 / countIf(event LIKE '%_success' OR event LIKE '%_failed'),
+      0
+    ) AS failure_pct
+  FROM events
+  WHERE timestamp > now() - interval {window:String}
+    AND event IN (
+      'garden_join_success', 'garden_join_failed',
+      'work_submission_success', 'work_submission_failed',
+      'work_approval_success', 'work_approval_failed',
+      'auth_passkey_register_success', 'auth_passkey_register_failed'
+    )
+  GROUP BY step
+  HAVING step IS NOT NULL
+  ORDER BY failure_pct DESC
+  ```
+- **Bind variables**: `{ window: "7d" }` (default; `30d` for monthly digest, `1d` for hot triage).
+- **Output schema**: every field public.
+- **Required emit-side events**: the four `*_started/_success/_failed` event triplets above (all present in `packages/shared/src/modules/app/analytics-events.ts`). Note that `work_approval_success` may live primarily on the Admin project (262122) — when this question runs against the App project, `work_approval` will report 100% failure even when admin successes exist. Run the query separately against project 262122 for the admin-side success counts and merge in the routine.
+- **Anomaly thresholds (consumer)**: failure rate > 50% AND absolute failed count ≥ 5 over the window → file a Linear anomaly Issue. 100% failure with absolute count ≥ 5 → P2/urgent. The thresholds catch real product breakage rather than tiny-N noise.
+- **Used by**: `growth-pulse` (anomaly detection, replaces sole reliance on `funnel.onboarding`).
+
+### `web.acquisition-summary`
+
+- **Lens**: growth-bd
+- **Default privacy**: public-safe
+- **What it answers**: sessions by source/UTM medium in the last window — for grant impact narratives and BD reporting.
+- **HogQL**:
+  ```sql
+  SELECT
+    coalesce(properties.utm_source, properties.$initial_referrer_host, 'direct') AS source,
+    coalesce(properties.utm_medium, '') AS medium,
+    count(DISTINCT $session_id) AS sessions,
+    count(DISTINCT distinct_id) AS users
+  FROM events
+  WHERE event = '$pageview'
+    AND timestamp > now() - interval {window:String}
+  GROUP BY source, medium
+  ORDER BY sessions DESC
+  LIMIT 25
+  ```
+- **Bind variables**: `{ window: "30d" }`
+- **Output schema**: all public.
+- **Required emit-side events**: `$pageview` (PostHog auto-captures).
+- **Used by**: deferred (`guild-grant-scout` follow-up).
+
+---
+
+## Blocked / pending emit-side coverage
+
+The following questions would expand coverage but require events that don't exist yet. Listed here so a future emit-side plan can pick them up:
+
+- `funnel.invite-acceptance` — needs `garden_invite_sent` and `garden_invite_accepted`. The current `garden_join_success` and `garden_auto_join_success` events fire after the invite link is followed, but the invite-creation step itself isn't tracked. Add via `createTracker<T>` in `packages/shared/src/modules/app/analytics-events.ts` if invitation conversion becomes a key metric.
+- `funnel.first-work-from-invite` — depends on the same invitation events plus a stable `first_work` derivation. The derivation is computable from `work_submission_success` (`min(timestamp) per distinct_id`), so no new event is strictly required, but a `first_work_submitted` event would let cohort joins be cheaper.
+
+Do not write a question for these until the underlying events ship. **Consuming** (running the HogQL of) a `blocked` question from a routine is a `routine-self-audit` violation; **documenting** a question's blocked/deprecated status in routine prose (as `growth-pulse` now does for `actions.template-creation-rate`) is expected and not a violation.
+
+**Blocked in place (written, but the required event never fires):**
+
+- `actions.template-creation-rate` — depends on `admin_action_create_success`, which is defined but unwired (no tracker, no call site; the whole `admin_action_*` family is orphaned constants). Marked 🚫 BLOCKED in its entry above (2026-05-24). Wire the event (`trackAdminActionCreateSuccess` + a call in `CreateAction.tsx`) or repoint the question at the indexer `Action` entity before any consumer uses it again.
+
+## Routine integration checklist
+
+A routine wiring this library should:
+
+1. List the question names it consumes in a `## PostHog usage` section near the top of its prompt.
+2. State each connector call with the named question, project env var, bind variables, and privacy mode, e.g. `funnel.onboarding` on `POSTHOG_PROJECT_ID_APP` with `{ window: "30d" }`, privacy `public`.
+3. Map output fields to the routine's Discord post / Linear body / Drive doc, **only** using fields marked public in the question's output schema (or pass `privacy: "public"` to the call).
+4. State a fail-soft behavior: if the question returns an error or no data, log it in the routine's failure block and continue rather than aborting the run.
+5. Never inline raw HogQL; never invent a question name not in this file. Both are `routine-self-audit` violations once Phase 3 lands.
+
+## Anti-Patterns
+
+- Inlining raw HogQL in routine prompts when a named question already exists.
+- Adding a routine-specific PostHog query outside this file instead of promoting it to a named question first.
+- Sharing replay URLs, session IDs, distinct IDs, wallet addresses, reporter identifiers, or full stack/query-string details in public surfaces.
+- Treating aspirational `posthog.run_question(...)` examples as callable runtime until the wrapper actually exists.
+- Marking a question public-safe when it returns one row per user or any single-user evidence.
+
+## Related Skills
+
+- `debug` uses product-quality questions for bug investigation and reporter/session lookup.
+- Routine setup, cloud-run configuration, and automation wiring live in [`docs/routines/README.md`](../../../docs/routines/README.md).
+- `plan` owns follow-up implementation planning when a new question needs emit-side events or a wrapper script.
+
+## Versioning
+
+Bump the file's `version:` in front matter when:
+
+- Adding or removing a question (consumers may break).
+- Changing a question's HogQL in a way that alters the output schema (consumers must re-validate).
+- Changing the privacy boundary (consumers must re-audit their public surfaces).
+
+Pure HogQL refactors that preserve the output schema do not need a bump but should record a one-line note in the routine self-audit log.

--- a/docs/routines/qa-triage-pulse.md
+++ b/docs/routines/qa-triage-pulse.md
@@ -18,7 +18,7 @@ connectors:
   - linear        # Customer Need + Backlog tracking-Issue pre-staging only
   - posthog       # per-surface telemetry cross-reference
   - vercel        # deploy correlation for PostHog-matched items (gated on first_seen)
-model: claude-opus-4-8[1m]
+model: claude-opus-5
 allow-unrestricted-branch-pushes: false  # Customer Needs only; no PRs, no Sheet writes, no GitHub Issues
 last_updated: "2026-06-10"
 last_verified: "2026-05-13"
@@ -28,6 +28,8 @@ last_verified: "2026-05-13"
 
 You are the **qa-triage-pulse** routine for Green Goods. The Build Sync (renamed from Product Sync, June 2026) runs Wednesdays at 10am PST, lasts at most 2 hours, and produces a Gemini-generated `.md` in the team Drive. Your job is to fetch those notes after each sync, extract the bugs/ideas/feedback discussed, cross-reference each against PostHog telemetry, and **pre-stage** them as Linear Customer Need + Backlog tracking-Issue pairs so the interactive [`/qa-triage`](../../.claude/skills/qa-triage/SKILL.md) skill can resume from there without re-extracting.
 
+**Engineering Sync extension (2026-07-18):** the biweekly **Engineering Sync** (Tuesdays ~09:30 PT, alternating weeks) also surfaces bugs, defects, and ideas worth triage. After processing the Build Sync notes, ALSO query Drive for `title contains 'Engineering Sync'` notes modified in the last 7 days. When one exists (on-weeks), run the same extract → PostHog cross-reference → pre-stage pipeline on it, labeling its records `qa-sync:<that meeting's date>`; when none exists (off-weeks), skip silently — never treat the absence as a failure. Dedupe across both sources within the run: an item raised in both syncs pre-stages once, citing both notes.
+
 You do NOT create Todo Issues, append rows to the QA Sheet, push code, open PRs, or create GitHub Issues. The only Issues this routine may create are Backlog tracking Issues required by Linear's Customer Need API. Promotion to Todo, assignee selection, severity, and Sheet writes require human judgment in `/qa-triage`. Your sole role is pre-stage Customer Need + Backlog tracking-Issue pairs → post Discord summary → exit.
 
 This routine is the **async sibling** of `/qa-triage`. The skill's Phase 1 step 0 detects pre-staged tracking Issues (labels `source:qa-triage-pulse` + `qa-sync:<YYYY-MM-DD>`) and their linked Customer Needs, then offers to resume from them instead of re-running the discover/extract phases. That cuts the user's interactive triage to ~5 minutes after the sync.
@@ -36,7 +38,7 @@ This routine is the **async sibling** of `/qa-triage`. The skill's Phase 1 step 
 
 - All env vars are loaded; do not read `.env`.
 - `DISCORD_USER_ID_AFO` is Afo's Discord snowflake ID. Use `<@${DISCORD_USER_ID_AFO}>` to @mention.
-- `DISCORD_PRODUCT_CHANNEL_ID` is the `#product` channel where this routine's daily summary posts.
+- `DISCORD_PRODUCT_CHANNEL_ID` is the `#product` channel where this routine's Phase 6 summary posts.
 - Google Drive connector is available for reading shared documents.
 - Linear connector is available — resolve team/label/status IDs by name at run-start; never hardcode.
 - PostHog connector is available — three projects (App `163591`, Admin `262122`, Agent `262124` — Agent unused here).
@@ -68,7 +70,7 @@ Linear's `save_customer_need` API surface accepts `body`, `customer`, `issue`, `
 
 ## PostHog enrichment
 
-Use the curated questions from [`.claude/skills/posthog-questions/SKILL.md`](../../.claude/skills/posthog-questions/SKILL.md). Same privacy boundary as `bug-intake`. Switch to the matching project per item before each query:
+Use the curated questions from [`posthog-questions.md`](./posthog-questions.md). Same privacy boundary as `bug-intake`. Switch to the matching project per item before each query:
 
 - `errors.match-bug-report` with the verbatim quote as `snippet`
 - `errors.recurring` over 30 days for the ≥50-session pattern signal
@@ -89,7 +91,7 @@ Only safe-summary fields cross into the Customer Need body. Replay URLs, session
    (name contains 'Build Sync' or name contains 'Product Sync') and name contains 'Notes by Gemini' and modifiedTime > '<6h-ago RFC3339>' and mimeType = 'application/vnd.google-apps.document'
    ```
 
-   The legacy 'Product Sync' clause covers the meeting's pre-June-2026 name (a straggling calendar title still produces old-name notes); drop it once it stops matching. The 6-hour window starts at routine-fire time and reaches back through the sync window. If zero matches, the sync didn't happen or notes haven't landed — post the silent-week summary (Phase 6) and exit cleanly. Do not fail loud; not every Wednesday has a sync.
+   The legacy 'Product Sync' clause covers the meeting's pre-June-2026 name (a straggling calendar title still produces old-name notes); drop it once it stops matching. The 6-hour window starts at routine-fire time and reaches back through the sync window. If zero matches, the sync didn't happen or notes haven't landed — post the Phase 6 one-line no-sync note and exit cleanly. Do not fail loud; not every Wednesday has a sync.
 
 2. **Multi-match handling**: if >1 candidate (rare — separate "Build Sync — Engineering" vs "Build Sync — Growth"), pick the newest. Surface the alternates in the Discord summary so the user knows.
 
@@ -148,7 +150,7 @@ For each extracted item:
 Linear requires every Customer Need to link to an Issue. For each non-duplicate item:
 
 1. **First, create the Backlog tracking Issue** on the Product team. Title: prefix with `[tracking]`, then use an action-verb-led one-line distillation (e.g., "[tracking] Investigate PWA install hang on Android" rather than "Install hangs"). Body: Summary + Surface + Suggested fix + Source + safe evidence — no Reproduction/Expected/Actual sections at this routine stage.
-   - Labels: `protocol:green-goods` + ONE `package:*` (primary surface; omit if unknown) + `activity:qa` (clear bug) or `activity:maintenance` (idea / polish / unclear actionability) + `source:drive` + `source:qa-triage-pulse` + `ai:routine` + `qa-sync:<YYYY-MM-DD>`.
+   - Labels: `protocol:green-goods` + ONE `package:*` (primary surface; omit if unknown) + `activity:qa` (clear bug) or `activity:maintenance` (idea / polish / unclear actionability) + `source:drive` + `source:qa-triage-pulse` + `ai:routine` + `qa-sync:<YYYY-MM-DD>`. Pass labels to `save_issue` as **bare child names** (`["green-goods", "qa", "routine"]`), not the `group:child` display form: the API does not accept the prefixed form, and one unresolvable entry rejects the whole array and files nothing.
    - Status: `Backlog` for all. The routine never claims work as `Todo`; the interactive `/qa-triage` skill promotes selected tracking Issues to `Todo` during the human triage gate.
    - Priority: P3 (Low) by default. P2 (Medium) when PostHog confirms ≥50 sessions in 30d. The routine never sets P0/P1 — humans decide release-blocker status.
 
@@ -175,32 +177,30 @@ Before posting, grep every Customer Need body created this run for `replay`, `se
 
 ## Phase 6: Discord summary to #product
 
-Post one summary message to `#product` (`DISCORD_PRODUCT_CHANNEL_ID`):
+**House style v2** (see [`routines/claude/README.md` in `.github`](https://github.com/greenpill-dev-guild/.github/blob/main/routines/claude/README.md#house-style-v2-applies-to-every-posting-routine)): ONE message, lede first, items over counts. Post to `#product` (`DISCORD_PRODUCT_CHANNEL_ID`):
 
 ```
-{if N >= 1 OR any_failure: "<@${DISCORD_USER_ID_AFO}> "}**QA Sync Pre-Stage — <meeting-title> · <YYYY-MM-DD>**
+{if N >= 1 OR any_failure: "<@${DISCORD_USER_ID_AFO}> "}**📋 QA Sync · {meeting-title} · {YYYY-MM-DD}**
 
-📋 Pre-staged {N} Customer Needs from the Build Sync
-🔗 Drive doc: <drive-url>
-🏷️ Linear label: `qa-sync:<YYYY-MM-DD>`
+{Lede: 1–2 sentences a teammate would write — what the sync surfaced and whether anything is urgent. e.g. "Six items from today's Build Sync, two matching live telemetry — the Android install hang is the one to look at first."}
 
-Surface breakdown:
-• Public Website: {n}
-• PWA iOS: {n}
-• PWA Android: {n}
-• Admin Dashboard: {n}
-• Cross Surface: {n}
-• Docs: {n}
+{Top items — up to 3, the most notable by telemetry match or severity, each one line:}
+- **{one-line item}** · {surface}{ · matches telemetry: {n} sessions/7d} → <{linear-url}>
 
-PostHog matches: {n}/{N} items matched recent telemetry
-Deduplicated: {n} items merged into existing Customer Needs
+{if N > 3: "…plus {N−3} more, all pre-staged under `qa-sync:<YYYY-MM-DD>`."}
+{if dedup_n >= 1: "{dedup_n} item(s) merged into existing Customer Needs."}
 
-{if N >= 1: "Ready for triage — run `/qa-triage qa-sync:<YYYY-MM-DD>` to promote these into Issues + QA-sheet rows."}
-
-{if any_failure: "⚠ Failures this run: {short list}"}
+Ready for triage → run `/qa-triage qa-sync:<YYYY-MM-DD>` · notes: <drive-url>
+{if any_failure: "⚠ {short failure list}"}
 ```
 
-@mention only when there's something to act on (≥1 Customer Need created) OR a setup failure needs attention. Silent weeks (0 notes found OR 0 new items) post the structured summary without the @mention.
+Counts by surface, PostHog match tallies, and other run telemetry stay OUT of the post — they're visible in Linear via the `qa-sync:*` label. @mention only when there's something to act on (≥1 Customer Need created) OR a setup failure needs attention.
+
+**No-sync day (0 notes found) or 0 new items: post exactly one line, no mention** — never the full skeleton:
+
+```
+📋 QA sync · {YYYY-MM-DD}: {no sync notes found today · nothing to pre-stage | notes read, nothing new to pre-stage ({dedup_n} already tracked)}.
+```
 
 The summary is **public**. Replay URLs, session IDs, distinct IDs, wallet/user identifiers, and reporter identifiers must not appear here — same privacy boundary as `bug-intake`'s Discord summary.
 

--- a/docs/routines/release-prep.md
+++ b/docs/routines/release-prep.md
@@ -1,7 +1,7 @@
 ---
 routine-name: release-prep
 trigger:
-  schedule: "0 16 1 * *" # 1st of each month @ 16:00 UTC = 08:00 PST / 09:00 PDT. Fires at the start of the month to open the beginning-of-month release. Edit via /schedule if the cadence changes.
+  schedule: "0 16 * * 1-5" # weekdays 16:00 UTC (= 08:00 PST / 09:00 PDT), self-gating: most runs are a cheap window check that exits quietly; the full brief posts when today is within 3 days of the release target (see Phase 0). Daily checks are what make "3 days before" land precisely even when the target date moves.
 max-duration: 30m
 repos:
   - green-goods
@@ -13,7 +13,8 @@ env-vars:
   - DISCORD_USER_ID_AFO
 connectors:
   - github # read-only: open PRs, commit range, existing releases/tags
-model: claude-opus-4-8[1m]
+  - linear # read-only: the active release project's targetDate drives the Phase 0 gate
+model: claude-opus-5
 allow-unrestricted-branch-pushes: false # read + draft only; no commits, no PRs, no tags
 last_updated: "2026-06-23"
 ---
@@ -31,22 +32,37 @@ It **reads and drafts only**. It never cuts the release, opens PRs, or tags anyt
 
 ## What it produces
 
-A single Discord brief containing:
+A Discord brief (max two messages — see Phase 7's budget) containing:
 
-- a summary of everything unreleased on `develop`, grouped by change type;
-- draft release notes and the version to bump to;
+- a one-line per-type summary of everything unreleased on `develop`;
+- draft release notes (highlights) and the version to bump to;
 - a doc-freshness + risk scan (contracts / auth / migrations that need extra QA);
-- a draft, plain-language announcement for gardeners.
+- a draft, plain-language announcement for gardeners;
+
+with the full commit enumeration linked as the live GitHub compare view rather than pasted into Discord.
 
 ## Cadence
 
-Runs on the **1st of each month** (`0 16 1 * *`, 08:00 PST), so the brief is waiting when you sit down to cut the beginning-of-month release. The day is pinned to the 1st rather than a weekday so it never drifts; if a release slips, the brief simply reflects the larger range. Adjust with `/schedule` if the release day moves.
+Runs **every weekday (16:00 UTC)** but is **self-gating**: most runs are a one-query window check that exits quietly, and the full brief posts **3 days before the release** — the first weekday run where today ≥ target − 3 days. Releases follow the Linear release project's target date, not the calendar (v1.2.0 shipped July 8; v1.3.0 targets Aug 12), so a fixed monthly fire was either early or stale, and a weekly fire could land on release day itself; the daily check is what makes "3 days before" land precisely even when the target moves. A **manual run always produces the brief**, whatever the window says — that is the "I'm cutting it now, brief me" button.
 
 ---
 
 # Prompt
 
-You are the **release-prep** routine for Green Goods. On the 1st of each month you produce a single **release-readiness brief** so the maintainer can cut a clean monthly release. You **read and draft only** — never commit, open PRs, or create tags.
+You are the **release-prep** routine for Green Goods. You produce a single **release-readiness brief** so the maintainer can cut a clean release. You **read and draft only** — never commit, open PRs, or create tags.
+
+## Phase 0 — Release-window gate (run this first)
+
+Decide whether this run produces the full brief or exits quietly:
+
+1. **Resolve the active release container from Linear**: the started Product-team project whose name matches `Green Goods v{X.Y.Z} QA & Release` (currently *Green Goods v1.3.0 QA & Release*); read its `targetDate`. Fallback when no such project exists: the latest release tag date + the size of `origin/main..origin/develop` (a large unreleased range with no tracking project is itself worth flagging).
+2. **Produce the full brief when ANY of:**
+   - today ≥ `targetDate − 3 days` (the release window is open — the brief lands 3 days out);
+   - this is a **manual run** (a human hit Run — always brief);
+   - the `targetDate` moved since the last posted brief (post a short delta note: old date → new date, what changed in the range);
+   - it is **Monday** AND no release project exists AND `origin/main..origin/develop` exceeds ~60 commits (cadence quietly slipping — checked weekly, not daily, so it never nags).
+3. **Otherwise exit quietly**: log `release window not open (target {date}), skipping` and post nothing.
+4. **Idempotency inside an open window (this runs daily — do not re-brief daily):** the brief posts ONCE when the window opens. After that, repost only when the `targetDate` moved, or when `develop` HEAD moved AND it has been ≥48h since the last brief (mark it *updated*). A same-state daily run inside the window logs `brief current, skipping` and exits.
 
 ## Setup
 
@@ -63,9 +79,9 @@ Run `git log origin/main..origin/develop` (the range that will ship). Group comm
 
 Produce a developer-facing draft for `vX.Y.0`, grouped by type (this approximates what `gh release create --generate-notes` will emit on tag push). Include the would-be title `"<Month Year> — vX.Y.0"`.
 
-## Phase 3 — Version-bump reminder
+## Phase 3 — Version and security-policy reminder
 
-State the command `bun run version:bump X.Y.0` (touches the seven `package.json` files) and that the tag is created on the **merged-main HEAD**, never before merge.
+State the commands `bun run version:bump X.Y.0` and `bun run version:check X.Y.0`. The bump updates the seven `package.json` files plus the supported release in `SECURITY.md`; the check must pass before tagging. The tag is created on the **merged-main HEAD**, never before merge.
 
 ## Phase 4 — Doc-freshness scan
 
@@ -84,7 +100,13 @@ Write 3-5 plain-language lines announcing the release. **Self-check the prose ag
 
 ## Phase 7 — Post and exit
 
-Post one brief to `DISCORD_ENGINEERING_CHANNEL_ID`. @mention `DISCORD_USER_ID_AFO` only when a Phase 5 risk needs a decision or a setup step failed. Keep the privacy boundary (no session IDs, replay URLs, wallet addresses, or reporter identifiers). Never commit, open PRs, or create tags.
+Post the brief to `DISCORD_ENGINEERING_CHANNEL_ID` with a **message budget of at most TWO Discord messages** (the stated house-style-v2 exception — every other routine gets one; see [`routines/claude/README.md` in `.github`](https://github.com/greenpill-dev-guild/.github/blob/main/routines/claude/README.md#house-style-v2-applies-to-every-posting-routine)). Structure:
+
+- **Message 1 — the decision surface**: a 1–2 sentence lede (what's shipping and when), the version + bump/check commands, per-type commit counts on ONE line (`{N} commits · {a} feat / {b} fix / {c} chore …`), the Phase 5 risk flags (these are why a human reads the brief), and the Phase 4 doc-freshness flags.
+- **Message 2 — the copy**: the draft release notes (highlights, not the full commit enumeration) and the 3–5 line gardener announcement.
+- **The full commit enumeration never goes to Discord**: Message 1 links the live GitHub compare view (`https://github.com/greenpill-dev-guild/green-goods/compare/{last-tag}...develop`, wrapped in `<>`), which IS the complete, always-current commit list. The routine stays read-only everywhere (no Linear writes, no GitHub writes) — the budget is met by linking, not by relocating content.
+
+@mention `DISCORD_USER_ID_AFO` only when a Phase 5 risk needs a decision or a setup step failed. Keep the privacy boundary (no session IDs, replay URLs, wallet addresses, or reporter identifiers). Never commit, open PRs, or create tags.
 
 ## Anti-patterns
 


### PR DESCRIPTION
**Mirror of the develop PR onto `main`, which the live bug-intake / health-watch / growth-pulse / qa-triage wrappers actually read** — without this, the changes (and the #641/#664/#666 improvements stranded on develop since mid-July: Opus 5 models, OAuth-only Linear, the growth-pulse unchanged-week fold, health-watch cadence text, the qa-triage Engineering Sync extension, and `docs/routines/posthog-questions.md`) never reach the running routines. Same dual-PR pattern as #553/#554.

`docs/routines/` only — no code paths. After both PRs merge, these files are byte-identical on develop and main, so the next release promote is clean. `main`'s legacy `.claude/skills/posthog-questions/SKILL.md` copy is left in place (its removal is part of develop's #660 skills consolidation and promotes with the release); the specs now reference the `docs/routines/` copy.

Part of the 2026-07-30 quiet-Discord routine revamp (pairs with greenpill-dev-guild/.github#54, which defines house style v2: one message per post, a conversational lede, one-line all-clears on quiet runs).

**What changes for each routine's Discord surface:**

- **bug-intake** — standalone per-capture ack messages retired (they were up to 8 messages/run; the biggest single noise source at ~9-15 msgs/week). Discord-source reporters keep the in-thread `Tracked ->` reply + ✅ reaction on their own message; Telegram/Drive captures surface as item lines in the digest. The digest itself becomes item-led (lede + up to 3 notable items) and posts only when something was captured; a quiet run is one line.
- **health-watch** — an all-green run posts exactly one line; the per-check breakdown appears only when a check is non-green or state changed (new/updated Issue, recovery). Mention rules unchanged (red only).
- **growth-pulse** — the #growth post becomes a lede (what the week means) + only the metrics that moved (max 3 bullets) + watch/anomaly lines + the full-digest link; a steady week is one line. The full tables stay in the Linear initiative status update, unchanged.
- **qa-triage-pulse** — item-led summary with a lede and a `/qa-triage` CTA; the always-on 6-line surface-breakdown count block is dropped; a no-sync Wednesday is one line instead of a skeleton.
- **release-prep** — two-message budget (decision surface + copy); the full commit enumeration is linked as the live GitHub compare view instead of pasted into Discord.
- **README** — channel map and portfolio rows updated; house style v2 pointer.

Net effect across the portfolio: roughly 18-25 routine messages/week drops to ~8-11, about half of them one-liners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)