### PR TITLE
feat(shared): curate which gardens appear on which surface

### DIFF
--- a/.claude/rules/frontend-design.md
+++ b/.claude/rules/frontend-design.md
@@ -186,10 +186,10 @@ Use the `Alert` component from `@green-goods/shared` for all error/warning/info 
 Persistent chrome (`AppBar` GardenChip, workspace title bar, breadcrumb) is the canonical declaration of which entity the operator is in. Views, page headers, toolbars, list rows, and cards must not restate that same entity. Re-declaration steals vertical space, dilutes the chrome's authority, and trains the eye to ignore the very element that should be ground truth.
 
 ```tsx
-// Bad — AppBar GardenChip already shows "Aiyeloja Family Garden"
+// Bad — AppBar GardenChip already shows "Tech and Sun Hub"
 <PageHeader
   title="Work"
-  description="Review work flowing through Aiyeloja Family Garden."
+  description="Review work flowing through Tech and Sun Hub."
   metadata={<MetaStrip items={[{ label: garden.name }]} />}
 />
 <WorkbenchRow eyebrow={garden.name} title={...} />

--- a/packages/admin/src/components/Layout/ActionFlowShell.stories.tsx
+++ b/packages/admin/src/components/Layout/ActionFlowShell.stories.tsx
@@ -80,7 +80,7 @@ type Story = StoryObj<typeof ActionFlowShell>;
 export const Configure: Story = {
   args: {
     title: "Submit work",
-    context: "Aiyeloja Family Garden",
+    context: "Tech and Sun Hub",
     backLabel: "Back to action selection",
     onBack: fn(),
     layout: "dialog",
@@ -102,7 +102,7 @@ export const Submitting: Story = {
 export const QualifyPhase: Story = {
   args: {
     title: "Submit work",
-    context: "Aiyeloja Family Garden",
+    context: "Tech and Sun Hub",
     layout: "dialog",
     children: (
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
@@ -144,7 +144,7 @@ const STEPS = [
 export const TwoColumnRail: Story = {
   args: {
     title: "Submit work",
-    context: "Aiyeloja Family Garden",
+    context: "Tech and Sun Hub",
     steps: STEPS,
     currentStep: 2,
     onStepClick: fn(),

--- a/packages/client/src/__tests__/components/DraftCard.test.tsx
+++ b/packages/client/src/__tests__/components/DraftCard.test.tsx
@@ -64,7 +64,7 @@ describe("DraftCard", () => {
         createElement(DraftCard, {
           draft: baseDraft,
           actionTitle: "Plant Trees",
-          gardenName: "Aiyeloja Family Garden",
+          gardenName: "Tech and Sun Hub",
           onResume: vi.fn(),
           onDelete: vi.fn(),
         })
@@ -74,7 +74,7 @@ describe("DraftCard", () => {
     expect(screen.getByText("Plant Trees")).toBeInTheDocument();
     // Garden name + time-ago share a parent with a separator span; match
     // both as substrings of the combined text.
-    expect(screen.getByText(/Aiyeloja Family Garden/)).toBeInTheDocument();
+    expect(screen.getByText(/Tech and Sun Hub/)).toBeInTheDocument();
     expect(screen.getByText(/2 hours ago/)).toBeInTheDocument();
   });
 

--- a/packages/client/src/__tests__/components/PublicFundingReceipt.test.tsx
+++ b/packages/client/src/__tests__/components/PublicFundingReceipt.test.tsx
@@ -69,7 +69,7 @@ const messages: Record<string, string> = {
 const baseReceipt = {
   id: "intent-123",
   status: "confirmed_onchain",
-  garden: { id: "0xabc", name: "Aiyeloja Family Garden", location: "Lagos, NG" },
+  garden: { id: "0xabc", name: "AgroforestDAO", location: "Bias Fortes, BR" },
   destination: { type: "vault", address: "0xdef" },
   fundingIntent: "endow",
   amount: {
@@ -125,7 +125,7 @@ describe("PublicFundingReceipt success state", () => {
 
     await waitFor(
       () => {
-        expect(container.textContent).toContain("Aiyeloja Family Garden");
+        expect(container.textContent).toContain("AgroforestDAO");
       },
       { timeout: 3000 }
     );
@@ -187,7 +187,7 @@ describe("PublicFundingReceipt success state", () => {
 
     await waitFor(
       () => {
-        expect(container.textContent).toContain("Aiyeloja Family Garden");
+        expect(container.textContent).toContain("AgroforestDAO");
       },
       { timeout: 3000 }
     );

--- a/packages/client/src/__tests__/views/Assessment.test.tsx
+++ b/packages/client/src/__tests__/views/Assessment.test.tsx
@@ -60,7 +60,7 @@ const baseAssessment = {
 
 const baseGarden = {
   id: GARDEN_ID,
-  name: "Aiyeloja Family Garden",
+  name: "Muizenberg Community Garden",
   assessments: [baseAssessment],
 };
 
@@ -128,7 +128,7 @@ describe("GardenAssessment", () => {
 
   it("renders title, description, capitals, and garden eyebrow", () => {
     renderRoute();
-    expect(screen.getByText("Aiyeloja Family Garden")).toBeInTheDocument();
+    expect(screen.getByText("Muizenberg Community Garden")).toBeInTheDocument();
     expect(screen.getByText("Q1 Soil Health Assessment")).toBeInTheDocument();
     expect(screen.getByText("Assessment of soil regeneration outcomes")).toBeInTheDocument();
     expect(screen.getByText("Natural")).toBeInTheDocument();

--- a/packages/client/src/components/Public/PublicFundingCard.stories.tsx
+++ b/packages/client/src/components/Public/PublicFundingCard.stories.tsx
@@ -90,7 +90,7 @@ export const SuccessDonate: StoryObj<typeof SuccessBody> = {
     <Frame>
       <SuccessBody
         amountLabel="$20.00"
-        gardenName="Aiyeloja Family Garden"
+        gardenName="Muizenberg Community Garden"
         isDonate={true}
         onDonateAgain={() => {}}
         onClose={() => {}}
@@ -103,7 +103,7 @@ export const SuccessEndow: StoryObj<typeof SuccessBody> = {
     <Frame>
       <SuccessBody
         amountLabel="$100.00"
-        gardenName="Aiyeloja Family Garden"
+        gardenName="Muizenberg Community Garden"
         isDonate={false}
         onDonateAgain={() => {}}
         onClose={() => {}}
@@ -116,7 +116,7 @@ export const SuccessEndowWeth: StoryObj<typeof SuccessBody> = {
     <Frame>
       <SuccessBody
         amountLabel="0.05 WETH"
-        gardenName="Aiyeloja Family Garden"
+        gardenName="Muizenberg Community Garden"
         isDonate={false}
         onDonateAgain={() => {}}
         onClose={() => {}}

--- a/packages/shared/src/__tests__/config/garden-visibility.test.ts
+++ b/packages/shared/src/__tests__/config/garden-visibility.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Curated Garden Visibility Tests
+ *
+ * Covers the two tiers and, most importantly, case-insensitive address
+ * matching: garden addresses arrive checksummed from the indexer and
+ * lower-cased from other joins, so a case-sensitive compare would silently
+ * un-hide a garden.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  GARDENS_HIDDEN_EVERYWHERE,
+  GARDENS_HIDDEN_FROM_EDITORIAL,
+  isGardenHiddenEverywhere,
+  isGardenPubliclyVisible,
+} from "../../config/garden-visibility";
+
+const LIVE_GARDEN_COOP = "0x3F22568aE0deAA24dA7b8c669AfDcBD72A6A7fd8";
+const COMMUNITY_GARDEN = "0xf401f34378384713222d1d21f63359cc4E8a858a";
+const AIYELOJA = "0xF7b892886998DAe960D64a9db488336684F137A0";
+const MAMA_GARDENS = "0x35077CaF6fBef1d5677d318a198C9c47C61bb976";
+const VIDA_VERDE = "0x26c32E54F23af9F9fcC757414c76E56e3fB176E2";
+
+const garden = (id: string, name = "A Garden", location = "Somewhere") => ({
+  id,
+  name,
+  location,
+});
+
+describe("config/garden-visibility", () => {
+  describe("curated lists", () => {
+    it("gives every entry a reason", () => {
+      for (const entry of [...GARDENS_HIDDEN_EVERYWHERE, ...GARDENS_HIDDEN_FROM_EDITORIAL]) {
+        expect(entry.reason.trim().length).toBeGreaterThan(0);
+      }
+    });
+
+    it("never lists the same garden in both tiers", () => {
+      const everywhere = new Set(GARDENS_HIDDEN_EVERYWHERE.map((g) => g.address.toLowerCase()));
+      for (const entry of GARDENS_HIDDEN_FROM_EDITORIAL) {
+        expect(everywhere.has(entry.address.toLowerCase())).toBe(false);
+      }
+    });
+  });
+
+  describe("isGardenHiddenEverywhere", () => {
+    it("hides the coop garden from every surface", () => {
+      expect(isGardenHiddenEverywhere(LIVE_GARDEN_COOP)).toBe(true);
+    });
+
+    it("matches regardless of address casing", () => {
+      expect(isGardenHiddenEverywhere(LIVE_GARDEN_COOP.toLowerCase())).toBe(true);
+      expect(isGardenHiddenEverywhere(LIVE_GARDEN_COOP.toUpperCase().replace("0X", "0x"))).toBe(
+        true
+      );
+    });
+
+    it("leaves editorial-only hidden gardens visible to the PWA and admin", () => {
+      expect(isGardenHiddenEverywhere(COMMUNITY_GARDEN)).toBe(false);
+      expect(isGardenHiddenEverywhere(AIYELOJA)).toBe(false);
+      expect(isGardenHiddenEverywhere(MAMA_GARDENS)).toBe(false);
+    });
+
+    it("leaves uncurated gardens alone", () => {
+      expect(isGardenHiddenEverywhere(VIDA_VERDE)).toBe(false);
+    });
+  });
+
+  describe("isGardenPubliclyVisible", () => {
+    it("keeps an ordinary garden public", () => {
+      expect(isGardenPubliclyVisible(garden(VIDA_VERDE))).toBe(true);
+    });
+
+    it("hides all three editorial-hidden gardens", () => {
+      expect(isGardenPubliclyVisible(garden(COMMUNITY_GARDEN))).toBe(false);
+      expect(isGardenPubliclyVisible(garden(AIYELOJA))).toBe(false);
+      expect(isGardenPubliclyVisible(garden(MAMA_GARDENS))).toBe(false);
+    });
+
+    it("also hides gardens curated out of every surface", () => {
+      expect(isGardenPubliclyVisible(garden(LIVE_GARDEN_COOP))).toBe(false);
+    });
+
+    it("matches regardless of address casing", () => {
+      expect(isGardenPubliclyVisible(garden(AIYELOJA.toLowerCase()))).toBe(false);
+    });
+
+    it("hides placeholder gardens with neither name nor location", () => {
+      expect(isGardenPubliclyVisible(garden(VIDA_VERDE, "", ""))).toBe(false);
+      expect(isGardenPubliclyVisible(garden(VIDA_VERDE, "   ", "  "))).toBe(false);
+    });
+
+    it("keeps a garden with only one of name or location", () => {
+      expect(isGardenPubliclyVisible(garden(VIDA_VERDE, "Vida Verde", ""))).toBe(true);
+      expect(isGardenPubliclyVisible(garden(VIDA_VERDE, "", "Brazil"))).toBe(true);
+    });
+
+    it("treats null and undefined metadata as absent", () => {
+      expect(isGardenPubliclyVisible({ id: VIDA_VERDE, name: null, location: null })).toBe(false);
+      expect(isGardenPubliclyVisible({ id: VIDA_VERDE })).toBe(false);
+    });
+  });
+});

--- a/packages/shared/src/config/garden-visibility.ts
+++ b/packages/shared/src/config/garden-visibility.ts
@@ -1,0 +1,97 @@
+/**
+ * Curated garden visibility.
+ *
+ * Not every garden minted on-chain belongs on every Green Goods surface. One
+ * was created for a different project. Others are real gardens whose recorded
+ * work is people practicing rather than impact, so counting it as evidence on
+ * the public website would overstate what we can show.
+ *
+ * There is no visibility flag on `Garden` in the contract or the indexer, so
+ * the list is curated here. Entries are keyed by garden address, never by
+ * name: names are operator-editable, and a name-matching shortcut has already
+ * caused one bug in this codebase.
+ *
+ * Two tiers:
+ *   - `GARDENS_HIDDEN_EVERYWHERE` is filtered inside `getGardens()`, so the
+ *     garden is absent from the client PWA and admin dashboard as well.
+ *   - `GARDENS_HIDDEN_FROM_EDITORIAL` is filtered only by the public hooks, so
+ *     the garden keeps working normally for the people using it while staying
+ *     off the public archive, impact ledger, funding list, and proof counters.
+ *
+ * To change a garden's visibility, edit the relevant list. Every entry carries
+ * the reason it is there.
+ */
+
+import type { Address } from "../types/domain";
+
+interface CuratedGarden {
+  address: Address;
+  /** Garden name when curated. Documentation only — never used to match. */
+  name: string;
+  reason: string;
+}
+
+/** Absent from every surface: public website, client PWA, and admin. */
+export const GARDENS_HIDDEN_EVERYWHERE: readonly CuratedGarden[] = [
+  {
+    address: "0x3F22568aE0deAA24dA7b8c669AfDcBD72A6A7fd8",
+    name: "Live Garden Coop",
+    reason: "Created during Coop project work; never a Green Goods garden.",
+  },
+] as const;
+
+/** Absent from the public website, but fully functional in the PWA and admin. */
+export const GARDENS_HIDDEN_FROM_EDITORIAL: readonly CuratedGarden[] = [
+  {
+    address: "0xf401f34378384713222d1d21f63359cc4E8a858a",
+    name: "Green Goods Community Garden",
+    reason: "Open-joining onramp; its work is people practicing, not impact.",
+  },
+  {
+    address: "0xF7b892886998DAe960D64a9db488336684F137A0",
+    name: "Aiyeloja Family Garden",
+    reason: "Carries test work; a small family garden, not a representative example.",
+  },
+  {
+    address: "0x35077CaF6fBef1d5677d318a198C9c47C61bb976",
+    name: "Mama Gardens",
+    reason: "Carries test work; a small family garden, not a representative example.",
+  },
+] as const;
+
+const hiddenEverywhere = new Set(GARDENS_HIDDEN_EVERYWHERE.map((g) => g.address.toLowerCase()));
+const hiddenFromEditorial = new Set(
+  GARDENS_HIDDEN_FROM_EDITORIAL.map((g) => g.address.toLowerCase())
+);
+
+/**
+ * True when a garden is curated out of every surface.
+ *
+ * Garden addresses arrive checksummed from the indexer and lower-cased from
+ * other joins, so both sides are normalized before comparing.
+ */
+export function isGardenHiddenEverywhere(address: string): boolean {
+  return hiddenEverywhere.has(address.toLowerCase());
+}
+
+/**
+ * True when a garden should appear on the public website.
+ *
+ * Also carries the placeholder check that was previously copy-pasted across
+ * the three public hooks: a garden with neither name nor location has never
+ * been filled in. The indexer does track this properly as
+ * `Garden.initialized`, but `getGardens()` does not select that field, so the
+ * heuristic stands in until it does.
+ */
+export function isGardenPubliclyVisible(garden: {
+  id: string;
+  name?: string | null;
+  location?: string | null;
+}): boolean {
+  const address = garden.id.toLowerCase();
+  if (hiddenEverywhere.has(address) || hiddenFromEditorial.has(address)) return false;
+
+  const hasName = (garden.name ?? "").trim().length > 0;
+  const hasLocation = (garden.location ?? "").trim().length > 0;
+  return hasName || hasLocation;
+}

--- a/packages/shared/src/config/index.ts
+++ b/packages/shared/src/config/index.ts
@@ -52,6 +52,14 @@ export {
 // From gardens-subgraph.ts
 export { getGardensSubgraphUrl } from "./gardens-subgraph";
 
+// From garden-visibility.ts
+export {
+  GARDENS_HIDDEN_EVERYWHERE,
+  GARDENS_HIDDEN_FROM_EDITORIAL,
+  isGardenHiddenEverywhere,
+  isGardenPubliclyVisible,
+} from "./garden-visibility";
+
 // From passkeyServer.ts (client-only passkey utilities)
 export {
   buildPasskeyRecoveryContext,

--- a/packages/shared/src/hooks/public/usePublicFieldNotes.ts
+++ b/packages/shared/src/hooks/public/usePublicFieldNotes.ts
@@ -30,6 +30,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { DEFAULT_CHAIN_ID } from "../../config/blockchain";
+import { isGardenPubliclyVisible } from "../../config/garden-visibility";
 import { queryKeys } from "../../config/query-keys";
 import { STALE_TIME_RARE } from "../../config/query-keys/constants";
 import { getWorks } from "../../modules/data/eas";
@@ -95,9 +96,7 @@ export function usePublicFieldNotes(opts: UsePublicFieldNotesOptions = {}) {
         recipient = gardenAddress;
       } else {
         const gardens = await getGardens();
-        const ids = gardens
-          .filter((g) => (g.name ?? "").trim().length > 0 || (g.location ?? "").trim().length > 0)
-          .map((g) => g.id as Address);
+        const ids = gardens.filter(isGardenPubliclyVisible).map((g) => g.id as Address);
         if (ids.length === 0) {
           return { fieldNotes: [], hasMore: false, total: 0 };
         }

--- a/packages/shared/src/hooks/public/usePublicGardenDetail.ts
+++ b/packages/shared/src/hooks/public/usePublicGardenDetail.ts
@@ -28,6 +28,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { DEFAULT_CHAIN_ID } from "../../config/blockchain";
+import { isGardenPubliclyVisible } from "../../config/garden-visibility";
 import { queryKeys } from "../../config/query-keys";
 import { STALE_TIME_RARE } from "../../config/query-keys/constants";
 import { logger } from "../../modules/app/logger";
@@ -97,7 +98,10 @@ export function usePublicGardenDetail(
     queryKey: queryKeys.public.gardenDetail(lookup || "none", chainId),
     enabled: lookup.length > 0,
     queryFn: async (): Promise<PublicGardenDetail> => {
-      const gardens = await getGardens();
+      // Resolve against the public set only. Without this, a garden curated
+      // off the archive would still render a full detail page at its own URL,
+      // which is the leak the curation is meant to close.
+      const gardens = (await getGardens()).filter(isGardenPubliclyVisible);
 
       const matched =
         gardens.find((g) => g.id.toLowerCase() === lookup) ??

--- a/packages/shared/src/hooks/public/usePublicGardens.ts
+++ b/packages/shared/src/hooks/public/usePublicGardens.ts
@@ -26,6 +26,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { DEFAULT_CHAIN_ID } from "../../config/blockchain";
+import { isGardenPubliclyVisible } from "../../config/garden-visibility";
 import { queryKeys } from "../../config/query-keys";
 import { STALE_TIME_RARE } from "../../config/query-keys/constants";
 import { logger } from "../../modules/app/logger";
@@ -73,15 +74,10 @@ export function usePublicGardens(
     enabled: options.enabled ?? true,
     queryFn: async (): Promise<PublicGardenSummary[]> => {
       const gardens = await getGardens();
-      // Filter placeholder gardens. The indexer's `Garden.initialized` flag is
-      // not exposed by `getGardens`; we approximate "placeholder" as a garden
-      // with no name AND no location. A garden with a name but no location
-      // (or vice-versa) is still public — it just hasn't filled all metadata.
-      const initializedGardens = gardens.filter((g) => {
-        const hasName = (g.name ?? "").trim().length > 0;
-        const hasLocation = (g.location ?? "").trim().length > 0;
-        return hasName || hasLocation;
-      });
+      // Curated visibility plus the placeholder check, both owned by
+      // config/garden-visibility.ts so the archive, the proof counters, and the
+      // evidence ledger can never disagree about which gardens are public.
+      const initializedGardens = gardens.filter(isGardenPubliclyVisible);
 
       if (initializedGardens.length === 0) return [];
 

--- a/packages/shared/src/hooks/public/usePublicImpactEvidence.ts
+++ b/packages/shared/src/hooks/public/usePublicImpactEvidence.ts
@@ -19,6 +19,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { DEFAULT_CHAIN_ID } from "../../config/blockchain";
+import { isGardenPubliclyVisible } from "../../config/garden-visibility";
 import { queryKeys } from "../../config/query-keys";
 import { STALE_TIME_RARE } from "../../config/query-keys/constants";
 import { logger } from "../../modules/app/logger";
@@ -49,10 +50,9 @@ export function usePublicImpactEvidence(options: UsePublicImpactEvidenceOptions 
     queryKey: queryKeys.public.impactEvidence(chainId, page, pageSize),
     queryFn: async (): Promise<PublicImpactSlice> => {
       const gardens = await getGardens();
-      const visibleGardens = gardens.filter(
-        (garden) =>
-          (garden.name ?? "").trim().length > 0 || (garden.location ?? "").trim().length > 0
-      );
+      // Same predicate the archive and the proof counters use. A garden hidden
+      // from the website must not leak back in through its work records.
+      const visibleGardens = gardens.filter(isGardenPubliclyVisible);
 
       // First pass: pull all Work entries to determine recency-ordered Garden caps.
       const worksResult = await getWorks(

--- a/packages/shared/src/hooks/public/usePublicStats.ts
+++ b/packages/shared/src/hooks/public/usePublicStats.ts
@@ -32,6 +32,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { DEFAULT_CHAIN_ID } from "../../config/blockchain";
+import { isGardenPubliclyVisible } from "../../config/garden-visibility";
 import { queryKeys } from "../../config/query-keys";
 import { STALE_TIME_RARE } from "../../config/query-keys/constants";
 import { logger } from "../../modules/app/logger";
@@ -85,11 +86,9 @@ export function usePublicStats(chainId: number = DEFAULT_CHAIN_ID) {
       const works = worksResult.status === "fulfilled" ? worksResult.value : [];
       const assessments = assessmentsResult.status === "fulfilled" ? assessmentsResult.value : [];
 
-      // Gardens: include only initialized rows (same heuristic as
-      // usePublicGardens — name OR location set).
-      const visibleGardens = gardens.filter(
-        (g) => (g.name ?? "").trim().length > 0 || (g.location ?? "").trim().length > 0
-      );
+      // Same predicate the archive and the evidence ledger use, so the headline
+      // garden count can never disagree with the gardens a visitor can browse.
+      const visibleGardens = gardens.filter(isGardenPubliclyVisible);
 
       return {
         gardenCount: visibleGardens.length,

--- a/packages/shared/src/hooks/public/usePublicVolume.ts
+++ b/packages/shared/src/hooks/public/usePublicVolume.ts
@@ -28,6 +28,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { DEFAULT_CHAIN_ID } from "../../config/blockchain";
+import { isGardenPubliclyVisible } from "../../config/garden-visibility";
 import { queryKeys } from "../../config/query-keys";
 import { STALE_TIME_RARE } from "../../config/query-keys/constants";
 import { logger } from "../../modules/app/logger";
@@ -105,9 +106,7 @@ export function usePublicVolume(volumeId: number, chainId: number = DEFAULT_CHAI
       };
 
       const gardens = await getGardens();
-      const initializedGardens = gardens.filter(
-        (g) => (g.name ?? "").trim().length > 0 || (g.location ?? "").trim().length > 0
-      );
+      const initializedGardens = gardens.filter(isGardenPubliclyVisible);
 
       if (initializedGardens.length === 0) {
         return {

--- a/packages/shared/src/modules/data/greengoods.ts
+++ b/packages/shared/src/modules/data/greengoods.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_CHAIN_ID } from "../../config/blockchain";
+import { isGardenHiddenEverywhere } from "../../config/garden-visibility";
 import {
   type Action,
   type ActionContentLocale,
@@ -354,7 +355,12 @@ export async function getGardens(): Promise<Garden[]> {
       ])
     );
 
-    return data.Garden.map((garden) => {
+    // Curated out of every surface — see config/garden-visibility.ts. Filtering
+    // here rather than per-view keeps the PWA and admin consistent with the
+    // website for gardens that should not exist anywhere in Green Goods.
+    const visibleGardens = data.Garden.filter((garden) => !isGardenHiddenEverywhere(garden.id));
+
+    return visibleGardens.map((garden) => {
       // DIRTY FIX: Override Octant Community Garden banner until indexer is updated
       const OCTANT_BANNER_OVERRIDE = "bafkreihslrqy363mkr4kn5skr56zcazyvikldosy433p6e5okxyxxjdyuy";
       const isOctantGarden = garden.name === "Octant Community Garden";


### PR DESCRIPTION
Four gardens minted on-chain shouldn't appear where they currently do.

**Live Garden Coop** was created during Coop project work and was never a Green Goods garden — it should exist nowhere in Green Goods. **Green Goods Community Garden** is the open-joining onramp where people submit their first work, so what it records is practice rather than impact. **Aiyeloja Family Garden** and **Mama Gardens** carry test work and are small family gardens rather than representative examples. Those three are real gardens that must keep working normally for the people using them — they just shouldn't shape what a visitor reads as evidence.

Neither the contract nor the indexer has a visibility flag, so the list is curated in config.

## Two tiers

`packages/shared/src/config/garden-visibility.ts` is the single place this is decided. Entries are keyed by **address, never by name** — names are operator-editable, and a name-matching shortcut has already caused one bug in this codebase. Every entry carries the reason it's there.

- **Hidden everywhere** — filtered inside `getGardens()`, so the garden is absent from the client PWA and admin dashboard as well as the website. Live Garden Coop only.
- **Hidden from editorial** — filtered only by the public hooks. The garden keeps working normally in the PWA and admin while staying off the public archive, impact ledger, funding list, cookie jar page, and proof counters.

## Two bugs found while wiring it up

The placeholder check (`name` or `location` non-empty) was copy-pasted across **five** public hooks, not the three I first found. `usePublicFieldNotes` and `usePublicVolume` turned up during the sweep — without them, a hidden garden's field notes and funding volume would still surface publicly.

More seriously, **`usePublicGardenDetail` applied no filter at all**. It resolved straight from `getGardens()`, so a garden curated off the archive would still render a complete detail page at its own `/gardens/:slug` URL — the exact leak the curation exists to close.

All six public hooks now share one predicate, so the archive, the counters, the ledger, and the detail pages can't disagree about which gardens are public.

## Also in this PR

Aiyeloja was the repo's canonical example garden, so retiring it meant moving 13 fixture references across admin stories and client tests to Tech and Sun Hub, Muizenberg Community Garden, and AgroforestDAO — spread across surfaces rather than concentrated on one garden, since a single canonical example is what forced this change twice. `.claude/rules/frontend-design.md` used it in the Rule 17 example too, which would have fed it back into future admin UI work.

## Validation

- Repo quick gate (`ci-local.js --quick`) — exit 0: format, lint, type checking, and shared, client, admin, and agent tests
- Full shared suite — 294 files, 3417 tests passing
- 14 new tests for the curation module, covering both tiers, the placeholder cases, and case-insensitive address matching (addresses arrive checksummed from the indexer and lower-cased from other joins, so a case-sensitive compare would silently un-hide a garden)

## Deliberately not included

The `Octant Community Garden` banner override in `greengoods.ts` is the same class of name-matching hack and belongs in this config, but that garden name doesn't appear in the current on-chain roster. Removing the override without confirming whether a garden still uses it risks breaking a live banner, so it stays for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
