### PR TITLE
test(contracts): raise fork harness gas ceiling

### DIFF
--- a/packages/contracts/foundry.toml
+++ b/packages/contracts/foundry.toml
@@ -137,7 +137,10 @@ cache_path = ".generated/foundry/cache/e2e"
 # ═══════════════════════════════════════════════════════════════════════════════
 [profile.fork]
 via_ir = true
-gas_limit = 80_000_000
+# Full-stack fork scenarios can create three independent Gardens V2 communities
+# in one test transaction. Keep the harness ceiling above that aggregate setup
+# cost; production transaction gas assertions remain in their scoped tests.
+gas_limit = 120_000_000
 fuzz = { runs = 32 }
 verbosity = 3
 out = ".generated/foundry/out/fork"


### PR DESCRIPTION
## Summary
- raise the fork-only transaction gas ceiling from 80M to 120M
- allow the three-garden Gardens V2 scenario to complete without changing production gas assertions

## Validation
- [x] `git diff --check`
- [x] the previously failing Arbitrum weight-scheme test passes locally
- [x] fresh Alchemy-backed fork-readiness workflow on this commit