### PR TITLE
chore(contracts): freeze the G$ settlement caps and fee policy

### DIFF
--- a/packages/contracts/config/commitment-pooling-release.json
+++ b/packages/contracts/config/commitment-pooling-release.json
@@ -279,16 +279,16 @@
       "recipientPolicy": "registered-garden-safe-only"
     },
     "caps": {
-      "maxTransferAmount": null,
-      "maxBatchAmount": null,
-      "maxPeriodAmount": null,
-      "periodDuration": null,
-      "maxBatchSize": null
+      "maxTransferAmount": "7000000000000000000000000",
+      "maxBatchAmount": "10000000000000000000000000",
+      "maxPeriodAmount": "15000000000000000000000000",
+      "periodDuration": "2592000",
+      "maxBatchSize": "2"
     },
     "feePolicy": {
       "mode": "disabled-until-authorized",
-      "maxFeeBps": null,
-      "maxFeeAmount": null,
+      "maxFeeBps": "0",
+      "maxFeeAmount": "0",
       "arbitrumReserveFloor": null,
       "celoReserveFloor": null
     }

--- a/packages/contracts/config/commitment-pooling-release.lock.json
+++ b/packages/contracts/config/commitment-pooling-release.lock.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "releaseId": "commitment-pooling-settlement-credit-v1",
   "sourceCommit": "fab5daef2eebbe83c1d444f6c148c682e122f1c3",
-  "manifestHash": "0x31c05bd61e7d8bcf187d6148e64f6f0415f34fb1fbe633b97e4cde1eef46c634",
+  "manifestHash": "0x2551245f9bbf071a28cc824fd8e101080f29e28f65e7f92e728bae183fcc5bae",
   "build": {
     "profile": "production",
     "solc": "0.8.28",

--- a/packages/contracts/script/utils/release-manifest.test.ts
+++ b/packages/contracts/script/utils/release-manifest.test.ts
@@ -62,9 +62,16 @@ describe("combined commitment release manifest", () => {
     duplicated.schemas[1].identity = duplicated.schemas[0].identity;
     expect(() => validateReleaseManifest(duplicated)).toThrow(/Duplicate schema identity/);
 
+    // The caps are frozen but the Roles module, keys, and condition hash are not, so enabling
+    // authority must still fail closed on the unset Zodiac identities.
     const authority = structuredClone(manifest);
     authority.safeAuthority.enabled = true;
-    expect(() => validateReleaseManifest(authority)).toThrow(/requires non-zero/);
+    expect(() => validateReleaseManifest(authority)).toThrow(/requires zodiacRoles\./);
+
+    const uncapped = structuredClone(manifest);
+    uncapped.safeAuthority.enabled = true;
+    uncapped.safeAuthority.caps.maxPeriodAmount = null;
+    expect(() => validateReleaseManifest(uncapped)).toThrow(/requires non-zero/);
 
     const numericGas = structuredClone(manifest);
     numericGas.chains.arbitrum.destinationGasLimit = 750_000 as unknown as string;


### PR DESCRIPTION
Fills the last empty decision in the settlement authority config. No authority is granted — `safeAuthority.enabled` stays `false` and `gardenSafes` stays empty, so no value-authority transaction can be built from this manifest.

## The decision

Anchored on the Good Labs pilot: $800/month in G$, protocol → garden, at $0.000117/G$ (~6.84M G$ per month). These caps are a blast radius, not a budget — `maxPeriodAmount` bounds what a fully compromised executor could move before intervention.

| Cap | Value | ≈ USD | Rationale |
|---|---|---|---|
| `maxTransferAmount` | 7M G$ | $819 | one full month to a single garden without splitting |
| `maxBatchAmount` | 10M G$ | $1,170 | sits below the period cap so a batch can't exhaust it |
| `maxPeriodAmount` | 15M G$ | $1,754 | ~2.2 months of real funding; worst-case loss per period |
| `periodDuration` | 2,592,000s | 30 days | matches the monthly allocation cadence |
| `maxBatchSize` | 2 | — | **not a choice** — see below |
| `maxFeeBps` / `maxFeeAmount` | 0 / 0 | — | fees off; the funder wants circulation, not a cut |

Chosen with ~2.2x headroom deliberately: a cap set too tight silently starts rejecting legitimate transfers, and you find out mid-disbursement. This survives G$ halving without blocking payments.

## Two things that were not decisions

`maxBatchSize` is fixed at 2 by `batching.releaseBatchSizeLimit`, which was measured, not picked — a 3-item acknowledgment costs 308,653 gas against a fixed 300,000 budget, so a larger batch would create settlements that can never confirm.

`arbitrumReserveFloor` and `celoReserveFloor` stay `null`. They must be non-zero before the module can unpause, but the value needs a live `quoteCommandFee` from a configured CCIP route, which doesn't exist yet. Guessing them here would be inventing a number.

## Proof

- `bun run --cwd packages/contracts test:script` — 21 files, 230 tests, 0 failed
- `typecheck` clean
- Lock regenerated via `release:manifest:write`; only `manifestHash` changes (`0x31c05bd6…` → `0x2551245f…`), `sourceCommit` untouched
- Manifest generation reports "Safe/Zodiac authority: disabled; no value-authority transaction can be built from this manifest"

The manifest test previously asserted that enabling authority throws on null caps. That premise is now gone, so it asserts both guards separately: enabling with caps set still fails closed on the unset Zodiac module/keys/condition hash, and explicitly nulling a cap still fails on the non-zero rule.

Note this changes a release lock's hash. The only artifacts asserting the old hash are regenerable files under `.generated/runtime/`.

Fixes PRD-822
Refs PRD-819

🤖 Generated with [Claude Code](https://claude.com/claude-code)