### PR TITLE
fix(contracts): give the Roles ceremony a default role and open the recipient scope

### DIFF
--- a/packages/contracts/script/deploy/garden-roles.test.ts
+++ b/packages/contracts/script/deploy/garden-roles.test.ts
@@ -1,11 +1,12 @@
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as nodePath from "node:path";
-import { getAddress } from "ethers";
+import { Interface, getAddress } from "ethers";
 import { describe, expect, it } from "vitest";
 
 import {
   ALLOWANCE_KEY,
+  ROLE_KEY,
   assertNextRolesBoundary,
   assertPlanUnblocked,
   assertRegisteredSafes,
@@ -81,35 +82,31 @@ describe("Garden Roles modifier planning", () => {
 const SAFES = Array.from({ length: 18 }, (_, index) => `0x${(index + 1).toString(16).padStart(40, "0")}`);
 
 describe("G$ transfer permission tree", () => {
-  it("allows only the registered Safes, and only within the allowance", () => {
-    const conditions = buildTransferConditions(SAFES);
+  it("bounds the amount by the allowance and leaves the recipient open", () => {
+    const conditions = buildTransferConditions();
 
-    // One calldata match, one logical Or for the recipient, one allowance check, 18 leaves.
-    expect(conditions).toHaveLength(21);
+    // One calldata match plus one node per parameter: parameters map positionally, so the
+    // unconstrained recipient still needs a node of its own.
+    expect(conditions).toHaveLength(3);
     expect(conditions[0]).toMatchObject({ parent: 0, paramType: 5, operator: 5 });
-    // Logical nodes carry no paramType of their own; the leaves hold Static.
-    expect(conditions[1]).toMatchObject({ parent: 0, paramType: 0, operator: 2 });
+    expect(conditions[1]).toMatchObject({ parent: 0, paramType: 1, operator: 0 });
     expect(conditions[2]).toMatchObject({ parent: 0, paramType: 1, operator: 28 });
     expect(conditions[2].compValue).toContain(ALLOWANCE_KEY.slice(2));
-
-    const leaves = conditions.slice(3);
-    expect(leaves).toHaveLength(18);
-    expect(leaves.every((leaf) => leaf.parent === 1 && leaf.paramType === 1 && leaf.operator === 16)).toBe(true);
-    // Every registered Safe appears exactly once as an allowed recipient.
-    for (const safe of SAFES) {
-      expect(leaves.filter((leaf) => leaf.compValue.toLowerCase().endsWith(safe.slice(2).toLowerCase()))).toHaveLength(
-        1,
-      );
-    }
   });
 
-  it("refuses an allowlist that is not the exact registered set", () => {
-    expect(() => buildTransferConditions(SAFES.slice(0, 17))).toThrow(/all 18 registered Garden Safes/);
-    expect(() => buildTransferConditions([...SAFES.slice(0, 17), SAFES[0]])).toThrow(/duplicate Safe/);
+  it("keeps a static recipient allowlist out of the tree", () => {
+    // A recipient allowlist here would reject every contributor payout, loan principal, and refund,
+    // because those are paid to individuals rather than to a Garden Safe. Reintroducing one costs a
+    // Safe transaction per Garden to undo, so it is asserted against rather than left to review.
+    const conditions = buildTransferConditions();
+
+    expect(conditions.some((condition) => condition.operator === 16)).toBe(false);
+    expect(conditions.some((condition) => condition.operator === 2)).toBe(false);
+    expect(conditions.filter((condition) => condition.parent === 0)).toHaveLength(3);
   });
 
   it("commits the immutable permission facts and nothing mutable", () => {
-    const conditions = buildTransferConditions(SAFES);
+    const conditions = buildTransferConditions();
     const modifier = "0x679AEB80a481772Df85E2b93F8fDc5180EF422e1";
     const base = permissionsConfigHash(SAFE_A, modifier, conditions);
 
@@ -118,7 +115,7 @@ describe("G$ transfer permission tree", () => {
     expect(permissionsConfigHash(SAFE_B, modifier, conditions)).not.toEqual(base);
     expect(permissionsConfigHash(SAFE_A, SAFE_B, conditions)).not.toEqual(base);
     // So is any change to the reviewed tree.
-    const widened = buildTransferConditions([...SAFES.slice(0, 17), SAFE_B]);
+    const widened = [...conditions.slice(0, 2), { ...conditions[2], operator: 0 }];
     expect(permissionsConfigHash(SAFE_A, modifier, widened)).not.toEqual(base);
   });
 });
@@ -138,31 +135,54 @@ describe("EOA configuration boundaries", () => {
   }));
   const executor = "0xB8a7F3c3DfA407c45e05b7B2381233101938a84F";
 
-  it("orders six unsigned boundaries per Safe and transfers ownership last", () => {
-    const transactions = buildRolesTransactions(boundaries, buildTransferConditions(SAFES), executor);
+  it("orders seven unsigned boundaries per Safe and transfers ownership last", () => {
+    const transactions = buildRolesTransactions(boundaries, buildTransferConditions(), executor);
 
-    expect(transactions).toHaveLength(SAFES.length * 6);
+    expect(transactions).toHaveLength(SAFES.length * 7);
     expect(transactions.map((transaction) => transaction.step)).toEqual(
       Array.from({ length: transactions.length }, (_, index) => index + 1),
     );
-    expect(transactions.slice(0, 6).map((transaction) => transaction.kind)).toEqual([
+    expect(transactions.slice(0, 7).map((transaction) => transaction.kind)).toEqual([
       "DEPLOY_MODIFIER",
       "SCOPE_TARGET",
       "SCOPE_FUNCTION",
       "SET_ALLOWANCE",
       "ASSIGN_EXECUTOR",
+      "SET_DEFAULT_ROLE",
       "TRANSFER_OWNERSHIP",
     ]);
     // Ownership must leave the operator only after the role is fully scoped.
     for (let safeIndex = 0; safeIndex < SAFES.length; safeIndex += 1) {
-      const perSafe = transactions.slice(safeIndex * 6, safeIndex * 6 + 6);
+      const perSafe = transactions.slice(safeIndex * 7, safeIndex * 7 + 7);
       expect(perSafe.every((transaction) => transaction.safe === boundaries[safeIndex].safe)).toBe(true);
       expect(perSafe.at(-1)?.kind).toBe("TRANSFER_OWNERSHIP");
     }
   });
 
+  it("gives the executor a default role, which configureGardenRoute refuses a route without", () => {
+    const transactions = buildRolesTransactions(boundaries, buildTransferConditions(), executor);
+    const setDefaultRole = transactions.filter((transaction) => transaction.kind === "SET_DEFAULT_ROLE");
+
+    // assignRoles grants membership and enables the module, but leaves defaultRoles at zero, and
+    // configureGardenRoute reads exactly that field.
+    const expected = new Interface(["function setDefaultRole(address module, bytes32 roleKey)"]).encodeFunctionData(
+      "setDefaultRole",
+      [executor, ROLE_KEY],
+    );
+
+    expect(setDefaultRole).toHaveLength(SAFES.length);
+    expect(setDefaultRole.every((transaction) => transaction.data === expected)).toBe(true);
+    // It has to land while the operator still owns the modifier; afterwards only the Safe can.
+    for (let safeIndex = 0; safeIndex < SAFES.length; safeIndex += 1) {
+      const perSafe = transactions.slice(safeIndex * 7, safeIndex * 7 + 7);
+      expect(perSafe.findIndex((transaction) => transaction.kind === "SET_DEFAULT_ROLE")).toBeLessThan(
+        perSafe.findIndex((transaction) => transaction.kind === "TRANSFER_OWNERSHIP"),
+      );
+    }
+  });
+
   it("moves no value and touches only the factory or that Safe's own modifier", () => {
-    const transactions = buildRolesTransactions(boundaries, buildTransferConditions(SAFES), executor);
+    const transactions = buildRolesTransactions(boundaries, buildTransferConditions(), executor);
 
     expect(transactions.every((transaction) => transaction.value === "0")).toBe(true);
     for (const transaction of transactions) {

--- a/packages/contracts/script/deploy/garden-roles.ts
+++ b/packages/contracts/script/deploy/garden-roles.ts
@@ -94,7 +94,7 @@ export const PERIOD_DURATION = 2_592_000n;
 
 /** Zodiac Roles v2 enums, read from the pinned 2.1.0 Types.sol. */
 const ABI_TYPE = { None: 0, Static: 1, Calldata: 5 } as const;
-const OPERATOR = { Or: 2, Matches: 5, EqualTo: 16, WithinAllowance: 28 } as const;
+const OPERATOR = { Pass: 0, Or: 2, Matches: 5, EqualTo: 16, WithinAllowance: 28 } as const;
 
 const FACTORY_INTERFACE = new Interface([
   "function deployModule(address masterCopy, bytes initializer, uint256 saltNonce) returns (address)",
@@ -104,11 +104,13 @@ const ROLES_CONFIG_INTERFACE = new Interface([
   "function scopeFunction(bytes32 roleKey, address targetAddress, bytes4 selector, tuple(uint8 parent, uint8 paramType, uint8 operator, bytes compValue)[] conditions, uint8 options)",
   "function setAllowance(bytes32 key, uint128 balance, uint128 maxRefill, uint128 refill, uint64 period, uint64 timestamp)",
   "function assignRoles(address module, bytes32[] roleKeys, bool[] memberOf)",
+  "function setDefaultRole(address module, bytes32 roleKey)",
   "function transferOwnership(address newOwner)",
   "function owner() view returns (address)",
   "function avatar() view returns (address)",
   "function target() view returns (address)",
   "function isModuleEnabled(address module) view returns (bool)",
+  "function defaultRoles(address module) view returns (bytes32)",
   "function allowances(bytes32 key) view returns (uint128 refill, uint128 maxRefill, uint64 period, uint64 timestamp, uint128 balance)",
 ]);
 const ROLES_INTERFACE = new Interface(["function setUp(bytes initParams)"]);
@@ -169,6 +171,7 @@ export type RolesTransactionKind =
   | "SCOPE_FUNCTION"
   | "SET_ALLOWANCE"
   | "ASSIGN_EXECUTOR"
+  | "SET_DEFAULT_ROLE"
   | "TRANSFER_OWNERSHIP"
   | "ENABLE_MODULE";
 
@@ -198,7 +201,7 @@ export interface GardenRolesPlan {
   canonicalTarget: string;
   canonicalSelector: string;
   allowance: { balance: string; maxRefill: string; refill: string; period: string };
-  recipientAllowlist: string[];
+  registeredGardenSafes: string[];
   conditions: ConditionFlat[];
   conditionsEncoded: string;
   boundaries: RolesBoundary[];
@@ -295,25 +298,26 @@ export interface ConditionFlat {
 }
 
 /**
- * Scopes `transfer(address,uint256)` on canonical G$ so the role may send only to a registered
- * Garden Safe, and only within the periodic allowance.
+ * Scopes `transfer(address,uint256)` on canonical G$ so the role may move only G$, only by transfer,
+ * and only within the periodic allowance.
  *
  * The flat tree is breadth-first with parent indices. Node 0 matches the calldata; its children map
- * positionally to the two parameters. The recipient is a logical Or over one EqualTo per registered
- * Safe, which is how Roles expresses set membership — logical nodes carry no paramType of their
- * own, so the leaves hold Static.
+ * positionally to the two parameters, so a parameter that carries no constraint still needs a node.
+ *
+ * The recipient is deliberately unconstrained. Three of the five disbursement kinds pay an
+ * individual rather than a Garden Safe — contributor consideration pays `entry.contributor`, loan
+ * principal pays `loan.borrower`, and refunds pay `funding.refundAccount` — and those addresses are
+ * not knowable when the tree is frozen. A static allowlist would have made every contributor payout
+ * revert with PARAMETER_NOT_ALLOWED, and rewriting it later costs one Safe transaction per Garden
+ * because the ceremony hands each modifier to its Safe. What bounds the destination instead is the
+ * source-side payout plan, which is authenticated over CCIP and re-checked per kind before dispatch;
+ * what bounds the amount on this chain is the allowance below plus the executor's own caps.
  */
-export function buildTransferConditions(recipients: readonly string[]): ConditionFlat[] {
-  if (recipients.length !== EXPECTED_GARDEN_COUNT) {
-    throw new Error(`Recipient allowlist must name all ${EXPECTED_GARDEN_COUNT} registered Garden Safes`);
-  }
-  const unique = new Set(recipients.map((value) => getAddress(value)));
-  if (unique.size !== recipients.length) throw new Error("Recipient allowlist contains a duplicate Safe");
-
+export function buildTransferConditions(): ConditionFlat[] {
   const encoder = AbiCoder.defaultAbiCoder();
-  const conditions: ConditionFlat[] = [
+  return [
     { parent: 0, paramType: ABI_TYPE.Calldata, operator: OPERATOR.Matches, compValue: "0x" },
-    { parent: 0, paramType: ABI_TYPE.None, operator: OPERATOR.Or, compValue: "0x" },
+    { parent: 0, paramType: ABI_TYPE.Static, operator: OPERATOR.Pass, compValue: "0x" },
     {
       parent: 0,
       paramType: ABI_TYPE.Static,
@@ -321,15 +325,6 @@ export function buildTransferConditions(recipients: readonly string[]): Conditio
       compValue: encoder.encode(["bytes32"], [ALLOWANCE_KEY]),
     },
   ];
-  for (const recipient of recipients) {
-    conditions.push({
-      parent: 1,
-      paramType: ABI_TYPE.Static,
-      operator: OPERATOR.EqualTo,
-      compValue: encoder.encode(["address"], [getAddress(recipient)]),
-    });
-  }
-  return conditions;
 }
 
 /** The exact ConditionFlat[] payload scopeFunction receives, so proofs can execute these bytes. */
@@ -365,7 +360,7 @@ export function permissionsConfigHash(
   return keccak256(encoded);
 }
 
-/** Six ordered boundaries per Safe, in the order the frozen ownership model requires. */
+/** Seven ordered boundaries per Safe, in the order the frozen ownership model requires. */
 export function buildRolesTransactions(
   boundaries: readonly RolesBoundary[],
   conditions: readonly ConditionFlat[],
@@ -441,6 +436,15 @@ export function buildRolesTransactions(
       boundary.modifier,
       ROLES_CONFIG_INTERFACE.encodeFunctionData("assignRoles", [executor, [ROLE_KEY], [true]]),
     );
+    // assignRoles grants membership and enables the module, but leaves defaultRoles at zero.
+    // configureGardenRoute refuses any route whose modifier has no default role for the executor,
+    // and after the next boundary only the Safe can set it — so it has to happen here.
+    push(
+      boundary,
+      "SET_DEFAULT_ROLE",
+      boundary.modifier,
+      ROLES_CONFIG_INTERFACE.encodeFunctionData("setDefaultRole", [executor, ROLE_KEY]),
+    );
     // Ownership leaves the operator before the modifier can ever gain authority.
     push(
       boundary,
@@ -495,12 +499,12 @@ async function buildPlan(safePlanPath: string): Promise<GardenRolesPlan> {
     staticNetwork: true,
   });
 
-  // The recipient allowlist is the authority on where G$ may go, so it is checked against the
-  // receipt-backed registry rather than trusted from the supplied plan. Uniqueness alone would let a
-  // substituted zero-nonce Safe produce a perfectly valid tree and permission hash.
+  // Every Safe in the supplied plan must match the receipt-backed registry. The tree no longer
+  // encodes the recipient set, but the registry still decides which Safes get a modifier at all, so
+  // a substituted Safe would otherwise walk away with live G$ authority.
   assertRegisteredSafes(safePlan.entries);
-  const recipientAllowlist = safePlan.entries.map((entry) => getAddress(entry.safe));
-  const conditions = buildTransferConditions(recipientAllowlist);
+  const registeredGardenSafes = safePlan.entries.map((entry) => getAddress(entry.safe));
+  const conditions = buildTransferConditions();
 
   const boundaries: RolesBoundary[] = [];
   for (const entry of safePlan.entries) {
@@ -587,7 +591,7 @@ async function buildPlan(safePlanPath: string): Promise<GardenRolesPlan> {
       refill: MAX_PERIOD_AMOUNT.toString(),
       period: PERIOD_DURATION.toString(),
     },
-    recipientAllowlist,
+    registeredGardenSafes,
     conditions,
     conditionsEncoded: encodeConditions(conditions),
     boundaries,
@@ -978,11 +982,12 @@ export async function verifyDeployedRoles(plan: GardenRolesPlan): Promise<void> 
         failures.push(`Garden ${boundary.tokenId}: modifier is not deployed`);
         continue;
       }
-      const [avatar, target, owner, member, allowance, enabled] = await Promise.all([
+      const [avatar, target, owner, member, defaultRole, allowance, enabled] = await Promise.all([
         roles.avatar() as Promise<string>,
         roles.getFunction("target").staticCall() as Promise<string>,
         roles.owner() as Promise<string>,
         roles.isModuleEnabled(celoSettlementExecutor()) as Promise<boolean>,
+        roles.defaultRoles(celoSettlementExecutor()) as Promise<string>,
         roles.allowances(ALLOWANCE_KEY) as unknown as Promise<bigint[]>,
         safe.isModuleEnabled(boundary.modifier) as Promise<boolean>,
       ]);
@@ -992,6 +997,9 @@ export async function verifyDeployedRoles(plan: GardenRolesPlan): Promise<void> 
         failures.push(`Garden ${boundary.tokenId}: modifier is owned by ${owner}, not its Safe`);
       }
       if (!member) failures.push(`Garden ${boundary.tokenId}: executor is not a Roles member`);
+      if (defaultRole !== ROLE_KEY) {
+        failures.push(`Garden ${boundary.tokenId}: executor default role is ${defaultRole}, not the reviewed role key`);
+      }
       if (allowance[0] !== MAX_PERIOD_AMOUNT || allowance[2] !== PERIOD_DURATION) {
         failures.push(`Garden ${boundary.tokenId}: allowance does not match the frozen period cap`);
       }
@@ -1030,7 +1038,7 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
 
   const plan = await buildPlan(safePlanPath);
   atomicWrite(planPath, plan);
-  // The fork proof reads its fixture inside the EVM, where the full plan's 108 calldata payloads
+  // The fork proof reads its fixture inside the EVM, where the full plan's 126 calldata payloads
   // exhaust the test gas budget. This carries only what the proof executes.
   atomicWrite(ENABLE_PLAN, {
     schemaVersion: 1,
@@ -1060,10 +1068,13 @@ export async function main(args = process.argv.slice(2)): Promise<void> {
     allowanceKey: plan.allowanceKey,
     allowance: plan.allowance,
     conditionsEncoded: plan.conditionsEncoded,
+    executor: celoSettlementExecutor(),
     boundaries: plan.boundaries.slice(0, 2).map((boundary) => ({
+      garden: boundary.garden,
       safe: boundary.safe,
       modifier: boundary.modifier,
       saltNonce: boundary.saltNonce,
+      permissionsConfigHash: boundary.permissionsConfigHash,
     })),
   });
   console.log(

--- a/packages/contracts/script/release-operator.test.ts
+++ b/packages/contracts/script/release-operator.test.ts
@@ -80,10 +80,10 @@ describe("release operator session", () => {
     expect(CEREMONY_STAGES.get("relay")?.boundaries).toBe(4);
     expect(plannedStageBoundaries("relay", 0)).toEqual([1, 2, 3, 4]);
     // Six unsigned boundaries per Safe across all 18, resumed from its own checkpoint.
-    expect(CEREMONY_STAGES.get("garden-roles")?.boundaries).toBe(108);
-    expect(plannedStageBoundaries("garden-roles", 106)).toEqual([107, 108]);
-    expect(plannedStageBoundaries("garden-roles", 108)).toEqual([]);
-    expect(() => plannedStageBoundaries("garden-roles", 109)).toThrow(/but its plan defines 108/);
+    expect(CEREMONY_STAGES.get("garden-roles")?.boundaries).toBe(126);
+    expect(plannedStageBoundaries("garden-roles", 124)).toEqual([125, 126]);
+    expect(plannedStageBoundaries("garden-roles", 126)).toEqual([]);
+    expect(() => plannedStageBoundaries("garden-roles", 127)).toThrow(/but its plan defines 126/);
     // Enabling is its own stage with its own checkpoint, one boundary per Safe.
     expect(parseSessionOptions(["--commit", candidate, "--stage", "garden-roles-enable"]).stage).toBe(
       "garden-roles-enable",

--- a/packages/contracts/script/release-operator.ts
+++ b/packages/contracts/script/release-operator.ts
@@ -96,7 +96,7 @@ export const CEREMONY_STAGES = new Map<CeremonyStage, { script: string; boundari
     "garden-roles",
     {
       script: "settlement:garden-roles:deploy",
-      boundaries: 108,
+      boundaries: 126,
       label: "Roles modifier deployment, scoping, allowance, executor assignment, and ownership transfer",
     },
   ],
@@ -282,7 +282,7 @@ Ceremony stages:
   garden-accounts                          2 boundaries
   garden-safes                             18 boundaries
   relay                                    4 boundaries
-  garden-roles                             108 boundaries
+  garden-roles                             126 boundaries
   garden-roles-enable                      18 boundaries
 
 Unlocking the session is not broadcast authorization. Run only the exact stage and transaction

--- a/packages/contracts/test/fork/CeloGardenRolesPermission.t.sol
+++ b/packages/contracts/test/fork/CeloGardenRolesPermission.t.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.25;
 import { Test } from "forge-std/Test.sol";
 import { stdJson } from "forge-std/StdJson.sol";
 
+import { ICeloSettlementExecutor } from "../../src/interfaces/ICeloSettlementExecutor.sol";
+
 /**
  * Proves the reviewed G$ transfer permission on a pinned Celo fork.
  *
@@ -39,6 +41,9 @@ interface IRoles {
     )
         external;
     function assignRoles(address module, bytes32[] memory roleKeys, bool[] memory memberOf) external;
+    function setDefaultRole(address module, bytes32 roleKey) external;
+    function defaultRoles(address module) external view returns (bytes32);
+    function isModuleEnabled(address module) external view returns (bool);
     function execTransactionWithRole(
         address to,
         uint256 value,
@@ -167,6 +172,10 @@ contract CeloGardenRolesPermissionForkTest is Test {
         roles.scopeFunction(roleKey, canonicalToken, canonicalSelector, _planConditions(), 0);
         roles.setAllowance(allowanceKey, periodAmount, periodAmount, periodAmount, periodDuration, 0);
         roles.assignRoles(EXECUTOR, roleKeys, memberOf);
+        // assignRoles grants membership and enables the module but leaves defaultRoles at zero,
+        // which is the one field configureGardenRoute reads. It has to be written before ownership
+        // moves, because afterwards only the Safe can write it.
+        roles.setDefaultRole(EXECUTOR, roleKey);
         // Ownership moves to the Safe while the modifier is still inert.
         roles.transferOwnership(safe);
         vm.stopPrank();
@@ -282,7 +291,7 @@ contract CeloGardenRolesPermissionForkTest is Test {
         );
     }
 
-    function testFork_reviewedTreeAllowsOnlyRegisteredRecipientsWithinAllowance() public {
+    function testFork_reviewedTreeSettlesToARegisteredSafeWithinTheAllowance() public {
         uint256 amount = 1000e18;
         uint256 before = IERC20(canonicalToken).balanceOf(registeredRecipient);
 
@@ -291,22 +300,16 @@ contract CeloGardenRolesPermissionForkTest is Test {
     }
 
     /**
-     * Roles reverts on a condition violation regardless of the shouldRevert flag, which only governs
-     * whether an inner call's own revert bubbles. A denied transfer therefore fails loudly rather
-     * than returning false, and no G$ moves.
+     * Contributor consideration, loan principal, and refunds are all paid to an individual rather
+     * than to a Garden Safe, and those addresses are not knowable when the tree is frozen. A
+     * recipient allowlist here would have refused every one of them with PARAMETER_NOT_ALLOWED.
      */
-    function testFork_reviewedTreeRejectsUnregisteredRecipient() public {
+    function testFork_reviewedTreePaysAnIndividualContributor() public {
+        uint256 amount = 1000e18;
         uint256 before = IERC20(canonicalToken).balanceOf(outsider);
 
-        assertEq(
-            _expectConditionViolation(
-                canonicalToken, abi.encodeWithSelector(canonicalSelector, outsider, uint256(1000e18))
-            ),
-            STATUS_PARAMETER_NOT_ALLOWED,
-            "recipient was refused for the wrong reason"
-        );
-
-        assertEq(IERC20(canonicalToken).balanceOf(outsider), before, "unregistered address received G$");
+        assertTrue(_send(outsider, amount), "transfer to an individual contributor was refused");
+        assertEq(IERC20(canonicalToken).balanceOf(outsider) - before, amount, "contributor did not receive G$");
     }
 
     function testFork_reviewedTreeRejectsAmountAboveTheAllowance() public {
@@ -339,5 +342,39 @@ contract CeloGardenRolesPermissionForkTest is Test {
             STATUS_TARGET_ADDRESS_NOT_ALLOWED,
             "target was refused for the wrong reason"
         );
+    }
+
+    /**
+     * The ceremony and the executor were previously proven apart: this proof drove
+     * execTransactionWithRole, which carries an explicit role key, while the unit tests drove
+     * configureGardenRoute against a mock whose defaultRoles always answered. Neither crossed the
+     * seam, and the real ceremony left defaultRoles at zero — so all eighteen routes would have
+     * reverted with PolicyNotConfigured, after ownership had already moved to the Safes and only a
+     * Safe transaction per Garden could have fixed it. This drives the live executor against the
+     * real modifier the ceremony just finished configuring.
+     */
+    function testFork_configureGardenRouteAcceptsTheFinishedCeremony() public {
+        ICeloSettlementExecutor executor = ICeloSettlementExecutor(EXECUTOR);
+        address garden = plan.readAddress(".boundaries[0].garden");
+
+        assertEq(roles.defaultRoles(EXECUTOR), roleKey, "ceremony did not leave the executor a default role");
+        assertTrue(roles.isModuleEnabled(EXECUTOR), "ceremony did not leave the executor a Roles member");
+        assertTrue(ISafe(safe).isModuleEnabled(address(roles)), "ceremony did not leave the modifier enabled");
+
+        vm.prank(_executorOwner());
+        executor.configureGardenRoute(
+            garden, safe, address(roles), roleKey, allowanceKey, plan.readBytes32(".boundaries[0].permissionsConfigHash")
+        );
+
+        ICeloSettlementExecutor.GardenRoute memory route = executor.gardenRouteOf(garden);
+        assertEq(route.safe, safe, "route did not record the Garden Safe");
+        assertEq(route.rolesModifier, address(roles), "route did not record the modifier");
+        assertTrue(route.active, "route was not activated");
+    }
+
+    function _executorOwner() private view returns (address) {
+        (bool ok, bytes memory data) = EXECUTOR.staticcall(abi.encodeWithSignature("owner()"));
+        require(ok && data.length == 32, "could not read the executor owner");
+        return abi.decode(data, (address));
     }
 }


### PR DESCRIPTION
A security review of the Celo settlement authority, run before the Garden Roles ceremony, found two defects that would each have surfaced only *after* the ceremony finished and ownership of all eighteen modifiers had moved to their Safes.

## The ceremony never set a default role

`assignRoles` grants membership and enables the module, but leaves `defaultRoles` at zero — and `defaultRoles` is the one field `configureGardenRoute` reads:

```solidity
|| !roles.isModuleEnabled(address(this)) || roles.defaultRoles(address(this)) != roleKey
```

Every one of the eighteen routes would have reverted with `PolicyNotConfigured`, recoverable only by one Safe transaction per Garden.

It survived review because the two halves were proven apart. The fork proof drove `execTransactionWithRole`, which carries an explicit role key and never reads `defaultRoles`. The unit tests drove `configureGardenRoute` against a mock whose `defaultRoles` always answered. Neither crossed the seam.

The ceremony is now **seven boundaries per Safe (126 total)**, with `SET_DEFAULT_ROLE` landing while the operator still owns the modifier — afterwards only the Safe could write it.

## The permission tree could not pay contributors

The tree scoped the recipient to an `Or` over the eighteen registered Garden Safes. But three of the five disbursement kinds pay an individual, not a Safe:

| Kind | Recipient | Source |
|---|---|---|
| `ContributorConsideration` | `entry.contributor` | `PlanLib.sol:535` |
| `LoanPrincipal` | `loan.borrower` | `LoanLib.sol:96` |
| `Refund` | `funding.refundAccount` | `FundingLib.sol:251` |

Every one of those payouts would have been refused with `PARAMETER_NOT_ALLOWED` — including the contributor payouts gardeners are paid through.

Those addresses are not knowable when the tree is frozen, so the recipient is now an explicit `Pass`. **This is a real reduction in on-chain bounding and is deliberate:** the destination is bounded by the source-side payout plan, which is authenticated over CCIP and re-checked per kind before dispatch; the amount is bounded by the periodic allowance and the executor's own caps. A regression test fails if a static allowlist is ever reintroduced.

## Verification

`verifyDeployedRoles` now checks `defaultRoles` too — without it, verification would have reported all eighteen Gardens green while every route was unconfigurable.

- **8/8** on the pinned Celo fork (block 75,178,393), including a route committed end-to-end against the **live deployed executor** and a contributor payout to a non-Safe address
- **2050/2050** forge tests · **261/261** script tests
- `bun format` clean · `bun lint` 0 errors · `bun run build` ok

No `packages/contracts/src/` changes, so no ABI, release-lock, or deployment impact.

## Not included

The same review raised four should-fix items on `CeloSettlementExecutor` itself (Safe-side module check in `configureGardenRoute`, a distinct paused error on the execution path, and `maxBatchSize` + fee policy in the unpause readiness gate). They are not here because the release lock pins CREATE2 identities: changing the executor source moves the implementation *and* the proxy (`0xB8a7F3c3…` → `0xD4fc96d2…`), and `0xB8a7F3c3…` is live on Celo. The lock models a from-scratch deployment, not an upgrade, and `upgrade.ts` has no target for this contract. Those need their own upgrade lane.

Refs PRD-819

🤖 Generated with [Claude Code](https://claude.com/claude-code)