### PR TITLE
feat(agents): add PR comment resolution workflow

### DIFF
--- a/.claude/skills/resolve-pr-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-comments/SKILL.md
@@ -152,7 +152,10 @@ Do not resolve a thread merely because a local edit exists.
    including every conditional addition selected in step 3. Every required stage must pass in the
    current invocation before committing or pushing. After each mutating stage, require every changed
    path to remain inside the allowlist; restage approved formatter changes and rerun the affected
-   stage, but stop on any extra path.
+   stage, but stop on any extra path. Inspect enabled commit and push hooks, and run every validation
+   command they require explicitly inside the same credential-free validation boundary. Treat
+   repository-controlled hooks as untrusted code; do not defer their execution until credentials are
+   available for publication.
 5. For visible UI changes, obtain the required authenticated Brave rendered proof or report browser
    QA as blocked.
 6. Repeat the root-cause search after all fixes. Any remaining approved manifestation keeps the
@@ -163,8 +166,8 @@ Do not resolve a thread merely because a local edit exists.
 
 Failed or unavailable targeted proof keeps the affected actionable feedback cluster unresolved. A
 failed or unavailable Ship Gate blocks commit and push even when the failure appears unrelated or
-environmental. Do not bypass a failed pre-push hook with `--no-verify`. Report the blocker, fix it
-only when it is inside the locked scope, and do not claim ship readiness.
+environmental. Do not use `--no-verify` or hook isolation to bypass a failed required hook check.
+Report the blocker, fix it only when it is inside the locked scope, and do not claim ship readiness.
 
 ## 7. Publish, reply, and resolve safely
 
@@ -178,14 +181,17 @@ pushing the scoped, proven fixes to the current tracked PR branch:
 2. Re-inspect `git diff --cached --name-only` and the full cached diff. Require every staged path and
    hunk to belong to the locked feedback scope and require `git write-tree` to equal the tested tree
    recorded after the Ship Gate; stop on any extra path, mixed-ownership hunk, or tree drift.
-3. Create a conventional commit from that verified index. Compare `git rev-parse HEAD^{tree}` with
-   the tested tree to detect pre-commit hook rewrites. If they differ, do not push: rerun the full
-   Ship Gate at the created commit, and require it to pass without tracked changes before treating
-   that commit as tested. If validation mutates files, create another scoped commit and repeat the
-   tree-identity check.
-4. Push normally to the verified PR head repository and branch. Never use `--no-verify`, force-push,
-   rewrite history, switch branches, create another branch, or open another PR without explicit
-   authorization.
+3. Create a conventional commit from that verified index while preventing repository-controlled
+   hooks from executing with publication credentials. Use a command-scoped `core.hooksPath` that
+   points to a freshly created, verified-empty directory outside the PR tree; never change persistent
+   Git configuration. This is execution isolation, not a validation bypass: phase 6 must already have
+   run and passed every required hook check explicitly. Compare `git rev-parse HEAD^{tree}` with the
+   tested tree after the guarded commit; stop on any mismatch and repeat proof at the new tree.
+4. Before pushing, revalidate the commit tree, live head SHA, remote repository identity, URL, and
+   target ref. Push normally to that verified destination with the same command-scoped empty hook
+   path so a repository-controlled pre-push hook cannot execute with credentials. Never use
+   `--no-verify`, force-push, rewrite history, switch branches, create another branch, or open another
+   PR without explicit authorization.
 5. Fetch the PR head again and record the pushed SHA. A local commit or successful `git push` message
    alone is not proof that the live PR contains the fix.
 

--- a/.claude/skills/resolve-pr-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: resolve-pr-comments
-description: Resolve actionable GitHub pull request review feedback with a validate, bounded-sweep, fix, proof, and publish workflow. Use when the user asks to address, fix, clear, or resolve unresolved PR review threads, requested changes on a pull request, review-level feedback, or GitHub PR comments. Confirm feedback against the current PR head, search the changed scope and direct consumers for the same root-cause class, fix approved instances, prove recurrence is closed, then commit and push scoped fixes to the existing PR branch by default. Make GitHub replies, reviews, reactions, and thread-resolution writes only with explicit authorization.
+description: Resolve actionable GitHub pull request review feedback with a validate, bounded-sweep, fix, proof, and publish workflow. Use when the user asks to address, fix, clear, or resolve unresolved PR review threads, requested changes on a pull request, review-level feedback, or GitHub PR comments. Confirm feedback against the current PR head, search the changed scope and direct consumers for the same root-cause class, fix approved instances, prove recurrence is closed, then commit and push scoped fixes to the existing PR branch by default after the full Ship Gate passes. Make GitHub replies, reviews, reactions, and thread-resolution writes only with explicit authorization.
 ---
 
 # Resolve PR Comments
@@ -20,18 +20,22 @@ selected from [`validation-pipeline.md`](../../context/validation-pipeline.md).
 
 1. Resolve the repository and PR from the supplied URL or number. For current-branch requests,
    resolve the PR from local Git and GitHub metadata.
-2. Fetch fresh PR metadata and record the base branch, live head SHA, changed files, and local HEAD.
-   Do not rely on an earlier feedback snapshot or a stale local checkout.
-3. Inspect the working tree before editing. Preserve unrelated changes and remain on the current
-   branch unless the user explicitly authorizes a branch change.
-4. Establish an exact live-head inspection surface before classifying feedback. Use GitHub file
+2. Fetch fresh PR metadata and record its state, base branch, head branch, live head SHA, changed
+   files, and local HEAD. Require the PR to be `OPEN` before classification or editing. Report a
+   closed or merged PR as blocked; do not edit or publish commits to its former head branch.
+3. Before editing, require the writable checkout to be the tracked PR head branch at the exact live
+   head SHA. Refuse to edit or publish directly from `main`, `master`, or `develop`. If the checkout
+   is on another branch, detached, ahead, behind, or diverged, stop and request authorization to use
+   an isolated writable checkout at the live head. Do not contaminate the current branch.
+4. Inspect the working tree and index before editing. Preserve unrelated changes and do not unstage,
+   overwrite, stash, or commit another session's work.
+5. Establish an exact live-head inspection surface before classifying feedback. Use GitHub file
    contents addressed by the live SHA, `git show <live-head-sha>:<path>`, or an isolated clean
    snapshot at that SHA. Use the current checkout only after proving tree identity for every
    affected path and confirming those paths have no staged, unstaged, or untracked changes.
