### PR TITLE
chore(claude): raise the proof bar for debugging, brainstorming, and review

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -162,6 +162,23 @@ geometry. Start at the failing output and trace backward through the data path.
 6. **Do not convert confirmed data/API/contract failures into UI styling investigations** unless
    the data is present and the rendered control is still collapsed, invisible, or unusable.
 
+### Hard-Bug Feedback Loop Gate
+
+Use this gate when the symptom has no exact failing assertion or observable loop, spans multiple
+layers, or survives the first evidence-backed fix attempt. Before expanding the hypothesis set:
+
+1. Establish one **red-capable signal** that fails for the reported symptom rather than for an
+   unrelated setup problem: a targeted test, exact command, boundary probe, or real-surface interaction.
+2. Minimize the reproduction while preserving the failure. Remove unrelated setup and inputs, not the
+   boundary where the symptom occurs.
+3. Make the loop deterministic, fast enough to repeat, and runnable by the agent in the current
+   environment. Record the exact input and failing output.
+4. Change one variable, rerun the same loop, and reject any explanation the loop falsifies.
+
+This gate does not replace required real-surface proof. A mocked or lower-layer test cannot certify an
+authenticated UI, wallet, passkey, deployment, or production-only symptom. If no red-capable loop can
+be established, state that proof limit and do not claim the eventual change fixed the original symptom.
+
 ### Phase 2: Hypothesis Testing
 
 Form one specific hypothesis ("X calls Y with null", not "something is wrong with the API"), test one variable at a time. After 3 failed fixes, STOP fixing — question the architecture and your assumptions before trying a fourth.

--- a/.claude/skills/plan/brainstorm.md
+++ b/.claude/skills/plan/brainstorm.md
@@ -57,10 +57,24 @@ Each sub-feature gets its own brief → plan → implementation cycle.
 
 Focus on: purpose, constraints, success criteria.
 
+Before asking the first question, maintain an internal **decision frontier**:
+
+1. List the unresolved decisions and the dependencies between them.
+2. Resolve repository facts from code, docs, plans, or live state; do not turn research work into a
+   user question.
+3. Treat the current frontier as the unresolved decisions whose prerequisites are already known.
+4. Ask the highest-impact frontier question, with a recommended answer and the tradeoff behind it.
+5. Update the frontier after each answer. Brainstorming is ready to advance only when no silent
+   assumptions remain; anything intentionally deferred must appear under `Open questions` in the brief.
+
+The frontier is a reasoning aid, not a second planning artifact. Do not create a separate decision
+ledger or expose a wall of questions when the one-at-a-time dialogue is sufficient.
+
 **Rules:**
 - One question per message. No stacking.
 - Prefer multiple choice when the option space is small. Open-ended is fine when it isn't.
 - Don't ask about things the code already answers.
+- For a human decision, state the recommended option and why it best fits the known constraints.
 
 **Good questions:**
 - "For the garden creation flow — should draft state persist across sessions, or only within the same tab? (a) cross-session via IndexedDB, (b) tab-only via sessionStorage, (c) no persistence"

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -89,6 +89,23 @@ Correctness of what changed. Prioritize high-signal risk areas:
 
 For large or critical diffs where an adversarial deep pass is warranted, the built-in `/code-review` (effort levels, verify pass) is the engine of choice — say so and use it rather than hand-rolling depth.
 
+### Safety facts for cross-package and critical reviews
+
+For `--scope cross-package` and any critical-surface review, choose the one or two highest-risk
+invariants whose failure would invalidate the change. Report each as a compact safety fact:
+
+- **Fact** — the precise invariant or compatibility claim being evaluated
+- **Consumers** — the affected callers, packages, deployments, or runtime paths
+- **Proof level** — the strongest evidence actually obtained:
+  `REFERENCED` (claimed by source or docs), `PATH_TRACED` (call/data path followed),
+  `DEPENDENCY_WALKED` (direct consumers checked), `EXECUTED` (targeted check passed), or
+  `LIVE_OBSERVED` (required runtime or rendered surface observed)
+- **Evidence and limit** — command, path, output, and anything still unproven
+
+Proof levels are descriptive, not a maturity ladder that every review must climb. Use the level the
+review intent requires, never promote a fact based on indirect evidence, and turn a missing required
+proof into a finding, gap, or blocker under the existing verdict rules.
+
 ## Pass 2 — Remaining Gaps
 
 Completeness against the authoritative requirements established during scoping. Map every requirement to implementation and evidence with an explicit status: `SATISFIED`, `MISSING`, `BLOCKED`, or `OUT_OF_SCOPE`. Any `MISSING` requirement produces `REQUEST_CHANGES`; any `BLOCKED` requirement prevents `APPROVE` and produces `COMMENT_ONLY` unless other findings already require changes.
