### PR TITLE
chore(contracts): freeze the settlement fee ceiling, reserve floors, and recipient policy

### DIFF
--- a/packages/contracts/config/commitment-pooling-release.json
+++ b/packages/contracts/config/commitment-pooling-release.json
@@ -276,7 +276,7 @@
       "allowanceKey": null,
       "canonicalTarget": "0x62B8B11039FcfE5aB0C56E502b1C372A3d2a9c7A",
       "canonicalSelector": "0xa9059cbb",
-      "recipientPolicy": "registered-garden-safe-only"
+      "recipientPolicy": "source-plan-bounded"
     },
     "caps": {
       "maxTransferAmount": "7000000000000000000000000",
@@ -286,11 +286,11 @@
       "maxBatchSize": "2"
     },
     "feePolicy": {
-      "mode": "disabled-until-authorized",
-      "maxFeeBps": "0",
-      "maxFeeAmount": "0",
-      "arbitrumReserveFloor": null,
-      "celoReserveFloor": null
+      "mode": "authorized-ceiling",
+      "maxFeeBps": "100",
+      "maxFeeAmount": "50000000000000000000000",
+      "arbitrumReserveFloor": "5000000000000000",
+      "celoReserveFloor": "50000000000000000000"
     }
   },
   "indexer": {

--- a/packages/contracts/config/commitment-pooling-release.lock.json
+++ b/packages/contracts/config/commitment-pooling-release.lock.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "releaseId": "commitment-pooling-settlement-credit-v1",
   "sourceCommit": "fab5daef2eebbe83c1d444f6c148c682e122f1c3",
-  "manifestHash": "0x2551245f9bbf071a28cc824fd8e101080f29e28f65e7f92e728bae183fcc5bae",
+  "manifestHash": "0xc69375b5e00a5a927b860f83af941885bb9e56a454e8515bb9d47d4acb188cb5",
   "build": {
     "profile": "production",
     "solc": "0.8.28",


### PR DESCRIPTION
Four of the eleven unset release values didn't need the ceremony to decide them. This closes them, leaving only the ones the ceremony itself produces plus `destinationGasLimit`.

## Fee ceiling — 100 bps / 50,000 G$

`maxFeeBps` / `maxFeeAmount` are a ceiling on the **G$ transfer fee the executor will tolerate**, not a fee Green Goods charges. GoodDollar quotes zero today (verified live against `0x62B8…9c7A`: `getFees(1000e18, …)` → `fee=0, senderPays=false`), so `0/0` worked.

But a zero in either field deliberately rejects every non-zero fee:

```solidity
if (fee != 0 && (maxFeeBps == 0 || maxFeeAmount == 0 || fee > maxFeeAmount || ...))
    return FeeQuoteExceeded;
```

The day GoodDollar enables transfer fees, every settlement fails closed — recoverable only by pausing, `setFeePolicy`, and unpausing. Both limits apply, so the absolute cap binds above a 5,000,000 G$ transfer (1% of 7M = 70,000 > 50,000). That's well clear of expected sizes at `maxBatchSize: 2`, and failure stays closed and recoverable if reached.

`mode` moves from `disabled-until-authorized` to `authorized-ceiling`.

## Reserve floors — 0.005 ETH / 50 CELO

Measured against both live CCIP routers (view calls, no mutation, `EVMExtraArgsV1`):

| Leg | Fee | ≈ USD |
|---|---|---|
| Arbitrum → Celo command | 0.00007 ETH | $0.13 |
| Celo → Arbitrum acknowledgment | 2.37 CELO | $0.14 |

About **$0.27 per round trip**. The floors give roughly seventy commands and twenty acknowledgments of headroom. These are reserves that must *remain* after a dispatch, not budgets.

## `recipientPolicy` was stale

It still read `registered-garden-safe-only`, which stopped being true in #733 when the permission tree opened the recipient. Three of the five disbursement kinds pay an individual rather than a Garden Safe, so the destination is bounded by the source-side payout plan — now `source-plan-bounded`.

## Lock

Only `manifestHash` moves (`0x2551245f…` → `0xc69375b5…`). Every deterministic address is unchanged, confirming the manifest feeds no CREATE2 salt.

2050/2050 forge · 261/261 script · lock re-verified green after the pre-commit formatter.

## Still unset

`gardenSafes`, the four `zodiacRoles` fields, and `enabled` are produced by the ceremony. `destinationGasLimit` stays pinned at `0` until the batch-of-24 measurement is re-taken against a live Safe and Zodiac modifier — the current 1,383,897 figure came from mocks (`liveSafeZodiacMeasured: false`).

Refs PRD-819

🤖 Generated with [Claude Code](https://claude.com/claude-code)