### PR TITLE
fix(claude): read the W1 season card from the shared pooling fixture

### DIFF
--- a/.plans/active/commitment-pooling/hifi/screens/client.ts
+++ b/.plans/active/commitment-pooling/hifi/screens/client.ts
@@ -43,12 +43,16 @@ type W1State = (typeof W1_STATES)[number][0];
 // incommensurable things (uiux-spec §5.2 "There is no synthetic
 // cross-commitment progress percentage", §12). A seeded or empty season shows
 // no counts line at all rather than a row of zeroes.
-const seasonCard = (opts: { offered?: number; kept?: number; stage?: string } = {}) => {
-  const offered = opts.offered ?? 12;
-  const kept = opts.kept ?? 7;
-  const counts = offered === 0 && kept === 0 ? "" : `<div class="t-meta num">${offered} offered · ${kept} kept</div>`;
+//
+// The card counts promises made and kept, the same pair W5, W12, W15 and W26
+// print for this moment — not open offers, which are a subset of what the
+// season has promised and so can never exceed `made` (PRD-760).
+const seasonCard = (opts: { made?: number; kept?: number; stage?: string } = {}) => {
+  const made = opts.made ?? SEASON_LIVE.made;
+  const kept = opts.kept ?? SEASON_LIVE.kept;
+  const counts = made === 0 && kept === 0 ? "" : `<div class="t-meta num">${made} promises · ${kept} kept</div>`;
   return card(
-    `<div class="cardrow">${hot("w1.season-card", `<div class="grow"><div class="t-title">Season of First Rains</div><div class="t-meta">${opts.stage ?? "Open"} · runs through Aug 30</div></div>`)}${chip("Season", "plain")}</div>` +
+    `<div class="cardrow">${hot("w1.season-card", `<div class="grow"><div class="t-title">${CYCLE}</div><div class="t-meta">${opts.stage ?? "Open"} · runs through Aug 30</div></div>`)}${chip("Season", "plain")}</div>` +
       counts,
   );
 };
@@ -199,7 +203,7 @@ function w1(state: W1State): string {
       break;
     case "empty-open":
       content = pagepad(
-        seasonCard({ offered: 0, kept: 0 }),
+        seasonCard({ made: 0, kept: 0 }),
         card(`<div class="t-title">No promises yet</div><div class="t-meta">Start the first one — offer something you can give, or ask for help you need.</div>`),
         `<div class="brow">${hot("w1.offer", btn("Offer support", { kind: "pri" }))}${hot("w1.request", btn("Request help", { kind: "sec" }))}</div>`,
       );
@@ -262,7 +266,7 @@ function w1(state: W1State): string {
     case "seeded":
       content = pagepad(
         banner("Opens soon — your steward is preparing this season's promises. You can browse what's coming; offering opens when the season does.", "amber", "time-line"),
-        seasonCard({ offered: 0, kept: 0, stage: "Opens soon" }),
+        seasonCard({ made: 0, kept: 0, stage: "Opens soon" }),
         card(`<div class="t-title">A preview of this season</div><div class="t-meta">These promises stay read-only until the season opens.</div>`, { cls: "inset" }),
       );
       break;


### PR DESCRIPTION
`seasonCard` was the one surface #692 left behind. It still defaulted to `offered ?? 12` and rendered "12 offered · 7 kept", while every other screen quoting the same open season already read 9/7 from `SEASON_LIVE`.

Offers are a subset of promises made, so "12 offered" against "9 promises made" could never both be true. Clicking from the garden pool tab to the wallet, the public garden page or the settlement roll-up, the totals changed under you.

Counts now come from `SEASON_LIVE` and read "9 promises · 7 kept" — the spelling `settlement.ts` already uses — and the title reads `CYCLE`. The zero-count callers move from `offered` to `made`, so a seeded or empty season still renders no counts row.

## Checked

- Artifact build clean: 36 screens, 377 states, 0 warnings
- `bun .plans/active/commitment-pooling/hifi/validate.ts` — exit 0
- Built output: zero `12 offered`, zero `/dashboard/` URLs, all 67 W2 states hide the AppBar
- Every live-season screen (W1, W5, W12, W15, W26) prints 7/9; `W1@cycle-summary` prints the closed 11/14

## Deliberately not in this PR

The **published prototype artifact still shows the old number.** It also carries W28–W31 from `feature/commitment-pooling-prototype-registry`, which aren't on develop — so rebuilding it from this branch would delete those four screens. It needs a rebuild from a tree that has both this fix and that work.

Also spotted, left alone: W26's close flow reads `SEASON_LIVE` (9 promises) while W1's post-close summary reads `SEASON_CLOSED` (14), so closing a 9-promise season yields a 14-promise summary. Fixing it means deciding which dataset W26 belongs to, and its hardcoded "7 fulfilled · 1 expired · 1 cancelled" line would move with it.

Refs PRD-760

🤖 Generated with [Claude Code](https://claude.com/claude-code)