@@ -173,7 +190,8 @@ inventing a capability.
 
 Lead with findings, keep the list actionable:
 
-1. **Summary** — scope, blast radius, lenses that fired (with triggering signal), intent sources used
+1. **Summary** — scope, blast radius, lenses that fired (with triggering signal), intent sources used,
+   and safety facts when cross-package or critical review rules require them
 2. **Must-Fix** (critical/high) · **Should-Fix** (medium) · **Nice-to-Have** (low, keep short)
 3. **Remaining Gaps** — unfinished intent, each with the smallest completing step
 4. **Human Call-Outs** — dependencies, auth/permissions, migrations, contract deploys, trust-boundary changes (never auto-fix these)

--- a/docs/docs/builders/quality/agentic-eval.mdx
+++ b/docs/docs/builders/quality/agentic-eval.mdx
@@ -4,7 +4,7 @@ sidebar_label: Agentic Eval
 slug: /builders/quality/agentic-eval
 audience: developer
 owner: docs
-last_verified: 2026-07-11
+last_verified: 2026-08-18
 feature_status: Live
 source_of_truth:
   - AGENTS.md
@@ -13,6 +13,8 @@ source_of_truth:
   - docs/routines/health-watch.md
   - scripts/quality/check-codex-docs.js
   - scripts/dev/ci-local.js
+  - scripts/harness/skill-trigger-eval.mjs
+  - scripts/data/skill-trigger-eval.json
   - .claude/loop.md
 keywords: [agentic evaluation, acceptance cases, guidance guardrails, inner loop, test generation]
 ---
@@ -47,9 +49,53 @@ flowchart LR
 | `.claude/evals/` (incl. `acceptance/`) | Committed eval directories | Retired |
 | `check-skill-frontmatter.js` / `bun run check:claude-guidance` | Skill registry/frontmatter structural checks | Retired |
 
-The `.claude/evals/` directory is gone entirely -- the lean-skills consolidation removed its last live surface (`acceptance/`) along with the skills registry, after the automated benchmark packs for `triage`, `code-reviewer`, `oracle`, and `cracked-coder` had already been retired. There are no committed agent definitions anymore either; specialization routes through the 9 skills, built-in subagent types, and plan-hub lanes. Drift around that retirement state is handled by CI guidance checks (`check-guidance-links.mjs` in the supply-chain workflow), Claude routines, Copilot automatic review, and human review instead of a dedicated eval workflow.
+The `.claude/evals/` directory is gone entirely -- the lean-skills consolidation removed its last live surface (`acceptance/`) along with the skills registry, after the automated benchmark packs for `triage`, `code-reviewer`, `oracle`, and `cracked-coder` had already been retired. There are no committed agent definitions anymore either; specialization routes through the repo-local skills, built-in subagent types, and plan-hub lanes. Drift around that retirement state is handled by CI guidance checks (`check-guidance-links.mjs` in the supply-chain workflow), Claude routines, Copilot automatic review, and human review instead of a dedicated eval workflow.
 
