### PR TITLE
ci: bound Playwright apt access to prevent 30-minute install hangs

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,42 @@
+name: Setup Playwright Chromium
+description: Install Playwright's Chromium browser and system dependencies with bounded, retried network access
+
+runs:
+  using: composite
+  steps:
+    # `playwright install --with-deps` shells out to `apt-get update`, which has
+    # no default overall timeout. On 2026-08-18 (admin run 32097509859) the Azure
+    # regional mirror returned Ign for every noble index, apt failed over to
+    # archive.ubuntu.com, then stalled after the last InRelease fetch with zero
+    # output for 28m47s until the 30-minute job timeout killed it. The same step
+    # normally finishes in ~22s. Bounding the transfer turns a silent 30-minute
+    # hang into a fast failure that the retry below usually recovers on its own.
+    - name: Bound apt network access
+      shell: bash
+      run: |
+        sudo tee /etc/apt/apt.conf.d/99-green-goods-timeouts >/dev/null <<'EOF'
+        Acquire::http::Timeout "20";
+        Acquire::https::Timeout "20";
+        Acquire::Retries "2";
+        EOF
+
+    # Split from the browser download so the log names which half stalled: the
+    # apt leg (system libraries) or the CDN leg (Chromium itself).
+    - name: Install Playwright Chromium and system dependencies
+      shell: bash
+      run: |
+        retry() {
+          label="$1"
+          shift
+          for attempt in 1 2; do
+            if timeout --kill-after=30s 180s "$@"; then
+              return 0
+            fi
+            echo "::warning::${label} attempt ${attempt} failed or timed out after 180s; retrying"
+            sleep 30
+          done
+          echo "::error::${label} failed after 2 attempts"
+          return 1
+        }
+        retry "playwright install-deps" bunx playwright install-deps chromium
+        retry "playwright install chromium" bunx playwright install chromium

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -22,20 +22,35 @@ runs:
 
     # Split from the browser download so the log names which half stalled: the
     # apt leg (system libraries) or the CDN leg (Chromium itself).
+    #
+    # Retry budget must stay under the caller's `timeout-minutes`, which covers
+    # this whole action. `--kill-after` extends each attempt, so one attempt costs
+    # up to ATTEMPT_TIMEOUT + KILL_GRACE. Worst case is one leg nearly exhausting
+    # its budget before succeeding, then the other failing outright:
+    #   (180 + 30 + 149) + (2*180 + 30) = 749s, against a 900s cap.
+    # Keep that inequality true if any value here or `timeout-minutes` changes.
     - name: Install Playwright Chromium and system dependencies
       shell: bash
+      env:
+        ATTEMPT_TIMEOUT: 150s
+        KILL_GRACE: 30s
+        RETRY_BACKOFF: 30
+        MAX_ATTEMPTS: 2
       run: |
         retry() {
           label="$1"
           shift
-          for attempt in 1 2; do
-            if timeout --kill-after=30s 180s "$@"; then
+          for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+            if timeout --kill-after="$KILL_GRACE" "$ATTEMPT_TIMEOUT" "$@"; then
               return 0
             fi
-            echo "::warning::${label} attempt ${attempt} failed or timed out after 180s; retrying"
-            sleep 30
+            # Only back off when another attempt actually follows.
+            if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+              echo "::warning::${label} attempt ${attempt} failed or timed out after ${ATTEMPT_TIMEOUT}; retrying"
+              sleep "$RETRY_BACKOFF"
+            fi
           done
-          echo "::error::${label} failed after 2 attempts"
+          echo "::error::${label} failed after ${MAX_ATTEMPTS} attempts"
           return 1
         }
         retry "playwright install-deps" bunx playwright install-deps chromium

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -22,6 +22,7 @@ on:
       - "scripts/dev/env-check.js"
       - "scripts/quality/check-source-structure.js"
       - ".github/actions/setup-js/action.yml"
+      - ".github/actions/setup-playwright/action.yml"
       - ".github/workflows/admin.yml"
   pull_request:
     paths:
@@ -43,6 +44,7 @@ on:
       - "scripts/dev/env-check.js"
       - "scripts/quality/check-source-structure.js"
       - ".github/actions/setup-js/action.yml"
+      - ".github/actions/setup-playwright/action.yml"
       - ".github/workflows/admin.yml"
   workflow_dispatch:
     inputs:
@@ -178,7 +180,8 @@ jobs:
         run: bun run codegen
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        timeout-minutes: 15
+        uses: ./.github/actions/setup-playwright
 
       - name: Run admin Playwright project
         run: PLAYWRIGHT_APP=admin APP_ENV=test bunx playwright test --project=admin-ci

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -22,6 +22,7 @@ on:
       - "scripts/dev/env-check.js"
       - "scripts/quality/check-source-structure.js"
       - ".github/actions/setup-js/action.yml"
+      - ".github/actions/setup-playwright/action.yml"
       - ".github/workflows/client.yml"
   pull_request:
     paths:
@@ -43,6 +44,7 @@ on:
       - "scripts/dev/env-check.js"
       - "scripts/quality/check-source-structure.js"
       - ".github/actions/setup-js/action.yml"
+      - ".github/actions/setup-playwright/action.yml"
       - ".github/workflows/client.yml"
   workflow_dispatch:
     inputs:
@@ -181,7 +183,8 @@ jobs:
         run: bun run codegen
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        timeout-minutes: 15
+        uses: ./.github/actions/setup-playwright
 
       - name: Run client Playwright project
         run: PLAYWRIGHT_APP=client APP_ENV=test bunx playwright test --project=client-ci

--- a/.github/workflows/design.yml
+++ b/.github/workflows/design.yml
@@ -37,6 +37,7 @@ on:
       - "scripts/quality/check-story-quality.ts"
       - "vercel.json"
       - ".github/actions/setup-js/action.yml"
+      - ".github/actions/setup-playwright/action.yml"
       - ".github/workflows/design.yml"
   pull_request:
     paths:
@@ -66,6 +67,7 @@ on:
       - "scripts/quality/check-story-quality.ts"
       - "vercel.json"
       - ".github/actions/setup-js/action.yml"
+      - ".github/actions/setup-playwright/action.yml"
       - ".github/workflows/design.yml"
 
 permissions:
@@ -122,7 +124,8 @@ jobs:
         run: bun run --filter @green-goods/shared check:story-quality
 
       - name: Install Playwright Chromium
-        run: bunx playwright install --with-deps chromium
+        timeout-minutes: 15
+        uses: ./.github/actions/setup-playwright
 
       - name: Run Storybook interaction smoke tests
         run: bun run --filter @green-goods/shared test:stories:ci


### PR DESCRIPTION
## Summary

`bunx playwright install --with-deps chromium` shells out to `apt-get update`, which has no default overall timeout. On admin run [32097509859](https://github.com/greenpill-dev-guild/green-goods/actions/runs/32097509859) the Azure regional Ubuntu mirror returned `Ign` for every `noble` index, apt failed over to `archive.ubuntu.com`, then stalled after the last `InRelease` fetch with **zero output for 28m47s** until the 30-minute job timeout killed it:

```
04:01:30  Ign: http://azure.archive.ubuntu.com/ubuntu noble InRelease       ← retried 4x
04:01:38  Get:8 https://archive.ubuntu.com/ubuntu noble-security InRelease  ← failed over
04:30:26  ##[error]The operation was canceled.
```

The same step normally completes in **~22s** (last five runs: 22s / 22s / 28s / 22s), and an earlier run hung identically for 1780s. So this is an intermittent infrastructure fault with precedent, not slowness.

The blast radius was larger than one job. CI Gate polled 88 times, reported `Admin concluded cancelled`, and left PR #722 showing a red required check that no amount of waiting would clear — both the job and the gate needed manual reruns.

**What changed**

- New composite action `.github/actions/setup-playwright`, replacing the identical inline step in `admin.yml`, `client.yml`, and `design.yml`.
- Bounds apt transfers (`Acquire::http/https::Timeout "20"`, `Acquire::Retries "2"`). This is the actual fix — that 28-minute stall now aborts in ~60s.
- Retries each leg once behind a 180s `timeout` backstop, so a transient mirror fault self-heals instead of failing the PR.
- Splits `install-deps` from `install chromium` so the log names which half stalled. Diagnosing this incident required downloading raw job logs.
- Adds the new action to each workflow's `push` and `pull_request` path filters, mirroring the existing `.github/actions/setup-js/action.yml` entry.

Worst case drops from **30 minutes with no tests run** to **~13 minutes with two chances to succeed**. The typical path is unchanged at ~22s.

**Deliberately no browser cache.** `setup-js` documents an evidence-based decision against caching here (restore cost exceeded savings; the repository cache is already over its 10 GB quota and was evicting Foundry caches that do pay off). Caching also would not have helped — the browser download is not the slow part.

## Validation

- [ ] `bun run test` — **not run.** This change touches zero package source; the monorepo suite cannot exercise a workflow YAML change. The applicable guard is below.
- [x] `bun format && bun lint` — run non-mutating as `bun run format:check` (2238 files, no fixes) + `bun lint` (0 errors; 260 pre-existing solhint warnings on contracts, untouched by this PR).
- [x] `bun run test:validation-system` — **78/78 pass**, including `workflow-performance-parity.test.mjs`, the static guard for workflow pins, cache scope, and routing.
- [x] YAML parses on all four files; `bash -n` clean on the extracted shell.
- [x] Retry/timeout logic exercised in an `ubuntu:24.04` container: success passes through; an infinite hang is killed, retried, and fails cleanly; a fail-then-succeed case recovers on attempt 2.
- [x] apt accepts the config — `apt-config dump` returns all three values.
- [x] `playwright install-deps` confirmed a real subcommand in the pinned 1.60.0.

**This PR exercises its own change.** The repo's own selector confirms the added path filters make it trigger `Admin, Client, Design, Supply Chain Guardrails` — so the new install path runs three times here. Without the path-filter addition, none of those would have fired and the change would have shipped unexercised.

## Reviewer notes

- `.github/workflows/**` and `.github/actions/**` are security-sensitive surfaces per `CLAUDE.md`. This PR touches only those, adds no new third-party action, and pins nothing new.
- The fix is unproven against a *real* mirror outage — that failure is intermittent. The next occurrence is the true test, and it should present as a fast failure plus an automatic retry rather than a 30-minute stall.
- No Linear issue; this came out of triaging the #722 CI hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)