### PR TITLE
fix(contracts): gate Celo broadcast on the checked-out candidate

### DIFF
--- a/packages/contracts/script/deploy/celo-garden-accounts.ts
+++ b/packages/contracts/script/deploy/celo-garden-accounts.ts
@@ -16,6 +16,7 @@ import {
 } from "ethers";
 import { execCastCaptured, parseCastTransactionHash } from "../utils/cast-env";
 import { NetworkManager } from "../utils/network";
+import { assertReleaseOperatorSession, resolveCheckoutCommit } from "../utils/release-session";
 
 const CONTRACTS_ROOT = path.join(__dirname, "../..");
 const REPOSITORY_ROOT = path.join(CONTRACTS_ROOT, "../..");
@@ -655,11 +656,8 @@ async function verifyDeployedPlan(plan: CeloGardenAccountPlan): Promise<void> {
   }
 }
 
-function credentialArgs(expectedCommit: string): string[] {
-  const session = process.env.GG_RELEASE_OPERATOR_SESSION;
-  if (session !== expectedCommit) {
-    throw new Error("Broadcast release-operator session does not match the reviewed commit");
-  }
+function credentialArgs(): string[] {
+  assertReleaseOperatorSession(resolveCheckoutCommit(REPOSITORY_ROOT));
   const passwordFile = process.env.ETH_PASSWORD;
   if (!passwordFile || !fs.existsSync(passwordFile)) {
     throw new Error("Broadcast requires the release operator's temporary ETH_PASSWORD file");
@@ -667,7 +665,7 @@ function credentialArgs(expectedCommit: string): string[] {
   return ["--account", process.env.FOUNDRY_KEYSTORE_ACCOUNT ?? "green-goods-deployer", "--password-file", passwordFile];
 }
 
-function sendTransaction(transaction: PlannedTransaction, rpcUrl: string, expectedCommit: string): string {
+function sendTransaction(transaction: PlannedTransaction, rpcUrl: string): string {
   const output = execCastCaptured(
     [
       "send",
@@ -682,7 +680,7 @@ function sendTransaction(transaction: PlannedTransaction, rpcUrl: string, expect
       String(CELO_CHAIN_ID),
       "--rpc-url",
       rpcUrl,
-      ...credentialArgs(expectedCommit),
+      ...credentialArgs(),
       "--json",
     ],
     { cwd: CONTRACTS_ROOT, env: process.env },
@@ -729,7 +727,7 @@ async function executeBoundary(plan: CeloGardenAccountPlan, step: number, recove
   const pendingNonce = await provider.getTransactionCount(plan.sender, "pending");
   if (pendingNonce !== transaction.nonce)
     throw new Error(`Expected sender nonce ${transaction.nonce}, live ${pendingNonce}`);
-  const transactionHash = sendTransaction(transaction, networkManager.getRpcUrl("celo"), plan.releaseSourceCommit);
+  const transactionHash = sendTransaction(transaction, networkManager.getRpcUrl("celo"));
   const [receipt, liveTransaction] = await Promise.all([
     provider.waitForTransaction(transactionHash, 1, 120_000),
     provider.getTransaction(transactionHash),

--- a/packages/contracts/script/deploy/garden-safe-owners.ts
+++ b/packages/contracts/script/deploy/garden-safe-owners.ts
@@ -21,6 +21,7 @@ import {
 import { execCastCaptured, parseCastTransactionHash } from "../utils/cast-env";
 import { NetworkManager } from "../utils/network";
 import { buildReleaseLock, loadReleaseManifest, type ReleaseManifest } from "../utils/release-manifest";
+import { assertReleaseOperatorSession, resolveCheckoutCommit } from "../utils/release-session";
 import { retryRpcAvailability } from "../utils/rpc-retry";
 
 const CONTRACTS_ROOT = path.join(__dirname, "../..");
@@ -995,10 +996,8 @@ export function assertCheckpointReceiptBlock(recorded: CheckpointEntry, verified
   }
 }
 
-function foundryCredentialArgs(expectedCommit: string): string[] {
-  if (process.env.GG_RELEASE_OPERATOR_SESSION !== expectedCommit) {
-    throw new Error("Broadcast release-operator session does not match the reviewed commit");
-  }
+function foundryCredentialArgs(): string[] {
+  assertReleaseOperatorSession(resolveCheckoutCommit(REPOSITORY_ROOT));
   const account = process.env.FOUNDRY_KEYSTORE_ACCOUNT ?? "green-goods-deployer";
   const passwordFile = process.env.ETH_PASSWORD;
   if (!passwordFile || !fs.existsSync(passwordFile)) {
@@ -1007,7 +1006,7 @@ function foundryCredentialArgs(expectedCommit: string): string[] {
   return ["--account", account, "--password-file", passwordFile];
 }
 
-function sendTransaction(to: string, data: string, nonce: number, rpcUrl: string, expectedCommit: string): string {
+function sendTransaction(to: string, data: string, nonce: number, rpcUrl: string): string {
   const output = execCastCaptured(
     [
       "send",
@@ -1022,7 +1021,7 @@ function sendTransaction(to: string, data: string, nonce: number, rpcUrl: string
       String(CELO_CHAIN_ID),
       "--rpc-url",
       rpcUrl,
-      ...foundryCredentialArgs(expectedCommit),
+      ...foundryCredentialArgs(),
       "--json",
     ],
     { cwd: CONTRACTS_ROOT, env: process.env },
@@ -1248,7 +1247,6 @@ async function executeFinalDeployment(
       entry.transaction.data,
       entry.transaction.nonce,
       networkManager.getRpcUrl("celo"),
-      plan.releaseSourceCommit,
     );
   }
 

--- a/packages/contracts/script/utils/release-session.test.ts
+++ b/packages/contracts/script/utils/release-session.test.ts
@@ -1,0 +1,49 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import { assertReleaseOperatorSession, resolveCheckoutCommit } from "./release-session";
+
+const CONTRACTS_ROOT = path.join(__dirname, "../..");
+const REPOSITORY_ROOT = path.join(CONTRACTS_ROOT, "../..");
+const RELEASE_MANIFEST = path.join(CONTRACTS_ROOT, "config/commitment-pooling-release.json");
+
+describe("release operator broadcast session", () => {
+  it("accepts the session the operator exports for the current checkout", () => {
+    const checkout = resolveCheckoutCommit(REPOSITORY_ROOT);
+
+    expect(() => assertReleaseOperatorSession(checkout, checkout)).not.toThrow();
+  });
+
+  it("rejects a session unlocked for a different checkout", () => {
+    expect(() => assertReleaseOperatorSession("a".repeat(40), "b".repeat(40))).toThrow(
+      /does not match the checked-out candidate/u,
+    );
+  });
+
+  it("rejects a missing session", () => {
+    expect(() => assertReleaseOperatorSession("a".repeat(40), undefined)).toThrow(
+      /does not match the checked-out candidate/u,
+    );
+  });
+
+  it("rejects a checkout commit that is not an exact 40-character hash", () => {
+    expect(() => assertReleaseOperatorSession("abc", "abc")).toThrow(/exact 40-character checkout commit/u);
+  });
+
+  it("resolves the checkout commit as an exact 40-character hash", () => {
+    expect(resolveCheckoutCommit(REPOSITORY_ROOT)).toMatch(/^[0-9a-f]{40}$/u);
+  });
+
+  /**
+   * Regression guard for the gate that made every Celo broadcast boundary unrunnable. The wrappers
+   * compared the operator session to the release manifest `sourceCommit` while the operator pinned
+   * `git HEAD` to that same value, so broadcast required a commit that names its own hash.
+   */
+  it("does not gate broadcast on a release identity the checkout can never equal", () => {
+    const manifest = JSON.parse(fs.readFileSync(RELEASE_MANIFEST, "utf8")) as { sourceCommit: string };
+
+    expect(manifest.sourceCommit).not.toEqual(resolveCheckoutCommit(REPOSITORY_ROOT));
+  });
+});

--- a/packages/contracts/script/utils/release-session.ts
+++ b/packages/contracts/script/utils/release-session.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared broadcast-session assertions for the release operator's Bun wrappers.
+ *
+ * The operator unlocks one credential session per exact checkout: it asserts that `git HEAD` equals
+ * the reviewed candidate before and after every boundary, then exports that candidate as
+ * `GG_RELEASE_OPERATOR_SESSION`. A wrapper re-checks the session against its own checkout so a
+ * session unlocked for one candidate can never sign from a different tree.
+ *
+ * Release identity — the manifest `sourceCommit` and hash — is a separate property, asserted where
+ * the plan is validated. It cannot stand in for the checkout here: `sourceCommit` names the commit a
+ * release was frozen from, so requiring `HEAD == sourceCommit` would need a commit containing its
+ * own hash, which left every Celo boundary unrunnable.
+ */
+import { execFileSync } from "node:child_process";
+
+const EXACT_COMMIT = /^[0-9a-f]{40}$/u;
+
+export function resolveCheckoutCommit(repositoryRoot: string): string {
+  return execFileSync("git", ["rev-parse", "HEAD"], { cwd: repositoryRoot, encoding: "utf8" }).trim();
+}
+
+export function assertReleaseOperatorSession(
+  checkoutCommit: string,
+  session = process.env.GG_RELEASE_OPERATOR_SESSION,
+): void {
+  if (!EXACT_COMMIT.test(checkoutCommit)) {
+    throw new Error("Broadcast requires an exact 40-character checkout commit");
+  }
+  if (session !== checkoutCommit) {
+    throw new Error("Broadcast release-operator session does not match the checked-out candidate");
+  }
+}


### PR DESCRIPTION
## Problem

Stage one of the Celo release ceremony could never broadcast. Both Celo wrappers compared `GG_RELEASE_OPERATOR_SESSION` against the release manifest `sourceCommit`, while `release-operator.ts` pins `git HEAD` to that same session value:

- `release-operator.ts:768` — `assertArtifactCheckout` requires `HEAD == --commit`
- `release-operator.ts:792` — exports `GG_RELEASE_OPERATOR_SESSION = --commit`
- `celo-garden-accounts.ts:658` / `garden-safe-owners.ts:998` — require that session to equal `manifest.sourceCommit`

Together those demand `HEAD == manifest.sourceCommit`. Since `sourceCommit` lives inside the commit it names, satisfying it needs a commit containing its own hash. The manifest currently pins `fab5daef2…` (2026-08-12), a commit where neither Celo script exists yet.

Observed on a real attempt — it stopped before composing any transaction, sender nonce unchanged at 118:

```
Running Bun wrapper: settlement:garden-accounts:deploy:celo --step 1
Broadcast release-operator session does not match the reviewed commit
```

The Arbitrum lane never referenced this variable, which is why its release broadcast fine through the same operator and the defect went unnoticed.

## Fix

The property worth holding is that the credential session was unlocked for exactly this checkout — which `assertArtifactCheckout` already pins, before and after every boundary. Release identity is asserted separately where the plan is validated (`plan.releaseSourceCommit`/`releaseManifestHash` vs the manifest), and is unchanged.

Both wrappers now re-check the session against the checkout via a shared `script/utils/release-session.ts`. No release identity, manifest, lock, plan artifact, or ceremony sequencing changes.

## Proof

- `bun run --cwd packages/contracts test:script` — 22 files, 236 tests, 0 failed (6 new)
- `bun run --cwd packages/contracts typecheck` — clean
- `bunx biome check` on touched files — exit 0 (one pre-existing `options.step!` warning, untouched)
- `bun run check:source-structure` — pass
- Positive: with the session set to HEAD and no `ETH_PASSWORD`, both scripts now advance past the session gate to `Broadcast requires the release operator's temporary ETH_PASSWORD file`
- Negative: a session for a different candidate still fails closed in both scripts with `does not match the checked-out candidate`

No broadcast, Safe creation, or authority mutation occurred. No dependency, lockfile, workflow, or agent-config changes.

Refs PRD-819, PRD-821

🤖 Generated with [Claude Code](https://claude.com/claude-code)