-5. Treat a descendant checkout separately. Classify the feedback against the exact live-head tree
-   first, then record whether descendant-only commits or working-tree changes already contain a
-   proposed fix. An ancestry check alone is not proof of live-head behavior. Do not silently switch
-   branches.
+6. Treat descendant-only commits or working-tree changes as a separate, read-only observation until
+   the branch mismatch is coordinated. Classify against the exact live-head tree first. An ancestry
+   check alone is not proof of live-head behavior or authority to edit or push the descendant.
 
 ## 2. Validate each feedback item
 
@@ -52,11 +56,17 @@ independently using `--paginate` with an `$endCursor` variable and
 and pagination completion. A flat list, first page, or unproven connector page is not sufficient for
 a complete ledger; report retrieval as blocked instead of silently omitting later feedback.
 
-Classify every feedback item:
+For inline review feedback, classify `isResolved: true` threads as `RESOLVED` before evaluating the
+underlying code. Do not reopen or modify an accepted decision unless the user explicitly asks to
+revisit resolved feedback.
 
+Classify every remaining feedback item:
+
+- `RESOLVED`: GitHub already records the inline thread as resolved; exclude it from actionable work.
 - `ACTIONABLE`: the issue still exists at the live PR head and the requested outcome is coherent.
-- `STALE`: the exact live-head tree removed the issue, the diff anchor is outdated, or a later review
-  superseded or dismissed the request.
+- `STALE`: exact live-head inspection proves the underlying concern is absent. An outdated, moved, or
+  missing diff anchor is only a relocation signal and is never sufficient by itself.
+- `SUPERSEDED`: a later authoritative review or comment explicitly replaces or dismisses the request.
 - `DUPLICATE`: another feedback item describes the same root-cause class.
 - `INFORMATIONAL`: no code or response change is requested.
 - `UNSUPPORTED`: current code, behavior, or repository requirements do not support the claimed issue.
@@ -94,9 +104,9 @@ Present a numbered ledger before editing unless the user already explicitly aske
 unresolved actionable feedback item.
 
 Interpret "fix all comments" as authorization to fix all `ACTIONABLE` feedback items and their
-approved in-scope sibling instances. On an existing PR branch, it also authorizes staging only the
-scoped files, creating a conventional commit, and pushing normally to that tracked branch after the
-required proof passes. It does not authorize:
+approved in-scope sibling instances. On a safe existing PR branch, it also authorizes staging only
+the scoped files, creating a conventional commit, and pushing normally to that tracked branch after
+the full Ship Gate passes. It does not authorize:
 
 - ambiguous or conflicting changes;
 - unrelated repository cleanup;
@@ -104,8 +114,8 @@ required proof passes. It does not authorize:
 - creating or switching branches, creating another PR, rewriting history, or force-pushing;
 - GitHub replies, reviews, reactions, or thread resolution.
 
-Surface ambiguity or scope expansion for a human decision. Keep stale, duplicate, informational,
-and unsupported feedback in the ledger so the final outcome remains traceable.
+Surface ambiguity or scope expansion for a human decision. Keep resolved, stale, superseded,
+duplicate, informational, and unsupported feedback in the ledger so the outcome remains traceable.
 
 ## 5. Fix the approved failure classes
 
@@ -120,33 +130,40 @@ Do not resolve a thread merely because a local edit exists.
 
 ## 6. Prove closure
 
-1. Run the lightest honest validation rung for the touched behavior. Escalate proof for shared,
-   cross-package, critical, or ship-readiness changes according to the repository ladder.
-2. For visible UI changes, obtain the required authenticated Brave rendered proof or report browser
+1. Run the lightest honest targeted proof for the touched behavior.
+2. When commit or push is in scope, also run the full Ship Gate from
+   [`validation-pipeline.md`](../../context/validation-pipeline.md), including every conditional
+   addition for the touched surfaces. Every required stage must pass in the current invocation
+   before committing or pushing.
+3. For visible UI changes, obtain the required authenticated Brave rendered proof or report browser
    QA as blocked.
-3. Repeat the root-cause search after all fixes. Any remaining approved manifestation keeps the
+4. Repeat the root-cause search after all fixes. Any remaining approved manifestation keeps the
    feedback cluster open.
-4. Re-read the changed code and record the exact tested state. Distinguish fixes present only in the
+5. Re-read the changed code and record the exact tested state. Distinguish fixes present only in the
    local working tree from fixes present on the live PR head.
 
-Failed or unavailable proof keeps the affected actionable feedback cluster unresolved. Do not
-publish a behavior change whose required touched-behavior proof failed. An unrelated or
-environmental broad-gate blocker does not invalidate passing scoped proof, but report it honestly
-and do not claim ship readiness.
+Failed or unavailable targeted proof keeps the affected actionable feedback cluster unresolved. A
+failed or unavailable Ship Gate blocks commit and push even when the failure appears unrelated or
+environmental. Do not bypass a failed pre-push hook with `--no-verify`. Report the blocker, fix it
+only when it is inside the locked scope, and do not claim ship readiness.
 
 ## 7. Publish, reply, and resolve safely
 
 Unless the user asks to keep changes local, finish an existing-PR feedback task by committing and
 pushing the scoped, proven fixes to the current tracked PR branch:
 
-1. Re-check that the local branch is the PR's head branch and that the live head has not changed
-   since classification. Stop for coordination if the remote advanced, the checkout is detached,
-   or the branch does not track the PR head.
-2. Stage only files attributable to the approved feedback clusters. Preserve unrelated local work.
-3. Create a conventional commit that describes the feedback fix, then push normally to the tracked
-   branch. Never force-push, rewrite history, switch branches, create another branch, or open another
-   PR without explicit authorization.
-4. Fetch the PR head again and record the pushed SHA. A local commit or successful `git push` message
+1. Re-fetch the PR and require it to remain open with the same non-protected head branch and live
+   head SHA used for classification. Stop if the remote advanced or any branch invariant changed.
+2. Define the exact path allowlist for the approved feedback clusters before staging. If
+   `git diff --cached --name-only` already contains unrelated paths, stop or move the work to an
+   authorized isolated checkout. Never unstage another session's work to make the index appear safe.
+3. Stage only the allowlisted paths, then inspect `git diff --cached --name-only` and the full cached
+   diff. Require every staged path and hunk to belong to the locked feedback scope; stop on any
+   extra path or mixed-ownership hunk.
+4. Create a conventional commit from that verified index, then push normally to the tracked PR head
+   branch. Never use `--no-verify`, force-push, rewrite history, switch branches, create another
+   branch, or open another PR without explicit authorization.
+5. Fetch the PR head again and record the pushed SHA. A local commit or successful `git push` message
    alone is not proof that the live PR contains the fix.
 
 GitHub replies, reactions, thread resolution, and review submission remain separate conversational
