### PR TITLE
feat(contracts): add the Garden-bound relay broadcast path

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -141,6 +141,8 @@
     "settlement:garden-safes:release:celo": "bun script/release-operator.ts --stage garden-safes",
     "settlement:garden-relay:plan": "bun script/deploy/garden-account-relay.ts plan",
     "settlement:garden-relay:verify": "bun script/deploy/garden-account-relay.ts verify",
+    "settlement:garden-relay:deploy": "bun script/deploy/garden-account-relay.ts deploy --broadcast",
+    "settlement:garden-relay:release": "bun script/release-operator.ts --stage relay",
     "settlement:peer:plan:arbitrum": "bun script/deploy.ts settlement-peer --network arbitrum --pure-simulation",
     "settlement:peer:plan:celo": "bun script/deploy.ts settlement-peer --network celo --pure-simulation",
     "release:recover:arbitrum": "bun script/deploy.ts release-recover --network arbitrum",

--- a/packages/contracts/script/deploy/garden-account-relay.test.ts
+++ b/packages/contracts/script/deploy/garden-account-relay.test.ts
@@ -1,5 +1,46 @@
-import { describe, expect, it } from "vitest";
-import { buildDeterministicRelayPlan, parseArguments } from "./garden-account-relay";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { keccak256, toUtf8Bytes } from "ethers";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  assertNextRelayBoundary,
+  buildDeterministicRelayPlan,
+  loadRelayCheckpoint,
+  parseArguments,
+} from "./garden-account-relay";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) fs.rmSync(directory, { recursive: true, force: true });
+});
+
+function checkpointFixture(completed: number, planBody = '{"kind":"relay"}'): string {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), "relay-checkpoint-"));
+  temporaryDirectories.push(directory);
+  const planPath = path.join(directory, "garden-account-relay.json");
+  fs.writeFileSync(planPath, planBody);
+  if (completed > 0) {
+    fs.writeFileSync(
+      path.join(directory, "garden-account-relay.checkpoint.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        planHash: keccak256(toUtf8Bytes(planBody)),
+        completed: Array.from({ length: completed }, (_, index) => ({
+          step: index + 1,
+          kind: "BOUNDARY",
+          chainId: 42161,
+          transactionHash: `0x${String(index + 1)
+            .repeat(64)
+            .slice(0, 64)}`,
+          blockNumber: 100 + index,
+        })),
+      }),
+    );
+  }
+  return planPath;
+}
 
 const gardens = Array.from({ length: 18 }, (_, index) => `0x${(index + 1).toString(16).padStart(40, "0")}`);
 const safes = Array.from({ length: 18 }, (_, index) => `0x${(index + 101).toString(16).padStart(40, "0")}`);