-One deliberately small eval survives the retirement: `bun run eval:skills` (`scripts/harness/skill-trigger-eval.mjs` + `scripts/data/skill-trigger-eval.json`) routes ~30 realistic queries against the live `SKILL.md` frontmatter descriptions through a single cheap `claude -p` call. It tests **description routing only** -- not harness trigger behavior and not skill output quality -- and exists to catch description regressions after trigger edits (a trimmed description that stops firing, a greedy one that swallows a sibling's queries). It runs on demand, never in CI.
+One deliberately small eval survives the retirement: `bun run eval:skills` (`scripts/harness/skill-trigger-eval.mjs` + `scripts/data/skill-trigger-eval.json`) routes the fixture's realistic queries against the live `SKILL.md` frontmatter descriptions through a single cheap `claude -p` call. It tests **description routing only** -- not harness trigger behavior and not skill output quality -- and exists to catch description regressions after trigger edits (a trimmed description that stops firing, a greedy one that swallows a sibling's queries). It runs on demand, never in CI.
+
+### Skill Lifecycle Policy
+
+The filesystem remains the skill registry. Keep the repo skill surface small by updating an existing
+workflow unless a candidate clears every addition gate:
+
+1. **Unique trigger** -- an existing skill cannot own the request without making its description or
+   completion contract ambiguous.
+2. **Repeated or critical workflow** -- evidence from recurring tasks justifies reuse, or the workflow
+   protects a critical safety boundary.
+3. **Observable completion** -- the skill produces a defined artifact, decision, proof, or terminal state.
+4. **Canonical policy** -- shared invariants stay in `AGENTS.md`, `CLAUDE.md`, or `.claude/context/`;
+   the skill links to them instead of copying a second policy.
+5. **Evaluation** -- positive, near-neighbor, and negative routing cases cover trigger changes, and
+   decision-changing body edits receive behavior evaluation proportional to risk.
+
+Prefer progressive disclosure: `SKILL.md` owns the trigger, ordered workflow, essential constraints,
+and completion contract; substantial conditional procedures live in references that the entrypoint
+loads only when needed. Do not add a reference, script, template, or parallel state ledger without a
+concrete caller and a deletion or consolidation story.
+
+Merge or retire a skill when it has no distinct trigger, only restates canonical guidance, is fully
+covered by another workflow, or creates more routing uncertainty than procedural clarity. Avoid
+hardcoded inventory counts in prose; derive them from the filesystem or fixture when a count is
+operationally necessary.
+
+### Behavior Evaluation for Substantive Skill Changes
+
+Trigger routing is insufficient when a change alters decisions, ordering, stopping conditions,
+permissions, evidence standards, or output contracts. For those changes, run a disposable blinded
+comparison when the risk justifies the model cost and the required delegation is authorized:
+
+1. Choose one realistic task that exercises the changed decision boundary.
+2. Run the task against the before and after skill using the same prompt, model, tools, repository
+   snapshot, and authorization boundary.
+3. Keep generated artifacts in isolated temporary workspaces. Do not restore committed benchmark packs.
+4. Anonymize the results before judging task success, corrections required, evidence quality,
+   unnecessary work, and scope preservation.
+5. Keep only the conclusion and the smallest supported skill change. A failed comparison is evidence
+   to revise or reject the change, not a reason to weaken the rubric.
+
+Narrow wording or link fixes do not require this comparison unless they change behavior. Critical
+contract, auth, JobQueue, Work-provider, mutation, deployment, or external-write workflows should
+receive the strongest practical evaluation before their instructions are treated as stable.
 
 ### Model Selection
 


### PR DESCRIPTION
Four guidance surfaces gain the same underlying discipline: **name the evidence you actually have, and don't let an indirect signal stand in for a direct one.**

## `debug` — hard-bug feedback loop gate

Fires when the symptom has no exact failing assertion, spans layers, or survives the first evidence-backed fix. Requires a red-capable signal, a minimized reproduction, a deterministic loop the agent can actually run, and one variable at a time.

It also states the proof limit plainly: a mocked or lower-layer test cannot certify an authenticated UI, wallet, passkey, deployment, or production-only symptom. If no red-capable loop can be established, say so rather than claiming the change fixed the original symptom.

## `plan/brainstorm` — decision frontier

Track unresolved decisions and their dependencies. Resolve repository facts from the repository, not from the user. Ask the highest-impact question whose prerequisites are already known, with a recommended answer and the tradeoff attached.

Explicitly a reasoning aid, not a second planning artifact — no separate decision ledger, no wall of questions when one-at-a-time works.

## `review` — safety facts

For `--scope cross-package` and critical-surface reviews, pick the one or two invariants whose failure would invalidate the change and report each as: the fact, its consumers, the proof level actually reached, and what remains unproven.

| Level | Meaning |
|---|---|
| `REFERENCED` | claimed by source or docs |
| `PATH_TRACED` | call/data path followed |
| `DEPENDENCY_WALKED` | direct consumers checked |
| `EXECUTED` | targeted check passed |
| `LIVE_OBSERVED` | required runtime or rendered surface observed |

Descriptive, not a ladder every review must climb. Never promote a fact on indirect evidence; a missing required proof becomes a finding under the existing verdict rules.

## `agentic-eval` — skill lifecycle policy

Documents the policy behind the above: five addition gates (unique trigger, repeated-or-critical workflow, observable completion, canonical policy stays canonical, evaluation coverage), progressive disclosure, and explicit merge/retire conditions.

Adds blinded before/after behavior evaluation for changes that move decisions, ordering, stopping conditions, permissions, evidence standards, or output contracts — trigger routing alone doesn't cover those. Also drops the hardcoded skill count in favour of deriving it from the filesystem.

## Note

Guidance-only — no runtime code. `bun run eval:skills` is the relevant on-demand check for description-routing regressions; none of these edits change a `SKILL.md` frontmatter description, so routing is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)