@@ -158,8 +175,9 @@ Before resolving an inline thread:
 2. Re-fetch the thread and ensure no newer reply or head change invalidates the conclusion.
 3. Summarize the root cause, bounded sweep, affected paths, and validation evidence concisely.
 4. Resolve only `ACTIONABLE` threads that are fixed and proven, `DUPLICATE` threads whose canonical
-   failure class is fixed and proven, or threads closed by an explicit, accurate explanation
-   accepted by the requested workflow.
+   failure class is fixed and proven, `STALE` threads whose underlying concern is proven absent at
+   the live head, or threads closed by an explicit, accurate explanation accepted by the requested
+   workflow. Leave `RESOLVED` threads untouched.
 
 Leave ambiguous, conflicting, out-of-scope, and unverified feedback open or unaddressed. Never use
 thread resolution to hide a deferred finding.

--- a/.claude/skills/resolve-pr-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-comments/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: resolve-pr-comments
+description: Resolve actionable GitHub pull request review feedback with a validate, bounded-sweep, fix, and proof workflow. Use when the user asks to address, fix, clear, or resolve unresolved PR review threads, requested changes, or inline GitHub comments. Confirm comments against the current PR head, search the changed scope and direct consumers for the same root-cause class, fix approved instances, prove recurrence is closed, and write back to GitHub only with explicit authorization.
+---
+
+# Resolve PR Comments
+
+Address PR feedback as evidence of a possible failure class, not as an isolated line edit.
+
+Follow this sequence:
+
+`VALIDATE -> SWEEP -> LOCK -> FIX -> PROVE -> RESOLVE`
+
+Apply the Implementation Quality Contract in
+[`values.md`](../../context/values.md#implementation-quality-contract), the behavior-proof rules in
+[`testing.md`](../../context/testing.md#regression-and-tooling-closure), and the validation rung
+selected from [`validation-pipeline.md`](../../context/validation-pipeline.md).
+
+## 1. Resolve the live PR state
+
+1. Resolve the repository and PR from the supplied URL or number. For current-branch requests,
+   resolve the PR from local Git and GitHub metadata.
+2. Fetch fresh PR metadata and record the base branch, live head SHA, changed files, and local HEAD.
+   Do not rely on an earlier comment snapshot or a stale local checkout.
+3. Inspect the working tree before editing. Preserve unrelated changes and remain on the current
+   branch unless the user explicitly authorizes a branch change.
+4. Verify that local HEAD contains the live PR head. If it is stale or unexpectedly diverged, stop
+   before editing or resolving threads and explain the mismatch. A local descendant may be fixed,
+   but its changes remain local-only until the live PR head advances. Do not silently switch branches.
+
+## 2. Validate each review thread
+
+Read thread-aware review data that preserves `isResolved`, `isOutdated`, file and line anchors, the
+diff hunk, and replies. Use the available GitHub connector when it exposes those fields; otherwise
+use `gh api graphql`. A flat list of comments is not sufficient evidence of unresolved thread state.
+
+Classify every thread:
+
+- `ACTIONABLE`: the issue still exists at the live PR head and the requested outcome is coherent.
+- `STALE`: later code or an outdated diff anchor already removed the issue.
+- `DUPLICATE`: another thread describes the same root-cause class.
+- `INFORMATIONAL`: no code or response change is requested.
+- `UNSUPPORTED`: current code, behavior, or repository requirements do not support the claimed issue.
+- `AMBIGUOUS`: the expected behavior or requested change is unclear.
+- `CONFLICTING`: the request conflicts with authoritative requirements, another review comment, or
+  a repository invariant.
+
+For an alleged defect, inspect or reproduce the behavior before accepting the proposed fix. Treat
+the comment as evidence, not authority. When the root cause is unclear, use the repository's debug
+workflow before editing.
+
+## 3. Sweep the root-cause class
+
+For each actionable feedback cluster:
+
+1. Name the root-cause class and the violated invariant, contract, or requirement.
+2. Search semantically, not only for the exact commented text.
+3. Sweep the bounded default scope:
+   - the PR's changed files;
+   - sibling implementations in the touched package;
+   - direct consumers of the changed API, type, component, hook, or contract;
+   - relevant tests, locales, schemas, configuration, or generated projections when the invariant
+     crosses those surfaces.
+4. Record affected paths and checked-unaffected paths. Never turn a bounded sweep into a claim that
+   the entire repository is safe.
+5. Separate manifestations inside the PR's intent from adjacent findings that would materially
+   expand scope. Report the latter and request approval before fixing them.
+
+Do not widen an intentionally unsupported product, security, deployment, or authorization boundary
+just because a similar code shape exists.
+
+## 4. Lock the fix scope
+
+Present a numbered ledger before editing unless the user already explicitly asked to fix every
+unresolved actionable thread.
+
+Interpret "fix all comments" as authorization to fix all `ACTIONABLE` threads and their approved
+in-scope sibling instances. It does not authorize:
+
+- ambiguous or conflicting changes;
+- unrelated repository cleanup;
+- material scope expansion outside the PR's intent;
+- commits, pushes, GitHub replies, reviews, or thread resolution.
+
+Surface ambiguity or scope expansion for a human decision. Keep stale, duplicate, informational,
+and unsupported threads in the ledger so the final outcome remains traceable.
+
+## 5. Fix the approved failure classes
+
+1. Add negative or boundary coverage for the original trigger when behavior changed. If a test is
+   genuinely inapplicable, record the concrete proof substitute.
+2. Fix the root cause and every approved in-scope manifestation found by the sweep.
+3. Keep each change traceable to a thread or feedback cluster.
+4. Prefer the smallest behavior-complete change and avoid opportunistic refactors.
+5. Draft a response instead of forcing a code change when the comment only needs explanation.
+
+Do not resolve a thread merely because a local edit exists.
+
+## 6. Prove closure
+
+1. Run the lightest honest validation rung for the touched behavior. Escalate proof for shared,
+   cross-package, critical, or ship-readiness changes according to the repository ladder.
+2. For visible UI changes, obtain the required authenticated Brave rendered proof or report browser
+   QA as blocked.
+3. Repeat the root-cause search after all fixes. Any remaining approved manifestation keeps the
+   feedback cluster open.
+4. Re-read the changed code and record the exact tested state. Distinguish fixes present only in the
+   local working tree from fixes present on the live PR head.
+
+Failed or unavailable proof keeps the affected actionable feedback cluster unresolved.
+
+## 7. Reply and resolve safely
+
+Reply on GitHub, resolve threads, submit a review, commit, or push only when the user explicitly
+authorizes that write action.
+
+Before resolving a thread:
+
+1. Confirm the fix is present on the live PR head, not only locally.
+2. Re-fetch the thread and ensure no newer reply or head change invalidates the conclusion.
+3. Summarize the root cause, bounded sweep, affected paths, and validation evidence concisely.
+4. Resolve only `ACTIONABLE` threads that are fixed and proven, `DUPLICATE` threads whose canonical
+   failure class is fixed and proven, or threads closed by an explicit, accurate explanation
+   accepted by the requested workflow.
+
+Leave ambiguous, conflicting, out-of-scope, and unverified threads open. Never use thread resolution
+to hide a deferred finding.
+
+## Output contract
+
+Report:
+
+1. PR number and live head SHA reviewed.
+2. Thread ledger with classification and root-cause clusters.
+3. Sweep boundary, affected paths, and checked-unaffected paths.
+4. Fixes made and regression coverage added.
+5. Exact validation run, results, and any blocked proof.
+6. Threads still open and why.
+7. GitHub writes performed, or an explicit statement that none were performed.

--- a/.claude/skills/resolve-pr-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-comments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: resolve-pr-comments
-description: Resolve actionable GitHub pull request review feedback with a validate, bounded-sweep, fix, and proof workflow. Use when the user asks to address, fix, clear, or resolve unresolved PR review threads, requested changes, or inline GitHub comments. Confirm comments against the current PR head, search the changed scope and direct consumers for the same root-cause class, fix approved instances, prove recurrence is closed, and write back to GitHub only with explicit authorization.
+description: Resolve actionable GitHub pull request review feedback with a validate, bounded-sweep, fix, proof, and publish workflow. Use when the user asks to address, fix, clear, or resolve unresolved PR review threads, requested changes on a pull request, review-level feedback, or GitHub PR comments. Confirm feedback against the current PR head, search the changed scope and direct consumers for the same root-cause class, fix approved instances, prove recurrence is closed, then commit and push scoped fixes to the existing PR branch by default. Make GitHub replies, reviews, reactions, and thread-resolution writes only with explicit authorization.
 ---
 
 # Resolve PR Comments
@@ -9,7 +9,7 @@ Address PR feedback as evidence of a possible failure class, not as an isolated 
 
 Follow this sequence:
 
-`VALIDATE -> SWEEP -> LOCK -> FIX -> PROVE -> RESOLVE`
+`VALIDATE -> SWEEP -> LOCK -> FIX -> PROVE -> PUBLISH -> RESOLVE`
 
 Apply the Implementation Quality Contract in
 [`values.md`](../../context/values.md#implementation-quality-contract), the behavior-proof rules in
@@ -21,32 +21,51 @@ selected from [`validation-pipeline.md`](../../context/validation-pipeline.md).
 1. Resolve the repository and PR from the supplied URL or number. For current-branch requests,
    resolve the PR from local Git and GitHub metadata.
 2. Fetch fresh PR metadata and record the base branch, live head SHA, changed files, and local HEAD.
-   Do not rely on an earlier comment snapshot or a stale local checkout.
+   Do not rely on an earlier feedback snapshot or a stale local checkout.
 3. Inspect the working tree before editing. Preserve unrelated changes and remain on the current
    branch unless the user explicitly authorizes a branch change.
-4. Verify that local HEAD contains the live PR head. If it is stale or unexpectedly diverged, stop
-   before editing or resolving threads and explain the mismatch. A local descendant may be fixed,
-   but its changes remain local-only until the live PR head advances. Do not silently switch branches.
+4. Establish an exact live-head inspection surface before classifying feedback. Use GitHub file
+   contents addressed by the live SHA, `git show <live-head-sha>:<path>`, or an isolated clean
+   snapshot at that SHA. Use the current checkout only after proving tree identity for every
+   affected path and confirming those paths have no staged, unstaged, or untracked changes.
+5. Treat a descendant checkout separately. Classify the feedback against the exact live-head tree
+   first, then record whether descendant-only commits or working-tree changes already contain a
+   proposed fix. An ancestry check alone is not proof of live-head behavior. Do not silently switch
+   branches.
 
-## 2. Validate each review thread
+## 2. Validate each feedback item
 
-Read thread-aware review data that preserves `isResolved`, `isOutdated`, file and line anchors, the
-diff hunk, and replies. Use the available GitHub connector when it exposes those fields; otherwise
-use `gh api graphql`. A flat list of comments is not sufficient evidence of unresolved thread state.
+Collect complete PR feedback from all applicable review surfaces:
 
-Classify every thread:
+- pull-request reviews with their state, body, author, submission time, and reviewed commit when
+  available; treat non-empty `CHANGES_REQUESTED` bodies as candidate actionable feedback and use
+  later review state plus the PR's `reviewDecision` to detect superseded or dismissed requests;
+- inline `reviewThreads` with `isResolved`, `isOutdated`, file and line anchors, the diff hunk, and
+  every reply;
+- top-level PR conversation comments that contain actionable review feedback.
+
+Use the available GitHub connector when it exposes these fields; otherwise use `gh api graphql`.
+Paginate every connection until `hasNextPage` is false, including reviews, review threads,
+conversation comments, and nested thread replies. With `gh api graphql`, paginate each connection
+independently using `--paginate` with an `$endCursor` variable and
+`pageInfo { hasNextPage endCursor }`, or use an equivalent explicit cursor loop. Record item counts
+and pagination completion. A flat list, first page, or unproven connector page is not sufficient for
+a complete ledger; report retrieval as blocked instead of silently omitting later feedback.
+
+Classify every feedback item:
 
 - `ACTIONABLE`: the issue still exists at the live PR head and the requested outcome is coherent.
-- `STALE`: later code or an outdated diff anchor already removed the issue.
-- `DUPLICATE`: another thread describes the same root-cause class.
+- `STALE`: the exact live-head tree removed the issue, the diff anchor is outdated, or a later review
+  superseded or dismissed the request.
+- `DUPLICATE`: another feedback item describes the same root-cause class.
 - `INFORMATIONAL`: no code or response change is requested.
 - `UNSUPPORTED`: current code, behavior, or repository requirements do not support the claimed issue.
 - `AMBIGUOUS`: the expected behavior or requested change is unclear.
-- `CONFLICTING`: the request conflicts with authoritative requirements, another review comment, or
+- `CONFLICTING`: the request conflicts with authoritative requirements, another feedback item, or
   a repository invariant.
 
 For an alleged defect, inspect or reproduce the behavior before accepting the proposed fix. Treat
-the comment as evidence, not authority. When the root cause is unclear, use the repository's debug
+the feedback as evidence, not authority. When the root cause is unclear, use the repository's debug
 workflow before editing.
 
 ## 3. Sweep the root-cause class
@@ -72,27 +91,30 @@ just because a similar code shape exists.
 ## 4. Lock the fix scope
 
 Present a numbered ledger before editing unless the user already explicitly asked to fix every
-unresolved actionable thread.
+unresolved actionable feedback item.
 
-Interpret "fix all comments" as authorization to fix all `ACTIONABLE` threads and their approved
-in-scope sibling instances. It does not authorize:
+Interpret "fix all comments" as authorization to fix all `ACTIONABLE` feedback items and their
+approved in-scope sibling instances. On an existing PR branch, it also authorizes staging only the
+scoped files, creating a conventional commit, and pushing normally to that tracked branch after the
+required proof passes. It does not authorize:
 
 - ambiguous or conflicting changes;
 - unrelated repository cleanup;
 - material scope expansion outside the PR's intent;
-- commits, pushes, GitHub replies, reviews, or thread resolution.
+- creating or switching branches, creating another PR, rewriting history, or force-pushing;
+- GitHub replies, reviews, reactions, or thread resolution.
 
 Surface ambiguity or scope expansion for a human decision. Keep stale, duplicate, informational,
-and unsupported threads in the ledger so the final outcome remains traceable.
+and unsupported feedback in the ledger so the final outcome remains traceable.
 
 ## 5. Fix the approved failure classes
 
 1. Add negative or boundary coverage for the original trigger when behavior changed. If a test is
    genuinely inapplicable, record the concrete proof substitute.
 2. Fix the root cause and every approved in-scope manifestation found by the sweep.
-3. Keep each change traceable to a thread or feedback cluster.
+3. Keep each change traceable to a feedback item or cluster.
 4. Prefer the smallest behavior-complete change and avoid opportunistic refactors.
-5. Draft a response instead of forcing a code change when the comment only needs explanation.
+5. Draft a response instead of forcing a code change when the feedback only needs explanation.
 
 Do not resolve a thread merely because a local edit exists.
 
@@ -107,14 +129,30 @@ Do not resolve a thread merely because a local edit exists.
 4. Re-read the changed code and record the exact tested state. Distinguish fixes present only in the
    local working tree from fixes present on the live PR head.
 
-Failed or unavailable proof keeps the affected actionable feedback cluster unresolved.
+Failed or unavailable proof keeps the affected actionable feedback cluster unresolved. Do not
+publish a behavior change whose required touched-behavior proof failed. An unrelated or
+environmental broad-gate blocker does not invalidate passing scoped proof, but report it honestly
+and do not claim ship readiness.
 
-## 7. Reply and resolve safely
+## 7. Publish, reply, and resolve safely
 
-Reply on GitHub, resolve threads, submit a review, commit, or push only when the user explicitly
-authorizes that write action.
+Unless the user asks to keep changes local, finish an existing-PR feedback task by committing and
+pushing the scoped, proven fixes to the current tracked PR branch:
 
-Before resolving a thread:
+1. Re-check that the local branch is the PR's head branch and that the live head has not changed
+   since classification. Stop for coordination if the remote advanced, the checkout is detached,
+   or the branch does not track the PR head.
+2. Stage only files attributable to the approved feedback clusters. Preserve unrelated local work.
+3. Create a conventional commit that describes the feedback fix, then push normally to the tracked
+   branch. Never force-push, rewrite history, switch branches, create another branch, or open another
+   PR without explicit authorization.
+4. Fetch the PR head again and record the pushed SHA. A local commit or successful `git push` message
+   alone is not proof that the live PR contains the fix.
+
+GitHub replies, reactions, thread resolution, and review submission remain separate conversational
+writes. Perform them only when the user explicitly authorizes them.
+
+Before resolving an inline thread:
 
 1. Confirm the fix is present on the live PR head, not only locally.
 2. Re-fetch the thread and ensure no newer reply or head change invalidates the conclusion.
@@ -123,17 +161,23 @@ Before resolving a thread:
    failure class is fixed and proven, or threads closed by an explicit, accurate explanation
    accepted by the requested workflow.
 
-Leave ambiguous, conflicting, out-of-scope, and unverified threads open. Never use thread resolution
-to hide a deferred finding.
+Leave ambiguous, conflicting, out-of-scope, and unverified feedback open or unaddressed. Never use
+thread resolution to hide a deferred finding.
+
+Review submissions and top-level PR conversation comments do not have review-thread resolution
+state. Report them as addressed only after the fix is present and proven on the live PR head. Reply
+only with explicit authorization, and leave the requested-changes decision for the reviewer to
+update through a subsequent review.
 
 ## Output contract
 
 Report:
 
 1. PR number and live head SHA reviewed.
-2. Thread ledger with classification and root-cause clusters.
+2. Feedback ledger with source, classification, and root-cause clusters.
 3. Sweep boundary, affected paths, and checked-unaffected paths.
 4. Fixes made and regression coverage added.
 5. Exact validation run, results, and any blocked proof.
-6. Threads still open and why.
-7. GitHub writes performed, or an explicit statement that none were performed.
+6. Feedback still open or unaddressed and why.
+7. Commit SHA, push result, and verified live PR head, or why publication was blocked or declined.
+8. GitHub conversational writes performed, or an explicit statement that none were performed.

--- a/.claude/skills/resolve-pr-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-comments/SKILL.md
@@ -65,6 +65,11 @@ independently using `--paginate` with an `$endCursor` variable and
 and pagination completion. A flat list, first page, or unproven connector page is not sufficient for
 a complete ledger; report retrieval as blocked instead of silently omitting later feedback.
 
+After classification and scope lock, record a feedback snapshot that can detect review-only drift
+without a head commit change. Include connection counts and pagination completion plus each item's
+stable ID, state or resolution fields, latest reply or submission identity and time, and body
+content or hash. A head SHA or connection cursor alone is not a feedback snapshot.
+
 For inline review feedback, classify `isResolved: true` threads as `RESOLVED` before evaluating the
 underlying code. Do not reopen or modify an accepted decision unless the user explicitly asks to
 revisit resolved feedback.
@@ -174,10 +179,14 @@ Report the blocker, fix it only when it is inside the locked scope, and do not c
 Unless the user asks to keep changes local, finish an existing-PR feedback task by committing and
 pushing the scoped, proven fixes to the current tracked PR branch:
 
-1. Re-fetch the PR and require it to remain open with the same non-protected head branch and live
-   head SHA used for classification. Reconfirm the head repository, push destination, trust boundary,
-   and tested-tree invariants from phases 1 and 6. Stop if the remote advanced or any invariant
-   changed.
+1. After the Ship Gate, re-fetch the PR and every feedback surface to pagination completion. Require
+   it to remain open with the same non-protected head branch and live head SHA used for
+   classification. Compare the new feedback snapshot with the locked ledger and reclassify every
+   added or changed item. If a request was resolved, superseded, or revised, or new actionable
+   feedback changes the locked scope, stop and repeat the sweep, scope lock, fix, and affected proof
+   before committing. An unchanged head SHA does not prove stable feedback. Reconfirm the head
+   repository, push destination, trust boundary, and tested-tree invariants from phases 1 and 6.
+   Stop if the remote advanced or any invariant changed.
 2. Re-inspect `git diff --cached --name-only` and the full cached diff. Require every staged path and
    hunk to belong to the locked feedback scope and require `git write-tree` to equal the tested tree
    recorded after the Ship Gate; stop on any extra path, mixed-ownership hunk, or tree drift.
@@ -187,11 +196,12 @@ pushing the scoped, proven fixes to the current tracked PR branch:
    Git configuration. This is execution isolation, not a validation bypass: phase 6 must already have
    run and passed every required hook check explicitly. Compare `git rev-parse HEAD^{tree}` with the
    tested tree after the guarded commit; stop on any mismatch and repeat proof at the new tree.
-4. Before pushing, revalidate the commit tree, live head SHA, remote repository identity, URL, and
-   target ref. Push normally to that verified destination with the same command-scoped empty hook
-   path so a repository-controlled pre-push hook cannot execute with credentials. Never use
-   `--no-verify`, force-push, rewrite history, switch branches, create another branch, or open another
-   PR without explicit authorization.
+4. Immediately before pushing, repeat the complete feedback-delta check from step 1 and require the
+   ledger and locked scope to remain valid. Revalidate the commit tree, live head SHA, remote
+   repository identity, URL, and target ref. Push normally to that verified destination with the
+   same command-scoped empty hook path so a repository-controlled pre-push hook cannot execute with
+   credentials. Never use `--no-verify`, force-push, rewrite history, switch branches, create another
+   branch, or open another PR without explicit authorization.
 5. Fetch the PR head again and record the pushed SHA. A local commit or successful `git push` message
    alone is not proof that the live PR contains the fix.
 

--- a/.claude/skills/resolve-pr-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-comments/SKILL.md
@@ -20,20 +20,29 @@ selected from [`validation-pipeline.md`](../../context/validation-pipeline.md).
 
 1. Resolve the repository and PR from the supplied URL or number. For current-branch requests,
    resolve the PR from local Git and GitHub metadata.
-2. Fetch fresh PR metadata and record its state, base branch, head branch, live head SHA, changed
-   files, and local HEAD. Require the PR to be `OPEN` before classification or editing. Report a
-   closed or merged PR as blocked; do not edit or publish commits to its former head branch.
-3. Before editing, require the writable checkout to be the tracked PR head branch at the exact live
-   head SHA. Refuse to edit or publish directly from `main`, `master`, or `develop`. If the checkout
-   is on another branch, detached, ahead, behind, or diverged, stop and request authorization to use
-   an isolated writable checkout at the live head. Do not contaminate the current branch.
-4. Inspect the working tree and index before editing. Preserve unrelated changes and do not unstage,
+2. Fetch fresh PR metadata and record its state; base repository and branch; head repository owner,
+   name, URL, and branch; cross-repository status; live head SHA; changed files; and local HEAD.
+   Require the PR to be `OPEN` before classification or editing. Report a closed or merged PR as
+   blocked; do not edit or publish commits to its former head branch.
+3. Before editing, require the writable checkout to be the tracked PR head repository and branch at
+   the exact live head SHA. Resolve the upstream fetch and push destinations to repository identity
+   and require the push destination plus ref to match the PR head repository plus branch; a matching
+   branch name or SHA on another remote is insufficient. Refuse to edit or publish directly from
+   `main`, `master`, or `develop`. If the checkout is on another branch, tracks another repository,
+   is detached, ahead, behind, or diverged, stop and request authorization to use an isolated
+   writable checkout at the live head. Do not contaminate the current branch.
+4. Establish the execution trust boundary before running repository-controlled code from the PR
+   head. For a fork or otherwise untrusted head, first inspect changes to dependency manifests,
+   lockfiles, package-manager configuration, hooks, workflows, agent instructions, and validation
+   scripts. Run commands only in an isolated credential-free, network-restricted sandbox, or stop
+   and report validation as blocked. Never expose local credentials to an untrusted PR head.
+5. Inspect the working tree and index before editing. Preserve unrelated changes and do not unstage,
    overwrite, stash, or commit another session's work.
-5. Establish an exact live-head inspection surface before classifying feedback. Use GitHub file
+6. Establish an exact live-head inspection surface before classifying feedback. Use GitHub file
    contents addressed by the live SHA, `git show <live-head-sha>:<path>`, or an isolated clean
    snapshot at that SHA. Use the current checkout only after proving tree identity for every
    affected path and confirming those paths have no staged, unstaged, or untracked changes.
-6. Treat descendant-only commits or working-tree changes as a separate, read-only observation until
+7. Treat descendant-only commits or working-tree changes as a separate, read-only observation until
    the branch mismatch is coordinated. Classify against the exact live-head tree first. An ancestry
    check alone is not proof of live-head behavior or authority to edit or push the descendant.
 
@@ -131,16 +140,26 @@ Do not resolve a thread merely because a local edit exists.
 ## 6. Prove closure
 
 1. Run the lightest honest targeted proof for the touched behavior.
-2. When commit or push is in scope, also run the full Ship Gate from
-   [`validation-pipeline.md`](../../context/validation-pipeline.md), including every conditional
-   addition for the touched surfaces. Every required stage must pass in the current invocation
-   before committing or pushing.
-3. For visible UI changes, obtain the required authenticated Brave rendered proof or report browser
+2. Before a mutating Ship Gate, use an isolated clean writable checkout, or prove the entire
+   formatter-covered working tree and index contain only the approved feedback paths. If unrelated
+   changes exist anywhere the formatter can rewrite, refuse publication instead of running the gate.
+   Apply the credential-free sandbox requirement from phase 1 to every untrusted head.
+3. When commit or push is in scope, define the exact approved path allowlist, require an empty index,
+   stage only those paths, and inspect the full cached diff before the Ship Gate. Select conditional
+   checks from the union of the committed PR diff and every allowlisted staged, unstaged, and
+   untracked path so new fixes cannot escape touched-surface detection.
+4. Run the full Ship Gate from [`validation-pipeline.md`](../../context/validation-pipeline.md),
+   including every conditional addition selected in step 3. Every required stage must pass in the
+   current invocation before committing or pushing. After each mutating stage, require every changed
+   path to remain inside the allowlist; restage approved formatter changes and rerun the affected
+   stage, but stop on any extra path.
+5. For visible UI changes, obtain the required authenticated Brave rendered proof or report browser
    QA as blocked.
-4. Repeat the root-cause search after all fixes. Any remaining approved manifestation keeps the
+6. Repeat the root-cause search after all fixes. Any remaining approved manifestation keeps the
    feedback cluster open.
-5. Re-read the changed code and record the exact tested state. Distinguish fixes present only in the
-   local working tree from fixes present on the live PR head.
+7. Re-read the changed code, require the allowlisted paths to have no unstaged or untracked changes,
+   and record the tested index tree with `git write-tree`. Distinguish fixes present only in the
+   tested index from fixes present in a commit or on the live PR head.
 
 Failed or unavailable targeted proof keeps the affected actionable feedback cluster unresolved. A
 failed or unavailable Ship Gate blocks commit and push even when the failure appears unrelated or
@@ -153,16 +172,20 @@ Unless the user asks to keep changes local, finish an existing-PR feedback task 
 pushing the scoped, proven fixes to the current tracked PR branch:
 
 1. Re-fetch the PR and require it to remain open with the same non-protected head branch and live
-   head SHA used for classification. Stop if the remote advanced or any branch invariant changed.
-2. Define the exact path allowlist for the approved feedback clusters before staging. If
-   `git diff --cached --name-only` already contains unrelated paths, stop or move the work to an
-   authorized isolated checkout. Never unstage another session's work to make the index appear safe.
-3. Stage only the allowlisted paths, then inspect `git diff --cached --name-only` and the full cached
-   diff. Require every staged path and hunk to belong to the locked feedback scope; stop on any
-   extra path or mixed-ownership hunk.
-4. Create a conventional commit from that verified index, then push normally to the tracked PR head
-   branch. Never use `--no-verify`, force-push, rewrite history, switch branches, create another
-   branch, or open another PR without explicit authorization.
+   head SHA used for classification. Reconfirm the head repository, push destination, trust boundary,
+   and tested-tree invariants from phases 1 and 6. Stop if the remote advanced or any invariant
+   changed.
+2. Re-inspect `git diff --cached --name-only` and the full cached diff. Require every staged path and
+   hunk to belong to the locked feedback scope and require `git write-tree` to equal the tested tree
+   recorded after the Ship Gate; stop on any extra path, mixed-ownership hunk, or tree drift.
+3. Create a conventional commit from that verified index. Compare `git rev-parse HEAD^{tree}` with
+   the tested tree to detect pre-commit hook rewrites. If they differ, do not push: rerun the full
+   Ship Gate at the created commit, and require it to pass without tracked changes before treating
+   that commit as tested. If validation mutates files, create another scoped commit and repeat the
+   tree-identity check.
+4. Push normally to the verified PR head repository and branch. Never use `--no-verify`, force-push,
+   rewrite history, switch branches, create another branch, or open another PR without explicit
+   authorization.
 5. Fetch the PR head again and record the pushed SHA. A local commit or successful `git push` message
    alone is not proof that the live PR contains the fix.
 
@@ -175,9 +198,11 @@ Before resolving an inline thread:
 2. Re-fetch the thread and ensure no newer reply or head change invalidates the conclusion.
 3. Summarize the root cause, bounded sweep, affected paths, and validation evidence concisely.
 4. Resolve only `ACTIONABLE` threads that are fixed and proven, `DUPLICATE` threads whose canonical
-   failure class is fixed and proven, `STALE` threads whose underlying concern is proven absent at
-   the live head, or threads closed by an explicit, accurate explanation accepted by the requested
-   workflow. Leave `RESOLVED` threads untouched.
+   failure class is fixed and proven, or `STALE` threads whose underlying concern is proven absent at
+   the live head. Resolve an explanation-only thread only after either the original reviewer accepts
+   or dismisses the explanation in a newer GitHub reply or review, or the user explicitly directs
+   closure after receiving the exact explanation and live-head evidence. General authorization to
+   resolve comments is not acceptance evidence. Leave `RESOLVED` threads untouched.
 
 Leave ambiguous, conflicting, out-of-scope, and unverified feedback open or unaddressed. Never use
 thread resolution to hide a deferred finding.
@@ -191,11 +216,12 @@ update through a subsequent review.
 
 Report:
 
-1. PR number and live head SHA reviewed.
+1. PR number, base and head repositories and branches, live head SHA, and execution-trust decision.
 2. Feedback ledger with source, classification, and root-cause clusters.
 3. Sweep boundary, affected paths, and checked-unaffected paths.
 4. Fixes made and regression coverage added.
-5. Exact validation run, results, and any blocked proof.
+5. Exact validation run, tested index tree, committed-tree comparison, results, and any blocked proof.
 6. Feedback still open or unaddressed and why.
-7. Commit SHA, push result, and verified live PR head, or why publication was blocked or declined.
+7. Commit SHA, verified push repository and ref, and verified live PR head, or why publication was
+   blocked or declined.
 8. GitHub conversational writes performed, or an explicit statement that none were performed.

--- a/.claude/skills/resolve-pr-comments/SKILL.md
+++ b/.claude/skills/resolve-pr-comments/SKILL.md
@@ -51,8 +51,9 @@ selected from [`validation-pipeline.md`](../../context/validation-pipeline.md).
 Collect complete PR feedback from all applicable review surfaces:
 
 - pull-request reviews with their state, body, author, submission time, and reviewed commit when
-  available; treat non-empty `CHANGES_REQUESTED` bodies as candidate actionable feedback and use
-  later review state plus the PR's `reviewDecision` to detect superseded or dismissed requests;
+  available; collect and classify every non-empty submitted review body regardless of state, using
+  `COMMENTED`, `APPROVED`, `CHANGES_REQUESTED`, later review state, and the PR's `reviewDecision` as
+  classification context rather than eligibility filters;
 - inline `reviewThreads` with `isResolved`, `isOutdated`, file and line anchors, the diff hunk, and
   every reply;
 - top-level PR conversation comments that contain actionable review feedback.
@@ -180,13 +181,15 @@ Unless the user asks to keep changes local, finish an existing-PR feedback task 
 pushing the scoped, proven fixes to the current tracked PR branch:
 
 1. After the Ship Gate, re-fetch the PR and every feedback surface to pagination completion. Require
-   it to remain open with the same non-protected head branch and live head SHA used for
-   classification. Compare the new feedback snapshot with the locked ledger and reclassify every
-   added or changed item. If a request was resolved, superseded, or revised, or new actionable
-   feedback changes the locked scope, stop and repeat the sweep, scope lock, fix, and affected proof
-   before committing. An unchanged head SHA does not prove stable feedback. Reconfirm the head
-   repository, push destination, trust boundary, and tested-tree invariants from phases 1 and 6.
-   Stop if the remote advanced or any invariant changed.
+   it to remain open with the same base repository and branch, non-protected head repository and
+   branch, and live head SHA used for classification. A base change alters the PR diff, changed-file
+   sweep, and conditional validation scope even when the head is unchanged; stop and repeat the
+   sweep, scope lock, fix, and affected proof if either base identity changes. Compare the new
+   feedback snapshot with the locked ledger and reclassify every added or changed item. If a request
+   was resolved, superseded, or revised, or new actionable feedback changes the locked scope, stop
+   and repeat the sweep, scope lock, fix, and affected proof before committing. An unchanged head
+   SHA does not prove stable feedback. Reconfirm the push destination, trust boundary, and
+   tested-tree invariants from phases 1 and 6. Stop if the remote advanced or any invariant changed.
 2. Re-inspect `git diff --cached --name-only` and the full cached diff. Require every staged path and
    hunk to belong to the locked feedback scope and require `git write-tree` to equal the tested tree
    recorded after the Ship Gate; stop on any extra path, mixed-ownership hunk, or tree drift.
@@ -213,12 +216,14 @@ Before resolving an inline thread:
 1. Confirm the fix is present on the live PR head, not only locally.
 2. Re-fetch the thread and ensure no newer reply or head change invalidates the conclusion.
 3. Summarize the root cause, bounded sweep, affected paths, and validation evidence concisely.
-4. Resolve only `ACTIONABLE` threads that are fixed and proven, `DUPLICATE` threads whose canonical
-   failure class is fixed and proven, or `STALE` threads whose underlying concern is proven absent at
-   the live head. Resolve an explanation-only thread only after either the original reviewer accepts
-   or dismisses the explanation in a newer GitHub reply or review, or the user explicitly directs
-   closure after receiving the exact explanation and live-head evidence. General authorization to
-   resolve comments is not acceptance evidence. Leave `RESOLVED` threads untouched.
+4. Resolve only `ACTIONABLE` threads whose exact manifestation is fixed and proven, `DUPLICATE`
+   threads whose own manifestation is fixed and proven or absent at the live head, or `STALE`
+   threads whose underlying concern is proven absent there. Fixing the canonical root-cause instance
+   alone is not proof for a duplicate manifestation; leave an unfixed out-of-scope duplicate open.
+   Resolve an explanation-only thread only after either the original reviewer accepts or dismisses
+   the explanation in a newer GitHub reply or review, or the user explicitly directs closure after
+   receiving the exact explanation and live-head evidence. General authorization to resolve
+   comments is not acceptance evidence. Leave `RESOLVED` threads untouched.
 
 Leave ambiguous, conflicting, out-of-scope, and unverified feedback open or unaddressed. Never use
 thread resolution to hide a deferred finding.

--- a/.claude/skills/resolve-pr-comments/agents/openai.yaml
+++ b/.claude/skills/resolve-pr-comments/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Resolve PR Comments"
-  short_description: "Validate, sweep, and fix PR feedback"
-  default_prompt: "Use $resolve-pr-comments to validate, sweep, and fix the unresolved review comments on this pull request."
+  short_description: "Validate, sweep, fix, and publish PR feedback"
+  default_prompt: "Use $resolve-pr-comments to validate, sweep, fix, commit, and push the unresolved review feedback on this pull request."
 
 policy:
   allow_implicit_invocation: true

--- a/.claude/skills/resolve-pr-comments/agents/openai.yaml
+++ b/.claude/skills/resolve-pr-comments/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Resolve PR Comments"
+  short_description: "Validate, sweep, and fix PR feedback"
+  default_prompt: "Use $resolve-pr-comments to validate, sweep, and fix the unresolved review comments on this pull request."
+
+policy:
+  allow_implicit_invocation: true

--- a/scripts/data/skill-trigger-eval.json
+++ b/scripts/data/skill-trigger-eval.json
@@ -127,6 +127,21 @@
       "expect": "review"
     },
     {
+      "id": "resolve-pr-comments-01",
+      "query": "Address every unresolved review comment on PR #482 and fix the similar instances the reviewer may have missed",
+      "expect": "resolve-pr-comments"
+    },
+    {
+      "id": "resolve-pr-comments-02",
+      "query": "The reviewer found swallowed errors in one mutation hook. Validate the comment, sweep the other mutation hooks for the same issue, and fix the approved cases",
+      "expect": "resolve-pr-comments"
+    },
+    {
+      "id": "resolve-pr-comments-03",
+      "query": "Check which GitHub review threads still apply at the current PR head, implement the actionable feedback, and leave the stale ones alone",
+      "expect": "resolve-pr-comments"
+    },
+    {
       "id": "audit-01",
       "query": "Is the repo healthy? Feels like there's drift and dead code accumulating across packages",
       "expect": "audit"

--- a/scripts/data/skill-trigger-eval.json
+++ b/scripts/data/skill-trigger-eval.json
@@ -142,6 +142,16 @@
       "expect": "resolve-pr-comments"
     },
     {
+      "id": "resolve-pr-comments-04",
+      "query": "PR #482 has a Request changes review with feedback only in the review body. Address that feedback even though there are no inline comments",
+      "expect": "resolve-pr-comments"
+    },
+    {
+      "id": "resolve-pr-comments-neg-01",
+      "query": "The product brief changed. Please implement the requested changes to the onboarding copy",
+      "expect": "none"
+    },
+    {
       "id": "audit-01",
       "query": "Is the repo healthy? Feels like there's drift and dead code accumulating across packages",
       "expect": "audit"


### PR DESCRIPTION
## Summary
- Add a reusable workflow for validating, sweeping, fixing, and proving closure of actionable PR review feedback.
- Add skill metadata and trigger-evaluation cases for automatic invocation.

## Validation
- [ ] `bun run test` — not run (not requested)
- [ ] `bun format && bun lint` — not run (not requested)

Automated PR labels: `automated/codex`
Draft PR.