@@ -43,7 +84,9 @@ describe("GardenAccount relay release plan", () => {
 
     expect(() => parseArguments(["deploy", "--step", "1"])).toThrow(/requires --broadcast/);
     expect(() => parseArguments(["deploy", "--broadcast"])).toThrow(/one explicit --step boundary/);
-    expect(() => parseArguments(["deploy", "--broadcast", "--step", "2"])).toThrow(/step-1 receipt/);
+    // A resumed lane recovers the prior receipt from its checkpoint, so the flag is not required
+    // at parse time; the binding itself is enforced when the boundary executes.
+    expect(parseArguments(["deploy", "--broadcast", "--step", "2"]).receipt).toBeUndefined();
     expect(() => parseArguments(["deploy", "--broadcast", "--step", "1", "--receipt", receipt])).toThrow(
       /no prerequisite receipt/,
     );
@@ -77,5 +120,37 @@ describe("GardenAccount relay release plan", () => {
   it("rejects duplicate or incomplete Garden/Safe bindings", () => {
     expect(() => buildDeterministicRelayPlan({ ...fixture(), gardens: gardens.slice(0, 17) })).toThrow(/18 unique/);
     expect(() => buildDeterministicRelayPlan({ ...fixture(), safes: safes.map(() => safes[0]) })).toThrow(/18 unique/);
+  });
+});
+
+describe("relay boundary checkpointing", () => {
+  it("resumes at the first uncheckpointed boundary and refuses to replay or skip", () => {
+    expect(assertNextRelayBoundary(1, 0)).toBe(1);
+    expect(assertNextRelayBoundary(3, 2)).toBe(3);
+    // Replaying a mined boundary and jumping over an unmined one both fail closed.
+    expect(() => assertNextRelayBoundary(2, 2)).toThrow(/next uncheckpointed boundary 3/);
+    expect(() => assertNextRelayBoundary(4, 2)).toThrow(/next uncheckpointed boundary 3/);
+    expect(() => assertNextRelayBoundary(1, 4)).toThrow(/next uncheckpointed boundary 5/);
+  });
+
+  it("reads a contiguous checkpoint and binds it to the exact reviewed plan", () => {
+    expect(loadRelayCheckpoint(checkpointFixture(0)).completed).toEqual([]);
+
+    const resumed = loadRelayCheckpoint(checkpointFixture(2));
+    expect(resumed.completed.map((entry) => entry.step)).toEqual([1, 2]);
+
+    // Regenerating the plan after a mined boundary must stop the lane, not silently resume.
+    const planPath = checkpointFixture(2);
+    fs.writeFileSync(planPath, '{"kind":"relay","regenerated":true}');
+    expect(() => loadRelayCheckpoint(planPath)).toThrow(/does not belong to the exact reviewed relay plan/);
+  });
+
+  it("rejects a checkpoint whose boundaries are not a contiguous prefix", () => {
+    const planPath = checkpointFixture(2);
+    const checkpointPath = planPath.replace(/\.json$/u, ".checkpoint.json");
+    const checkpoint = JSON.parse(fs.readFileSync(checkpointPath, "utf8"));
+    checkpoint.completed[1].step = 3;
+    fs.writeFileSync(checkpointPath, JSON.stringify(checkpoint));
+    expect(() => loadRelayCheckpoint(planPath)).toThrow(/contiguous boundary prefix/);
   });
 });

--- a/packages/contracts/script/deploy/garden-account-relay.test.ts
+++ b/packages/contracts/script/deploy/garden-account-relay.test.ts
@@ -23,11 +23,34 @@ function fixture() {
 }
 
 describe("GardenAccount relay release plan", () => {
-  it("accepts only inert planning and verification commands", () => {
+  it("keeps planning and verification inert and fails closed on unknown commands", () => {
     expect(parseArguments(["plan"]).command).toBe("plan");
     expect(parseArguments(["verify"]).command).toBe("verify");
-    expect(() => parseArguments(["deploy", "--broadcast"])).toThrow(/plan\|verify/);
-    expect(() => parseArguments(["plan", "--broadcast"])).toThrow(/requires a value/);
+    expect(parseArguments(["plan"]).broadcast).toBe(false);
+    expect(() => parseArguments(["enable"])).toThrow(/plan\|verify\|deploy/);
+    expect(() => parseArguments(["plan", "--broadcast"])).toThrow(/does not accept --broadcast/);
+    expect(() => parseArguments(["verify", "--step", "1"])).toThrow(/does not accept --step/);
+  });
+
+  it("binds every broadcast boundary to one step and its prior receipt", () => {
+    const receipt = `0x${"ab".repeat(32)}`;
+    expect(parseArguments(["deploy", "--broadcast", "--step", "1"])).toMatchObject({
+      command: "deploy",
+      broadcast: true,
+      step: 1,
+    });
+    expect(parseArguments(["deploy", "--broadcast", "--step", "4", "--receipt", receipt]).receipt).toBe(receipt);
+
+    expect(() => parseArguments(["deploy", "--step", "1"])).toThrow(/requires --broadcast/);
+    expect(() => parseArguments(["deploy", "--broadcast"])).toThrow(/one explicit --step boundary/);
+    expect(() => parseArguments(["deploy", "--broadcast", "--step", "2"])).toThrow(/step-1 receipt/);
+    expect(() => parseArguments(["deploy", "--broadcast", "--step", "1", "--receipt", receipt])).toThrow(
+      /no prerequisite receipt/,
+    );
+    expect(() => parseArguments(["deploy", "--broadcast", "--step", "5", "--receipt", receipt])).toThrow(
+      /--step must be between 1 and 4/,
+    );
+    expect(() => parseArguments(["deploy", "--broadcast", "--step", "0"])).toThrow(/--step must be between 1 and 4/);
   });
 
   it("derives one deterministic four-step cross-chain plan", () => {

--- a/packages/contracts/script/deploy/garden-account-relay.ts
+++ b/packages/contracts/script/deploy/garden-account-relay.ts
@@ -266,8 +266,6 @@ export function parseArguments(args: string[]): RelayCliOptions {
   if (command === "deploy") {
     if (!broadcast) throw new Error("deploy requires --broadcast");
     if (step === undefined) throw new Error("deploy requires one explicit --step boundary");
-    if (step > 1 && !receipt)
-      throw new Error(`Step ${step} requires the reviewed step-${step - 1} receipt via --receipt`);
     if (step === 1 && receipt) throw new Error("Step 1 has no prerequisite receipt");
   } else {
     if (broadcast) throw new Error(`${command} does not accept --broadcast`);
@@ -667,6 +665,54 @@ async function relayDeploymentStarted(plan: GardenAccountRelayPlan): Promise<boo
   return (await providerFor(SOURCE_CHAIN_ID, manager).getCode(plan.router.address, "latest")) !== "0x";
 }
 
+export interface RelayCheckpointEntry {
+  step: number;
+  kind: string;
+  chainId: number;
+  transactionHash: string;
+  blockNumber: number;
+}
+
+export interface RelayCheckpoint {
+  schemaVersion: 1;
+  planHash: string;
+  completed: RelayCheckpointEntry[];
+}
+
+function checkpointPath(planPath: string): string {
+  return planPath.replace(/\.json$/u, ".checkpoint.json");
+}
+
+function hashFileContent(filePath: string): string {
+  return keccak256(toUtf8Bytes(fs.readFileSync(filePath, "utf8")));
+}
+
+/**
+ * The checkpoint is bound to the exact reviewed plan. Regenerating the plan after a mined boundary
+ * must stop the lane rather than silently resume against different addresses or nonces.
+ */
+export function loadRelayCheckpoint(planPath: string): RelayCheckpoint {
+  const filePath = checkpointPath(planPath);
+  const planHash = hashFileContent(planPath);
+  if (!fs.existsSync(filePath)) return { schemaVersion: 1, planHash, completed: [] };
+  const checkpoint = readJson<RelayCheckpoint>(filePath);
+  if (checkpoint.schemaVersion !== 1 || checkpoint.planHash !== planHash) {
+    throw new Error("Checkpoint does not belong to the exact reviewed relay plan");
+  }
+  for (const [offset, entry] of checkpoint.completed.entries()) {
+    if (entry.step !== offset + 1) throw new Error("Checkpoint must be a contiguous boundary prefix");
+  }
+  return checkpoint;
+}
+
+export function assertNextRelayBoundary(selected: number, completed: number): number {
+  const nextBoundary = completed + 1;
+  if (selected !== nextBoundary) {
+    throw new Error(`Relay deploy must target the next uncheckpointed boundary ${nextBoundary}`);
+  }
+  return selected;
+}
+
 function recordBoundary(
   plan: GardenAccountRelayPlan,
   step: number,
@@ -701,6 +747,7 @@ function recordBoundary(
 export async function executeRelayBoundary(
   plan: GardenAccountRelayPlan,
   step: number,
+  planPath: string,
   priorReceipt?: string,
 ): Promise<void> {
   if (plan.transactions.length !== RELAY_BOUNDARIES) {
@@ -708,15 +755,24 @@ export async function executeRelayBoundary(
   }
   const transaction = plan.transactions[step - 1];
   if (!transaction || transaction.step !== step) throw new Error(`Reviewed plan has no boundary ${step}`);
+  const checkpoint = loadRelayCheckpoint(planPath);
+  assertNextRelayBoundary(step, checkpoint.completed.length);
   const manager = new NetworkManager();
   const provider = providerFor(transaction.chainId, manager);
 
   if (step > 1) {
     const prior = plan.transactions[step - 2];
+    // A resumed lane has no captured hash from this run, so the checkpointed receipt stands in.
+    const recorded = checkpoint.completed[step - 2]?.transactionHash;
+    const priorHash = priorReceipt ?? recorded;
+    if (!priorHash) throw new Error(`Step ${step} requires the reviewed step-${step - 1} receipt`);
+    if (recorded && priorReceipt && recorded !== priorReceipt) {
+      throw new Error(`Step-${step - 1} receipt differs from the checkpointed boundary`);
+    }
     // The prior boundary can live on the other chain, so its receipt is read there, not here.
     await assertReceiptMatchesBoundary(
       providerFor(prior.chainId, manager),
-      priorReceipt as string,
+      priorHash,
       plan.sender,
       prior,
       `Step-${step - 1} receipt`,
@@ -741,6 +797,14 @@ export async function executeRelayBoundary(
     `${transaction.kind} receipt`,
   );
   await assertBoundaryPostcondition(plan, step, manager);
+  checkpoint.completed.push({
+    step,
+    kind: transaction.kind,
+    chainId: transaction.chainId,
+    transactionHash,
+    blockNumber: receipt.blockNumber,
+  });
+  atomicWrite(checkpointPath(planPath), checkpoint);
   recordBoundary(plan, step, transactionHash, receipt.blockNumber);
   process.stdout.write(`${transaction.kind} verified as ${transactionHash}; close the credential session.\n`);
 }
@@ -769,6 +833,7 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
     await executeRelayBoundary(
       readJson<GardenAccountRelayPlan>(options.planPath),
       options.step as number,
+      options.planPath,
       options.receipt,
     );
     return;

--- a/packages/contracts/script/deploy/garden-account-relay.ts
+++ b/packages/contracts/script/deploy/garden-account-relay.ts
@@ -13,8 +13,11 @@ import {
   JsonRpcProvider,
   keccak256,
   toUtf8Bytes,
+  ZeroAddress,
 } from "ethers";
+import { execCastCaptured, parseCastTransactionHash } from "../utils/cast-env";
 import { NetworkManager } from "../utils/network";
+import { assertReleaseOperatorSession, resolveCheckoutCommit } from "../utils/release-session";
 
 const CONTRACTS_ROOT = path.join(__dirname, "../..");
 const REPOSITORY_ROOT = path.join(CONTRACTS_ROOT, "../..");
@@ -80,14 +83,22 @@ const RELAY_CONSTRUCTOR_TYPES = [
   "address[]",
   "address[]",
 ] as const;
-const ROUTER_INTERFACE = new Interface(["function bindDestinationRelay(address destinationRelay)"]);
+const ROUTER_INTERFACE = new Interface([
+  "function bindDestinationRelay(address destinationRelay)",
+  "function destinationRelay() view returns (address)",
+]);
 const GUARDIAN_INTERFACE = new Interface([
   "function owner() view returns (address)",
   "function isTrustedExecutor(address executor) view returns (bool)",
   "function setTrustedExecutor(address executor,bool trusted)",
 ]);
 
-type Command = "plan" | "verify";
+type Command = "plan" | "verify" | "deploy";
+
+/** Boundaries alternate chains, so every live read resolves its network from the plan, never a flag. */
+const NETWORK_BY_CHAIN: Readonly<Record<number, string>> = { [SOURCE_CHAIN_ID]: "arbitrum", [CELO_CHAIN_ID]: "celo" };
+const RELAY_BOUNDARIES = 4;
+const DEPLOYMENT_ARTIFACT = path.join(CONTRACTS_ROOT, "deployments/garden-account-relay.json");
 
 interface FoundryArtifact {
   bytecode?: { object?: string } | string;
@@ -211,22 +222,58 @@ function confinedRuntimePath(value: string): string {
   return resolved;
 }
 
-export function parseArguments(args: string[]): { command: Command; safePlanPath: string; planPath: string } {
+export interface RelayCliOptions {
+  command: Command;
+  safePlanPath: string;
+  planPath: string;
+  broadcast: boolean;
+  step?: number;
+  receipt?: string;
+}
+
+export function parseArguments(args: string[]): RelayCliOptions {
   const command = args[0] as Command | undefined;
-  if (!command || !["plan", "verify"].includes(command)) {
-    throw new Error("Use: garden-account-relay.ts plan|verify [--safe-plan <runtime path>] [--plan <runtime path>]");
+  if (!command || !["plan", "verify", "deploy"].includes(command)) {
+    throw new Error(
+      "Use: garden-account-relay.ts plan|verify|deploy [--safe-plan <runtime path>] [--plan <runtime path>]" +
+        " [--broadcast --step <1-4> [--receipt <prior boundary hash>]]",
+    );
   }
   let safePlanPath = DEFAULT_SAFE_PLAN;
   let planPath = DEFAULT_PLAN;
-  for (let index = 1; index < args.length; index += 2) {
+  let broadcast = false;
+  let step: number | undefined;
+  let receipt: string | undefined;
+  for (let index = 1; index < args.length; index += 1) {
     const key = args[index];
+    if (key === "--broadcast") {
+      broadcast = true;
+      continue;
+    }
     const value = args[index + 1];
     if (!value || value.startsWith("--")) throw new Error(`${key} requires a value`);
+    index += 1;
     if (key === "--safe-plan") safePlanPath = confinedRuntimePath(value);
     else if (key === "--plan") planPath = confinedRuntimePath(value);
-    else throw new Error(`Unknown argument: ${key}`);
+    else if (key === "--receipt") receipt = value;
+    else if (key === "--step") {
+      step = Number(value);
+      if (!Number.isInteger(step) || step < 1 || step > RELAY_BOUNDARIES) {
+        throw new Error(`--step must be between 1 and ${RELAY_BOUNDARIES}`);
+      }
+    } else throw new Error(`Unknown argument: ${key}`);
   }
-  return { command, safePlanPath, planPath };
+  if (command === "deploy") {
+    if (!broadcast) throw new Error("deploy requires --broadcast");
+    if (step === undefined) throw new Error("deploy requires one explicit --step boundary");
+    if (step > 1 && !receipt)
+      throw new Error(`Step ${step} requires the reviewed step-${step - 1} receipt via --receipt`);
+    if (step === 1 && receipt) throw new Error("Step 1 has no prerequisite receipt");
+  } else {
+    if (broadcast) throw new Error(`${command} does not accept --broadcast`);
+    if (step !== undefined || receipt !== undefined) throw new Error(`${command} does not accept --step or --receipt`);
+  }
+  return { command, safePlanPath, planPath, broadcast, step, receipt };
 }
 
 function initCode(bytecode: string, types: readonly string[], values: readonly unknown[]): string {
@@ -457,6 +504,247 @@ async function liveInputs(
   };
 }
 
+function networkFor(chainId: number): string {
+  const network = NETWORK_BY_CHAIN[chainId];
+  if (!network) throw new Error(`Relay plan names an unsupported chain: ${chainId}`);
+  return network;
+}
+
+function providerFor(chainId: number, manager: NetworkManager): JsonRpcProvider {
+  return new JsonRpcProvider(manager.getRpcUrl(networkFor(chainId)), chainId, { staticNetwork: true });
+}
+
+/**
+ * The release operator unlocks one credential session per checkout and asserts that git HEAD equals
+ * that candidate before and after every boundary, so broadcast re-checks the session against the
+ * checkout rather than any release identity.
+ */
+function credentialArgs(): string[] {
+  assertReleaseOperatorSession(resolveCheckoutCommit(REPOSITORY_ROOT));
+  const passwordFile = process.env.ETH_PASSWORD;
+  if (!passwordFile || !fs.existsSync(passwordFile)) {
+    throw new Error("Broadcast requires the release operator's temporary ETH_PASSWORD file");
+  }
+  return ["--account", process.env.FOUNDRY_KEYSTORE_ACCOUNT ?? "green-goods-deployer", "--password-file", passwordFile];
+}
+
+function sendRelayTransaction(transaction: PlannedRelayTransaction, rpcUrl: string): string {
+  const output = execCastCaptured(
+    [
+      "send",
+      transaction.to,
+      "--data",
+      transaction.data,
+      "--value",
+      transaction.value,
+      "--nonce",
+      String(transaction.nonce),
+      "--chain",
+      String(transaction.chainId),
+      "--rpc-url",
+      rpcUrl,
+      ...credentialArgs(),
+      "--json",
+    ],
+    { cwd: CONTRACTS_ROOT, env: process.env },
+    transaction.kind,
+  );
+  return parseCastTransactionHash(output, transaction.kind);
+}
+
+async function assertReceiptMatchesBoundary(
+  provider: JsonRpcProvider,
+  hash: string,
+  sender: string,
+  expected: PlannedRelayTransaction,
+  label: string,
+): Promise<void> {
+  const [receipt, sent] = await Promise.all([provider.getTransactionReceipt(hash), provider.getTransaction(hash)]);
+  if (
+    !receipt ||
+    receipt.status !== 1 ||
+    !sent ||
+    getAddress(sent.from) !== getAddress(sender) ||
+    getAddress(sent.to ?? ZeroAddress) !== getAddress(expected.to) ||
+    sent.data !== expected.data ||
+    sent.value !== 0n ||
+    sent.nonce !== expected.nonce
+  ) {
+    throw new Error(`${label} does not match the reviewed ${expected.kind} boundary`);
+  }
+}
+
+async function routerBinding(plan: GardenAccountRelayPlan, manager: NetworkManager): Promise<string> {
+  const router = new Contract(plan.router.address, ROUTER_INTERFACE, providerFor(SOURCE_CHAIN_ID, manager));
+  return getAddress((await router.destinationRelay()) as string);
+}
+
+async function relayTrusted(plan: GardenAccountRelayPlan, manager: NetworkManager): Promise<boolean> {
+  const guardian = new Contract(plan.guardian, GUARDIAN_INTERFACE, providerFor(CELO_CHAIN_ID, manager));
+  return (await guardian.isTrustedExecutor(plan.relay.address)) as boolean;
+}
+
+async function runtimeHash(provider: JsonRpcProvider, address: string): Promise<string> {
+  return keccak256(await provider.getCode(address, "latest"));
+}
+
+/**
+ * Each boundary asserts only the state its own step depends on. A blanket inertness check would be
+ * wrong here: after step 1 the router exists by design, so re-asserting the planned snapshot would
+ * refuse every later boundary.
+ */
+async function assertBoundaryPrecondition(
+  plan: GardenAccountRelayPlan,
+  step: number,
+  manager: NetworkManager,
+): Promise<void> {
+  const source = providerFor(SOURCE_CHAIN_ID, manager);
+  const celo = providerFor(CELO_CHAIN_ID, manager);
+  if (step === 1) {
+    if ((await source.getCode(plan.router.address, "latest")) !== "0x") {
+      throw new Error("Source router already has code at its deterministic address");
+    }
+    return;
+  }
+  if ((await runtimeHash(source, plan.router.address)) !== plan.router.runtimeCodeHash) {
+    throw new Error("Source router runtime does not match the reviewed plan");
+  }
+  if (step === 2) {
+    if ((await celo.getCode(plan.relay.address, "latest")) !== "0x") {
+      throw new Error("Celo relay already has code at its deterministic address");
+    }
+    return;
+  }
+  if ((await runtimeHash(celo, plan.relay.address)) !== plan.relay.runtimeCodeHash) {
+    throw new Error("Celo relay runtime does not match the reviewed plan");
+  }
+  const bound = await routerBinding(plan, manager);
+  if (step === 3) {
+    if (bound !== getAddress(ZeroAddress)) throw new Error("Source router destination is already bound");
+    return;
+  }
+  if (bound !== getAddress(plan.relay.address)) {
+    throw new Error("Source router is not bound to the reviewed relay");
+  }
+  if (await relayTrusted(plan, manager)) throw new Error("Guardian already trusts the reviewed relay");
+}
+
+async function assertBoundaryPostcondition(
+  plan: GardenAccountRelayPlan,
+  step: number,
+  manager: NetworkManager,
+): Promise<void> {
+  if (step === 1) {
+    if (
+      (await runtimeHash(providerFor(SOURCE_CHAIN_ID, manager), plan.router.address)) !== plan.router.runtimeCodeHash
+    ) {
+      throw new Error("Source router deployment did not produce the reviewed runtime");
+    }
+    return;
+  }
+  if (step === 2) {
+    if ((await runtimeHash(providerFor(CELO_CHAIN_ID, manager), plan.relay.address)) !== plan.relay.runtimeCodeHash) {
+      throw new Error("Celo relay deployment did not produce the reviewed runtime");
+    }
+    return;
+  }
+  if (step === 3) {
+    if ((await routerBinding(plan, manager)) !== getAddress(plan.relay.address)) {
+      throw new Error("Destination binding did not record the reviewed relay");
+    }
+    return;
+  }
+  if (!(await relayTrusted(plan, manager))) throw new Error("Guardian did not record trust for the reviewed relay");
+}
+
+export async function verifyDeployedRelay(plan: GardenAccountRelayPlan): Promise<void> {
+  const manager = new NetworkManager();
+  for (const step of [1, 2, 3, 4]) await assertBoundaryPostcondition(plan, step, manager);
+}
+
+async function relayDeploymentStarted(plan: GardenAccountRelayPlan): Promise<boolean> {
+  const manager = new NetworkManager();
+  return (await providerFor(SOURCE_CHAIN_ID, manager).getCode(plan.router.address, "latest")) !== "0x";
+}
+
+function recordBoundary(
+  plan: GardenAccountRelayPlan,
+  step: number,
+  transactionHash: string,
+  blockNumber: number,
+): void {
+  const existing = fs.existsSync(DEPLOYMENT_ARTIFACT)
+    ? readJson<{ boundaries?: Array<Record<string, unknown>> }>(DEPLOYMENT_ARTIFACT)
+    : {};
+  const boundaries = (existing.boundaries ?? []).filter((entry) => entry.step !== step);
+  boundaries.push({
+    step,
+    kind: plan.transactions[step - 1].kind,
+    chainId: plan.transactions[step - 1].chainId,
+    transactionHash,
+    blockNumber,
+  });
+  boundaries.sort((left, right) => Number(left.step) - Number(right.step));
+  atomicWrite(DEPLOYMENT_ARTIFACT, {
+    schemaVersion: 1,
+    kind: "GARDEN_ACCOUNT_RELAY_DEPLOYMENT_RECEIPTS",
+    sender: plan.sender,
+    router: plan.router.address,
+    relay: plan.relay.address,
+    guardian: plan.guardian,
+    authorityEnabled: false,
+    valueAuthorityGranted: false,
+    boundaries,
+  });
+}
+
+export async function executeRelayBoundary(
+  plan: GardenAccountRelayPlan,
+  step: number,
+  priorReceipt?: string,
+): Promise<void> {
+  if (plan.transactions.length !== RELAY_BOUNDARIES) {
+    throw new Error(`Reviewed plan does not contain the expected ${RELAY_BOUNDARIES} boundaries`);
+  }
+  const transaction = plan.transactions[step - 1];
+  if (!transaction || transaction.step !== step) throw new Error(`Reviewed plan has no boundary ${step}`);
+  const manager = new NetworkManager();
+  const provider = providerFor(transaction.chainId, manager);
+
+  if (step > 1) {
+    const prior = plan.transactions[step - 2];
+    // The prior boundary can live on the other chain, so its receipt is read there, not here.
+    await assertReceiptMatchesBoundary(
+      providerFor(prior.chainId, manager),
+      priorReceipt as string,
+      plan.sender,
+      prior,
+      `Step-${step - 1} receipt`,
+    );
+  }
+  await assertBoundaryPrecondition(plan, step, manager);
+
+  const pendingNonce = await provider.getTransactionCount(plan.sender, "pending");
+  if (pendingNonce !== transaction.nonce) {
+    throw new Error(
+      `Boundary ${step} expected sender nonce ${transaction.nonce} on chain ${transaction.chainId}, live ${pendingNonce}`,
+    );
+  }
+  const transactionHash = sendRelayTransaction(transaction, manager.getRpcUrl(networkFor(transaction.chainId)));
+  const receipt = await provider.waitForTransaction(transactionHash, 1, 180_000);
+  if (!receipt || receipt.status !== 1) throw new Error(`${transaction.kind} did not produce a successful receipt`);
+  await assertReceiptMatchesBoundary(
+    provider,
+    transactionHash,
+    plan.sender,
+    transaction,
+    `${transaction.kind} receipt`,
+  );
+  await assertBoundaryPostcondition(plan, step, manager);
+  recordBoundary(plan, step, transactionHash, receipt.blockNumber);
+  process.stdout.write(`${transaction.kind} verified as ${transactionHash}; close the credential session.\n`);
+}
+
 async function assertPlannedState(plan: GardenAccountRelayPlan): Promise<void> {
   const manager = new NetworkManager();
   const source = new JsonRpcProvider(manager.getRpcUrl("arbitrum"), SOURCE_CHAIN_ID, { staticNetwork: true });
@@ -475,11 +763,31 @@ async function assertPlannedState(plan: GardenAccountRelayPlan): Promise<void> {
 
 export async function main(args = process.argv.slice(2)): Promise<void> {
   const options = parseArguments(args);
+
+  if (options.command === "deploy") {
+    if (!fs.existsSync(options.planPath)) throw new Error(`Reviewed plan is missing: ${options.planPath}`);
+    await executeRelayBoundary(
+      readJson<GardenAccountRelayPlan>(options.planPath),
+      options.step as number,
+      options.receipt,
+    );
+    return;
+  }
+
   const reviewed =
     options.command === "verify" && fs.existsSync(options.planPath)
       ? readJson<GardenAccountRelayPlan>(options.planPath)
       : undefined;
   if (options.command === "verify" && !reviewed) throw new Error(`Reviewed plan is missing: ${options.planPath}`);
+
+  // Once the router exists the planned snapshot is no longer inert by design, so verification
+  // switches from "the plan is still broadcastable" to "the deployment matches the plan".
+  if (reviewed && (await relayDeploymentStarted(reviewed))) {
+    await verifyDeployedRelay(reviewed);
+    console.log("Deployed relay matches the reviewed plan: router, relay, destination binding, and Guardian trust.");
+    console.log("No transaction was signed or broadcast.");
+    return;
+  }
   const inputs = await liveInputs(
     options.safePlanPath,
     reviewed

--- a/packages/contracts/script/release-operator.test.ts
+++ b/packages/contracts/script/release-operator.test.ts
@@ -75,6 +75,10 @@ describe("release operator session", () => {
     }
     expect(CEREMONY_STAGES.get("garden-accounts")?.boundaries).toBe(2);
     expect(CEREMONY_STAGES.get("garden-safes")?.boundaries).toBe(18);
+    // The relay lane spans both chains, so its four boundaries are one reviewed stage.
+    expect(parseSessionOptions(["--commit", candidate, "--stage", "relay"]).stage).toBe("relay");
+    expect(CEREMONY_STAGES.get("relay")?.boundaries).toBe(4);
+    expect(plannedStageBoundaries("relay", 0)).toEqual([1, 2, 3, 4]);
   });
 
   it("resumes a staged lane after its checkpoint without replaying a mined boundary", () => {
@@ -172,6 +176,7 @@ describe("release operator session", () => {
     expect([...RELEASE_OPERATOR_COMMANDS.keys()]).toEqual([
       "settlement:garden-accounts:deploy:celo",
       "settlement:garden-safes:deploy:celo",
+      "settlement:garden-relay:deploy",
     ]);
     expect(
       assertAllowedOperatorCommand(

--- a/packages/contracts/script/release-operator.ts
+++ b/packages/contracts/script/release-operator.ts
@@ -686,6 +686,7 @@ function verifyDeployerPassword(passwordFile: string): string {
   return unlocked;
 }
 const GARDEN_SAFE_PLAN_PATH = path.join(CONTRACTS_ROOT, ".generated/runtime/42220-garden-safe-final.json");
+const RELAY_PLAN_PATH = path.join(CONTRACTS_ROOT, ".generated/runtime/garden-account-relay.json");
 
 /**
  * Resolves which boundaries a stage still has to run. Kept pure and separate from execution so the
@@ -766,8 +767,17 @@ async function runCeremonyStage(
   if (stage === "relay") {
     // Every relay boundary depends on the previous one's receipt, and consecutive boundaries sit on
     // different chains, so each hash is captured and handed to the next rather than copied by hand.
+    // A resumed lane starts at the first uncheckpointed boundary and lets the wrapper recover that
+    // boundary's prerequisite from its own checkpoint instead of replaying a mined transaction.
+    const completed = completedBoundaries(RELAY_PLAN_PATH);
+    const boundaries = plannedStageBoundaries(stage, completed);
+    if (boundaries.length === 0) {
+      console.log(`Stage ${stage} is already complete with ${completed} checkpointed boundaries.`);
+      return;
+    }
+    if (completed > 0) console.log(`Resuming stage ${stage} after ${completed} checkpointed boundaries.`);
     let receipt: string | undefined;
-    for (let boundary = 1; boundary <= definition.boundaries; boundary += 1) {
+    for (const boundary of boundaries) {
       console.log(`--- boundary ${boundary} of ${definition.boundaries} ---`);
       const args = ["--broadcast", "--step", String(boundary)];
       if (receipt) args.push("--receipt", receipt);

--- a/packages/contracts/script/release-operator.ts
+++ b/packages/contracts/script/release-operator.ts
@@ -25,11 +25,17 @@ const RELEASE_ARTIFACT_MUTATIONS = new Set([
 ]);
 const GARDEN_SAFE_ARTIFACT_PATH = "packages/contracts/deployments/42220-settlement-safes.json";
 const GARDEN_SAFE_ARTIFACT_MUTATIONS = new Set([GARDEN_SAFE_ARTIFACT_PATH]);
-const INTERACTIVE_ARTIFACT_MUTATIONS = new Set([...RELEASE_ARTIFACT_MUTATIONS, ...GARDEN_SAFE_ARTIFACT_MUTATIONS]);
+const RELAY_ARTIFACT_MUTATIONS = new Set(["packages/contracts/deployments/garden-account-relay.json"]);
+const INTERACTIVE_ARTIFACT_MUTATIONS = new Set([
+  ...RELEASE_ARTIFACT_MUTATIONS,
+  ...GARDEN_SAFE_ARTIFACT_MUTATIONS,
+  ...RELAY_ARTIFACT_MUTATIONS,
+]);
 
 export const RELEASE_OPERATOR_COMMANDS = new Map<string, string>([
   ["settlement:garden-accounts:deploy:celo", "one exact GardenAccount coordinator boundary"],
   ["settlement:garden-safes:deploy:celo", "one final native/G$-clear 2-of-3 Garden Safe boundary"],
+  ["settlement:garden-relay:deploy", "one zero-value Garden-bound relay boundary"],
 ] as const);
 
 const FORBIDDEN_ARGUMENTS = new Set([
@@ -46,6 +52,7 @@ const FORBIDDEN_ARGUMENTS = new Set([
 const RELEASE_OPERATOR_ARGUMENTS = new Map<string, ReadonlySet<string>>([
   ["settlement:garden-accounts:deploy:celo", new Set(["--plan", "--step", "--receipt"])],
   ["settlement:garden-safes:deploy:celo", new Set(["--plan", "--inventory", "--step", "--receipt"])],
+  ["settlement:garden-relay:deploy", new Set(["--plan", "--safe-plan", "--broadcast", "--step", "--receipt"])],
 ]);
 
 /**
@@ -54,7 +61,7 @@ const RELEASE_OPERATOR_ARGUMENTS = new Map<string, ReadonlySet<string>>([
  * boundary, and the first failure stops the run — while charging the operator one password entry
  * for the lane instead of one per boundary.
  */
-export type CeremonyStage = "garden-accounts" | "garden-safes";
+export type CeremonyStage = "garden-accounts" | "garden-safes" | "relay";
 
 export const CEREMONY_STAGES = new Map<CeremonyStage, { script: string; boundaries: number; label: string }>([
   [
@@ -71,6 +78,14 @@ export const CEREMONY_STAGES = new Map<CeremonyStage, { script: string; boundari
       script: "settlement:garden-safes:deploy:celo",
       boundaries: 18,
       label: "final 2-of-3 Garden Safes",
+    },
+  ],
+  [
+    "relay",
+    {
+      script: "settlement:garden-relay:deploy",
+      boundaries: 4,
+      label: "Garden-bound relay router, relay, destination binding, and Guardian trust",
     },
   ],
 ]);
@@ -745,6 +760,22 @@ async function runCeremonyStage(
     console.log(`Binding step-2 to the verified step-1 receipt ${receipt}.`);
     runStageBoundary(definition.script, ["--step", "2", "--receipt", receipt], environment, candidateCommit, false);
     console.log(`Stage ${stage} completed both boundaries.`);
+    return;
+  }
+
+  if (stage === "relay") {
+    // Every relay boundary depends on the previous one's receipt, and consecutive boundaries sit on
+    // different chains, so each hash is captured and handed to the next rather than copied by hand.
+    let receipt: string | undefined;
+    for (let boundary = 1; boundary <= definition.boundaries; boundary += 1) {
+      console.log(`--- boundary ${boundary} of ${definition.boundaries} ---`);
+      const args = ["--broadcast", "--step", String(boundary)];
+      if (receipt) args.push("--receipt", receipt);
+      const output = runStageBoundary(definition.script, args, environment, candidateCommit, true);
+      receipt = transactionHashFromBoundaryOutput(output, boundary);
+      if (boundary < definition.boundaries) console.log(`Binding boundary ${boundary + 1} to receipt ${receipt}.`);
+    }
+    console.log(`Stage ${stage} completed all ${definition.boundaries} boundaries.`);
     return;
   }
 


### PR DESCRIPTION
Builds the missing execution path for the relay lane, with checkpoint resume. **Nothing was broadcast.**

> **Stacked on #724.** Base is `fix/celo-release-operator-session-gate` so the diff shows only the relay work — it reuses `release-session.ts` from that PR. Merge #724 first, then retarget this to `develop`.

## Why this was needed

The relay was planned, unit-tested, and address-frozen, but had no way to execute. `garden-account-relay.ts` declared `type Command = "plan" | "verify"`, and the release operator's allowlist named no relay script. "Deploy the relay" meant building the path first.

## What's different from the account and Safe lanes

**Cross-chain boundaries.** Router and binding land on Arbitrum, relay and Guardian trust on Celo. Both existing deploy scripts hardcode Celo. Here the network resolves per boundary from the plan, and a prior boundary's receipt is read on the chain that produced it — step 2 verifies an Arbitrum receipt, step 3 a Celo one.

**Chained receipts across all four.** Every boundary depends on the previous receipt, so the stage captures each hash and passes it forward rather than asking the operator to copy hashes between password-gated sessions.

**Per-boundary preconditions.** A blanket inertness check would be wrong: after step 1 the router exists by design, so re-asserting the planned snapshot would refuse every later boundary. Each step asserts only what it depends on, then proves its own postcondition — reviewed runtime hash, recorded binding, or Guardian trust — before writing its receipt.

**Checkpoint resume.** Each boundary checkpoints beside its reviewed plan, using the same shape and contiguity rules as the Garden Safe lane. A resumed stage starts at the first uncheckpointed boundary; since a resumed run has no captured hash from its own process, the wrapper recovers that boundary's prerequisite from the checkpoint. An explicit `--receipt` still works and is cross-checked against the checkpointed hash rather than trusted over it. The checkpoint is bound to a hash of the exact plan, so regenerating the plan after a mined boundary stops the lane instead of silently resuming against different addresses or nonces.

**`verify` now distinguishes two states.** An untouched plan is checked for inertness as before; a started deployment is checked against achieved on-chain state.

**Artifact allowance.** The relay receipt artifact joins the operator's allowed mutations. Without it the checkout-drift guard would have aborted the stage after its first boundary.

## Proof

- `test:script` — 22 files, **240 tests**, 0 failed
- `typecheck` clean, `biome check` clean
- `verify` still passes pre-deployment against live chains

Live behaviour against both chains, valid session and no password file, so it can reach the signing gate but never sign:

| Case | Result |
|---|---|
| Step 1, valid session | preconditions + nonce check run, stops at `Broadcast requires the release operator's temporary ETH_PASSWORD file` |
| Step 1, wrong session | `session does not match the checked-out candidate` |
| Step 2 or 3, no checkpoint | `Relay deploy must target the next uncheckpointed boundary 1` |
| Step 2, bogus prior receipt | `Step-1 receipt does not match the reviewed DEPLOY_SOURCE_ROUTER boundary` |
| Step 3, out of order | `Step-2 receipt does not match the reviewed DEPLOY_CELO_RELAY boundary` |

Unit coverage added for replay, skip-ahead, plan drift, and non-contiguous checkpoints.

Three tests changed because their premise did: two asserted `deploy` was rejected outright and that exactly two commands were allowlisted; the third asserted a receipt-flag rule that moved from argument parsing into execution, where it can actually see the checkpoint. All were replaced with stronger coverage rather than loosened.

## Not included

No broadcast, no relay deployed, no Guardian mutation, no value authority. Running it is a separate authorized action:

```
bun run --cwd packages/contracts release:operator -- --commit <sha> --stage relay
```

Estimated cost across the four boundaries: ~0.000052 ETH on Arbitrum, ~0.604 CELO.

Refs PRD-819

🤖 Generated with [Claude Code](https://claude.com/claude-code)