### PR TITLE
Repair the two Mermaid diagrams that fail to render in the pooling gallery

### DIFF
--- a/.plans/active/commitment-pooling/diagrams.md
+++ b/.plans/active/commitment-pooling/diagrams.md
@@ -351,7 +351,7 @@ sequenceDiagram
   M-->>IDX: WorkLinked(contributor) (derived state flips to Active)
   OP->>EAS: attest WorkApproval decision (existing approval/rejection flow)
   EAS->>WAR: onAttest — full existing validation
-  WAR->>WAR: increment per-Work decisionSequence; store it by decisionUID
+  WAR->>WAR: increment per-Work decisionSequence · store it by decisionUID
   WAR->>M: onWorkDecision(workUID, decisionUID, decisionSequence, garden, approved) in try/catch
   alt newer effective approval before freeze
     M-->>IDX: ApprovedWorkCounted(contributor, requirementIndex, approvedWorkCount, approvedUnits, newlyApprovedUnits, …)
@@ -614,7 +614,7 @@ stateDiagram-v2
   Disputed --> Accepted : resolveDispute (RestorePrevious)
   Disputed --> ReadyForConfirmation : resolveDispute (RestorePrevious)
   Disputed --> Expired : resolveDispute (RestorePrevious or Expired)
-  Disputed --> Fulfilled : resolveDispute (never from pre-dispute Expired); reject contributor-steward SelfConfirmation; require policy + verified contributor; freeze roster first when needed
+  Disputed --> Fulfilled : resolveDispute (never from pre-dispute Expired) · reject contributor-steward SelfConfirmation · require policy + verified contributor · freeze roster first when needed
   Disputed --> Cancelled : resolveDispute (Cancelled)
   Fulfilled --> Reconciled : CycleClosed
   Cancelled --> Reconciled : CycleClosed

--- a/.plans/active/commitment-pooling/visual-assets-artifact.build.ts
+++ b/.plans/active/commitment-pooling/visual-assets-artifact.build.ts
@@ -1902,4 +1902,9 @@ console.log(`local preview: ${LOCAL_OUT} (${Buffer.byteLength(localDocument).toL
 console.log(`Artifact body: ${ARTIFACT_OUT} (${Buffer.byteLength(artifactBody).toLocaleString()} bytes, host-rendered Mermaid)`);
 console.log(`sections: story ${storyAssetCount} · architecture ${architectureSectionCount} · screens ${wfOut.body.split("<section").length - 1} · reference ${referenceSectionCount}`);
 console.log(`mermaid blocks: ${mermaidCount} · ascii frames: ${frameCount} · wireframe screens: ${wfScreenCount} · wf-only tags: ${WF_ONLY_FRAMES.length}`);
-console.log("publish only the Artifact body; open the local preview directly with file://");
+console.log(
+  "NOT directly publishable: <pre class=\"mermaid\"> blocks refuse public sharing (prerender header, confirmed 2026-07-22).",
+);
+console.log(
+  "Deploy via visual-assets-prerender.ts and publish its SHAREABLE_OUT; open the local preview directly with file://",
+);


### PR DESCRIPTION
The Visual Asset Gallery republish surfaced two diagrams on `develop` that fail to parse — D2 (offer→fulfillment sequence) and D6 (commitment state machine). Both render as error boxes on the artifact host, and `visual-assets-prerender.ts` correctly fails closed on them (34/36 rendered).

## Root cause

The known semicolon gotcha, in a wider form than previously recorded: Mermaid treats `;` as a statement terminator inside **any** text — sequence messages and state-transition labels, not only notes. D2 line 20 had `decisionSequence; store it by decisionUID` in a self-message; D6's `Disputed --> Fulfilled` label carried three semicolons. Everything after the first `;` parses as a new statement and the diagram refuses to draw.

Fix: the hub's house `·` separator, no semantic change. All 36 blocks (35 in `diagrams.md` + the `wireframes.md` surface map) now parse; the prerender freezes 36/36 in both themes:

```
render status: ready (rendered 36, failed 0)
8,484,919 bytes · froze 36 diagrams (light+dark) · total <svg>=84 · <pre class="mermaid">=0
```

## Guard against the recurrence that found this

`visual-assets-artifact.build.ts` closed with "publish only the Artifact body" — meaning "not the local preview", but the body it names contains `<pre class="mermaid">` blocks, and those refuse public sharing ("This version can't be shared publicly", confirmed empirically 2026-07-22 per the prerender header). That wording caused exactly this mispublish once. The build now names the real deploy path: `visual-assets-prerender.ts` → `SHAREABLE_OUT`.

The [gallery artifact](https://claude.ai/code/artifact/007ef090-9e26-4b1d-898c-615155304d9d) is already republished from this exact content and shares publicly again.

Planning-artifact scope only (`.plans/active/commitment-pooling/`); no runtime code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
