### PR TITLE
chore(contracts): freeze Celo Safe authority after the ceremony

### DIFF
--- a/.plans/active/celo-garden-account-safe-ownership/status.json
+++ b/.plans/active/celo-garden-account-safe-ownership/status.json
@@ -10,7 +10,7 @@
     "overall_status": "active",
     "priority": "p1",
     "created_at": "2026-08-15T06:08:14.457Z",
-    "updated_at": "2026-08-18T19:05:00.000Z"
+    "updated_at": "2026-08-21T07:30:00.000Z"
   },
   "links": {
     "brief": "brief.md",
@@ -70,7 +70,7 @@
     "The Garden-bound relay is separate from Settlement and cannot satisfy Safe threshold two alone, become a Safe owner/module/guard/Zodiac member, or receive value authority.",
     "Implementation, review, release, guardian trust, Safe deployment, and value activation remain separate authorization boundaries.",
     "Use Bun wrappers only; never raw Forge.",
-    "Broadcast is complete. All 18 Celo GardenAccounts and all 18 final 2-of-3 Garden Safes are live and independently verified; deployments/42220-settlement-safes.json holds the receipt-backed record for every Safe boundary. authorityEnabled is false: no Zodiac Roles module, allowance, peer binding, or value authority was configured. The bounded settlement authority half of PRD-819 is still unbuilt and has no operator stage.",
+    "Broadcast is complete. All 18 Celo GardenAccounts and all 18 final 2-of-3 Garden Safes are live and independently verified; deployments/42220-settlement-safes.json holds the receipt-backed record for every Safe boundary. The bounded settlement authority half then landed in two steps: the 2026-08-20 ceremony configured 18 Zodiac Roles modifiers, enabled them as Safe modules, and bound 18 write-once executor routes, and the 2026-08-21 re-freeze recorded that in the release manifest with safeAuthority.enabled true. What is still open is live and human-owned: reserve funding on both chains, the Arbitrum setCcipRoute boundary, and the ping/ack plus minimum-value canary.",
     "The release operator's broadcast gate was unsatisfiable until PR 724. Both Celo wrappers compared GG_RELEASE_OPERATOR_SESSION against the release manifest sourceCommit while release-operator.ts pinned git HEAD to that same session value, so broadcast required a commit containing its own hash. The wrappers now check the session against the checked-out candidate; release identity is still asserted separately where the plan is validated. The Arbitrum lane never used this variable.",
     "The Garden-bound relay is deployed and verified: source router 0xDBF71edb4902cB43260f8A3e4460072e2028E627 on Arbitrum, Celo relay 0x21E4594760454D3c5A7085e3D48F1E60c6AeD1C9, destination bound once, and the Guardian trusting that exact relay. Across all 18 Garden Safes the relay is not an owner, not a module, no guard is set, and it holds no value. It still cannot reach threshold two alone; one recovery-owner signature remains required for every Safe execution.",
     "Comparing a deployed runtime hash to the artifact's deployedBytecode is wrong for any contract with immutables, which Solidity writes at construction. The router differs from its artifact in 416 bytes, all inside its nine declared immutable spans. Verification masks the declared spans and relies on the CREATE2 address to bind the init code. A boundary that mines before a failing postcondition is recovered with the adopt command rather than replayed against a consumed nonce."
@@ -322,6 +322,22 @@
       "status": "relay_broadcast_complete",
       "branch": "fix/relay-immutable-runtime-verification",
       "note": "Afo authorized and executed the four-boundary Garden-bound relay ceremony on 2026-08-18. Source router and destination binding landed on Arbitrum, the relay and Guardian trust on Celo; receipts are in deployments/garden-account-relay.json. Boundary 1 mined and then failed a postcondition that compared the deployed runtime hash to the artifact's deployedBytecode, which cannot hold for a contract with immutables; PR 729 masks the declared immutable spans and adds an adopt command for the mined-but-uncheckpointed state. No value authority was granted and the relay holds no Safe role on any of the 18 boundaries."
+    },
+    {
+      "timestamp": "2026-08-20T22:42:00.000Z",
+      "actor": "human",
+      "lane": "contracts",
+      "status": "safe_zodiac_ceremony_complete",
+      "branch": "claude/celo-garden-safes-deploy-04bd67",
+      "note": "Afo ran the Zodiac Roles, module-enablement, and executor-route ceremony through the release operator pinned to 32e25d621065d34d062a6943e506b3e0aed3a7da: 126 Roles configuration and ownership-transfer transactions, 18 module enablements, and 18 write-once route bindings, ending at block 75390218. Plan hashes, final receipts, and the full Garden/Safe/modifier inventory are in .plans/active/commitment-pooling/reports/celo-garden-safe-ceremony-checkpoint-2026-08-20.md."
+    },
+    {
+      "timestamp": "2026-08-21T07:30:00.000Z",
+      "actor": "claude",
+      "lane": "contracts",
+      "status": "manifest_refreeze_complete",
+      "branch": "claude/celo-garden-safes-deploy-04bd67",
+      "note": "Completed the post-ceremony re-freeze. settlement:garden-roles:verify and settlement:garden-routes:verify were re-run live against Celo and both passed, and all 18 rows of the committed ceremony report were diffed against the receipt ledger with no mismatch. The manifest now carries 18 gardenSafes plus the Zodiac module, moduleFactory, roleKey, allowanceKey, and a conditionsHash derived from keccak256(encodeConditions(buildTransferConditions())) rather than transcribed; caps, feePolicy, and destinationGasLimit are untouched and the lock moved only its manifestHash, to 0x2c7fd3ec4e7dc461af193e2eda2635042e63b5e2342592c3360c193705d7df6a. Three gates that hard-asserted the disabled state were re-pointed: the release-verify check now proves the freeze names all 18 boundaries, the manifest test proves the enabled shape fails closed on any cleared identity, and two release.ts strings that claimed authority was disabled were corrected. No transaction, funding, or value movement occurred."
     }
   ]
 }

--- a/.plans/active/commitment-pooling/handoffs/human-release-ops.md
+++ b/.plans/active/commitment-pooling/handoffs/human-release-ops.md
@@ -381,17 +381,24 @@ the `release:verify:safe:*` variants; those belong to the later ownership-transf
   executor routes are deployed and verified. The exact plan hashes, final receipts, authority
   identities, and restart instructions are recorded in
   [`../reports/celo-garden-safe-ceremony-checkpoint-2026-08-20.md`](../reports/celo-garden-safe-ceremony-checkpoint-2026-08-20.md).
-- The committed manifest still keeps Safe authority disabled. The next repository boundary is one
-  receipt-backed post-ceremony re-freeze that fills every Safe/Zodiac field and flips
-  `safeAuthority.enabled` together. No settlement is authorized before that change is reviewed and
-  merged.
+- The post-ceremony re-freeze is committed. `safeAuthority.enabled` is true, all 18 Garden
+  boundaries are named, and the Zodiac module, role key, allowance key, and condition hash are set;
+  the manifest hash moved to
+  `0x2c7fd3ec4e7dc461af193e2eda2635042e63b5e2342592c3360c193705d7df6a` and no library,
+  implementation, or proxy address moved with it. Enabling authority in the manifest is not an
+  authorization to settle: funding, routing, and the canary each remain their own gate. Evidence and
+  the gates that had to move are in
+  [`../reports/celo-safe-authority-refreeze-2026-08-21.md`](../reports/celo-safe-authority-refreeze-2026-08-21.md).
 - The hosted production indexer is the older deployment and is deliberately outside this contracts
   ceremony. PRD-722 remains responsible for its later deployment/reindex/cutover/read-back.
 
-The Garden Safe bootstrap and route ceremony is complete. The next boundary is the post-ceremony
-manifest re-freeze described in the checkpoint report above. It is repository work and does not
-authorize another transaction. Fee-reserve funding, Arbitrum `setCcipRoute`, message-only ping,
-minimum-value canary, ownership transfer, cap changes, and value movement remain separately gated.
+The Garden Safe bootstrap, the route ceremony, and the manifest re-freeze are all complete, which
+closes the repository half of this lane. Every remaining step moves value or sends a transaction and
+belongs to the release owner: funding the Arbitrum SettlementModule and the Celo executor above
+their frozen reserve floors, executing and verifying the Arbitrum `setCcipRoute` boundary at the
+frozen 3,000,000 destination gas limit, then the message-only ping/ack and the minimum-value
+canary, in that order. Ownership transfer, cap changes, and broader value movement stay gated
+behind their own authorizations.
 
 ## Core-tier unblock evidence
 

--- a/.plans/active/commitment-pooling/reports/celo-safe-authority-refreeze-2026-08-21.md
+++ b/.plans/active/commitment-pooling/reports/celo-safe-authority-refreeze-2026-08-21.md
@@ -1,0 +1,81 @@
+# Celo Safe authority re-freeze — 2026-08-21
+
+Closure artifact for the resume point in
+[`celo-garden-safe-ceremony-checkpoint-2026-08-20.md`](./celo-garden-safe-ceremony-checkpoint-2026-08-20.md).
+That report is the record of the ceremony and stays as written; this one records the repository
+re-freeze it asked for. The re-freeze is done. Do not re-run it.
+
+## What changed
+
+`packages/contracts/config/commitment-pooling-release.json` now carries the completed ceremony:
+`safeAuthority.enabled` is `true`, `gardenSafes` names all 18 Garden boundaries, and
+`zodiacRoles` carries the module, module factory, role key, allowance key, and condition hash.
+`caps`, `feePolicy`, and `chains.arbitrum.destinationGasLimit` were not touched, and every byte
+outside the `safeAuthority` block is unchanged.
+
+The manifest hash moved from `0xa8be2ac177a457d2636d1ef705a8b05dac00d18198672eefb00dc75e97d85392`
+to `0x2c7fd3ec4e7dc461af193e2eda2635042e63b5e2342592c3360c193705d7df6a`. That is the **only** line
+that changed in `commitment-pooling-release.lock.json`: no library, implementation, proxy, or other
+contract address moved, and the identity count stayed at 31.
+
+## How the values were established
+
+The ceremony receipts, not the prose of the earlier report, are the source. Both live verifications
+were re-run against Celo first and both passed:
+
+```text
+Verified 18 Roles modifiers: avatar, target, ownership, membership, allowance, and module state.
+All 18 Garden routes match the reviewed plan.
+```
+
+Each of the 18 rows in the earlier report's inventory table was then diffed field by field against
+`.generated/runtime/42220-garden-roles.json` — token id, Garden, Safe, modifier, and permission
+configuration hash — with no mismatch.
+
+`conditionsHash` was **derived**, not transcribed, as the earlier report required. It is
+`keccak256(encodeConditions(buildTransferConditions()))`, and a test in
+`script/utils/release-manifest.test.ts` now recomputes it from those two exported functions on every
+run, so the manifest cannot drift from the condition tree the ceremony actually scoped.
+
+## One shape decision worth knowing
+
+`zodiacRoles.module` is a single field but the ceremony deployed 18 modifiers, so `module` holds the
+shared Roles v2 mastercopy (`0x9646fDAD06d3e24444381f44362a3B0eB343D337`) and each Garden's own
+modifier proxy lives in its `gardenSafes` entry. A test asserts no Garden's modifier is ever the
+mastercopy itself.
+
+## Gates that had to move
+
+The earlier report's seven-step procedure did not account for these. Three places hard-asserted the
+disabled state and would have failed or lied once authority was enabled:
+
+- `script/release-verify.ts` checked `manifest.safe-authority-disabled` against a literal `false`.
+  It now proves the opposite property that still has teeth: authority is frozen and the freeze names
+  all 18 boundaries, so a nineteenth Garden cannot inherit authority without its own ceremony.
+- `script/utils/release-manifest.test.ts` proved authority *could not* be enabled. It now proves the
+  enabled shape fails closed — clearing any one Zodiac identity is still rejected, and disabling
+  authority while garden Safes stay listed is still rejected.
+- Two strings in `script/deploy/release.ts` told the operator authority was disabled. Both now
+  reflect the real state.
+
+A fourth fix is unrelated to authority but was found on the way: the "production artifact missing"
+error told the operator to run `bun run build:full`, which compiles the test profile and leaves
+`out/production` empty, so following it reproduces the same error. It now names
+`FOUNDRY_PROFILE=production bun run build`.
+
+## What this does not authorize
+
+Enabling authority in the manifest records that the ceremony happened. It does not authorize
+settlement. Every remaining step moves value or sends a transaction and belongs to the release
+owner, in order:
+
+1. Fund the Arbitrum SettlementModule at `0x15c8F6CF25abA2161cc04719b4C4a93c4146935D` above the
+   frozen reserve floor.
+2. Fund the CeloSettlementExecutor at `0xB8a7F3c3DfA407c45e05b7B2381233101938a84F` above the frozen
+   reserve floor.
+3. Execute and verify the Arbitrum `setCcipRoute` boundary at the frozen 3,000,000 destination gas
+   limit.
+4. Run the separately authorized message-only ping/ack, then the minimum-value canary, before any
+   broader settlement.
+
+Ownership transfer, cap increases, and unpause remain behind their own authorizations.

--- a/packages/contracts/config/commitment-pooling-release.json
+++ b/packages/contracts/config/commitment-pooling-release.json
@@ -265,16 +265,144 @@
     }
   ],
   "safeAuthority": {
-    "enabled": false,
+    "enabled": true,
     "safeSingleton": "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
     "safeFactory": "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67",
-    "gardenSafes": [],
+    "gardenSafes": [
+      {
+        "tokenId": 0,
+        "garden": "0xf401f34378384713222d1d21f63359cc4E8a858a",
+        "safe": "0xe41a1e446644034f24a4B2E1bfB28Fd414dBc66d",
+        "modifier": "0x679AEB80a481772Df85E2b93F8fDc5180EF422e1",
+        "permissionsConfigHash": "0x209742b923570909ea2d3e411472c811312da1438a26428f674d2344d7b948bf"
+      },
+      {
+        "tokenId": 1,
+        "garden": "0xF7b892886998DAe960D64a9db488336684F137A0",
+        "safe": "0xa23716F7B0DBBB0387Fb1274f1Ae8247670dCC37",
+        "modifier": "0x2E99B81149226dc97397cdF1d8A75498700b29E0",
+        "permissionsConfigHash": "0x6e0ae964b5610e21c55f498a92781517b2fe14bcac58b11b8b8061b89bdd3f84"
+      },
+      {
+        "tokenId": 2,
+        "garden": "0xA2DF8Eb73444A3f3cf9b8E3749313C7471d7D5E3",
+        "safe": "0x67828f64f6D33522679F40D9f1BE1F53c9eb71cB",
+        "modifier": "0xBfFE452892Ae484727D51073c796bbC32791a318",
+        "permissionsConfigHash": "0xb0f75be63f56312073572eaf97559b68ee30477dc1c5af512a76c705136ad941"
+      },
+      {
+        "tokenId": 3,
+        "garden": "0x4055530dB392FB2B56037065A512c5b283D90A10",
+        "safe": "0xCFfADc80904b760F1588D0Ebfd53f4c307691A86",
+        "modifier": "0xbdF9c2Ef74097eD6b96b198B7745A6ec314b20BD",
+        "permissionsConfigHash": "0x4fc97aa512a6cf6096de5148956a14b9d82079384981e22f68798fce4a3b69a8"
+      },
+      {
+        "tokenId": 4,
+        "garden": "0x51499A44BB7793647e67ed827bd17367d7e55314",
+        "safe": "0xC9D5bF40a49a0a5A60E1677aAA06342655025c94",
+        "modifier": "0xD8661E8Ba898cf94e8cc0ce72E5aC55e032D7a6b",
+        "permissionsConfigHash": "0xa7310d66898ed1c2a0d97084e21a270728144567226c985bc00e3ccfdd423c58"
+      },
+      {
+        "tokenId": 5,
+        "garden": "0xbcCE994513615988690aBCA373B1368218E4957C",
+        "safe": "0x6640D2809aA4989192F1caaF6D9614BaD9aA5518",
+        "modifier": "0x7dF7Ada423B3A4a9f740976c7513EB319480A222",
+        "permissionsConfigHash": "0x66a95601163f1fad425be9a1acef8e47aedada3c832c408f693338544c6a41b1"
+      },
+      {
+        "tokenId": 6,
+        "garden": "0xFDa72CE1D75b735d6595E5814DDF23b97516caEf",
+        "safe": "0x6e64e6bB9977BF1d5db40f71bCBb194269cE503B",
+        "modifier": "0xE5b6B19195973e5480EaFA4144F52237d22DB94b",
+        "permissionsConfigHash": "0xe41721692f85af26f47f0f98c8804fb910eef582ae24680de9505d61adf6a897"
+      },
+      {
+        "tokenId": 7,
+        "garden": "0xD1F8e787a325F91F5d4Be2D30ea1E67B19e28b30",
+        "safe": "0x0092904e7c33e04EcAc35E2e45cD6D1D1571EE81",
+        "modifier": "0xc916ceDDf02749931E6d68670720b8307bBDf54d",
+        "permissionsConfigHash": "0x2b3594997a8defc74182e178d83ca2cb3e7abdb804d02540b5b96d165faa63f2"
+      },
+      {
+        "tokenId": 8,
+        "garden": "0x4f11FB4c255D3eDC7C44a461ab45fBC421Aacb09",
+        "safe": "0x1295E5F1D78e0f1904A78798bA494d2Bb996E23b",
+        "modifier": "0xd50C59Eb4611C3ea247BF72DB29d65b0F8B6FC08",
+        "permissionsConfigHash": "0xd7b2a9102b7e0423c55cc963999dd7fe5737cb93280e3a76a0ce0baa5b626d9e"
+      },
+      {
+        "tokenId": 9,
+        "garden": "0x636962584b1F492B06151Fee87810281372879b6",
+        "safe": "0x3EB95Adb3B603945C3a422fe564aAAB605d27a4b",
+        "modifier": "0x05102eAA437eFe9f3E68f8d58C4AdA5945135Aae",
+        "permissionsConfigHash": "0x60fa8de81f1ae68aed6c30a7308295dc0030afa80c364ed5bcd957b015df4a96"
+      },
+      {
+        "tokenId": 10,
+        "garden": "0x1121218D5e017B57c6DF3B5a001a991BDB910338",
+        "safe": "0x94706E563B94980EDe33bd7A538B3D24a53ef010",
+        "modifier": "0xd42142f56a7D6390Ed827fC4D98C03165cb239DE",
+        "permissionsConfigHash": "0x06f32d42a5cdae3c727ca8a7f3609adb6d4811c72af04d76effc892d363359e1"
+      },
+      {
+        "tokenId": 11,
+        "garden": "0x3f0f1551C7E08a2cf6800BD7D72aBfE23E3E32a0",
+        "safe": "0x7Cf45A3205CE3FFC3e552bc0b49B3bF3aA090241",
+        "modifier": "0x8CEd80d759da8A0D73Dd1A8Ee2c31fF724C22F9C",
+        "permissionsConfigHash": "0x489a500b338b822fd90ec735de958259e6e4f7ce7be01ce6a790e8635acb8051"
+      },
+      {
+        "tokenId": 12,
+        "garden": "0x3F22568aE0deAA24dA7b8c669AfDcBD72A6A7fd8",
+        "safe": "0x8d759c89f82A8eCE6e45164Ba9cDD32fE498f2D9",
+        "modifier": "0x617DDcaED815DabbA0348b94642d52AB9bbf060d",
+        "permissionsConfigHash": "0xb6c2329cd0d828daa69b60781f85b1fac9a428d2eb36ac8d3a70bf2c1100cc7c"
+      },
+      {
+        "tokenId": 13,
+        "garden": "0x26c32E54F23af9F9fcC757414c76E56e3fB176E2",
+        "safe": "0x15F104203570BC53B5349EE888e02B0DB100E4F7",
+        "modifier": "0x9fbe57F793151dEB8b969413Bf3780D6aD84a345",
+        "permissionsConfigHash": "0x80496183f9f61a2496ab9e32b61a3060404a498a829dce30ab4fe63a4e647ded"
+      },
+      {
+        "tokenId": 14,
+        "garden": "0x35077CaF6fBef1d5677d318a198C9c47C61bb976",
+        "safe": "0x14094635AdA852bCd740AdF546D2ef0dd79Ad4DB",
+        "modifier": "0x1b03f8722c2649f605482748C0072e6D79812Ea6",
+        "permissionsConfigHash": "0xd9eda50eba02271fb91cc6dc7e49eb340f62ed4d3d4ee8fadbe2acf1acb104b5"
+      },
+      {
+        "tokenId": 15,
+        "garden": "0x7bE6eAeb2FB5842Da06A34Af4fAe418347427cd1",
+        "safe": "0x82EFf72CB9A33fC6F74422146Ae04F8629097db9",
+        "modifier": "0x4e68c3dC1fb7877a88Ba392839845E05C17c87E3",
+        "permissionsConfigHash": "0x8720bee862f9f31f71368f6c80b6abbeb5fd7a5a5a9c4feeeb7c97b71e1c2613"
+      },
+      {
+        "tokenId": 16,
+        "garden": "0x35722eEdf3F7566A23FA871f0a04267AEe78E0dB",
+        "safe": "0x6516E0051D95b6C6B3a8Fa051b1bF51821e9697c",
+        "modifier": "0xEac98FCF7793897F4aafF77B1a7A167317Ee5D1D",
+        "permissionsConfigHash": "0xf747d7f99620ea3a3000c83e918914bcf16db4dfdcccfc6da17128610ba3da72"
+      },
+      {
+        "tokenId": 17,
+        "garden": "0x749F84CA070cD2F98d9353F49eCE77C1A3fED532",
+        "safe": "0xB2C312402dbaabBe0cDB91aD387A4b46689f35B5",
+        "modifier": "0xC1F06bFE2b8264750d2B092F8BE582d178eC7834",
+        "permissionsConfigHash": "0x2ce4ef3508c6ac363c90e4fa9b485ba37cc24a5f81c8ab67406f19477c7ad380"
+      }
+    ],
     "zodiacRoles": {
       "version": "2",
-      "module": null,
-      "roleKey": null,
-      "conditionsHash": null,
-      "allowanceKey": null,
+      "module": "0x9646fDAD06d3e24444381f44362a3B0eB343D337",
+      "moduleFactory": "0x000000000000aDdB49795b0f9bA5BC298cDda236",
+      "roleKey": "0x53905249f34c6420380224324b0c3e1521b717a2c165dfab931f8121c5160ce5",
+      "conditionsHash": "0xa1a076f78edfb7f6af43f202947371d2c6d449c7f5c789cc3a31a94bfd006a00",
+      "allowanceKey": "0x675d2ce2e7ee2d674ee28f4a96615cf1d706e9a055fabe883e7d69472108302b",
       "canonicalTarget": "0x62B8B11039FcfE5aB0C56E502b1C372A3d2a9c7A",
       "canonicalSelector": "0xa9059cbb",
       "recipientPolicy": "source-plan-bounded"

--- a/packages/contracts/config/commitment-pooling-release.lock.json
+++ b/packages/contracts/config/commitment-pooling-release.lock.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "releaseId": "commitment-pooling-settlement-credit-v1",
   "sourceCommit": "fab5daef2eebbe83c1d444f6c148c682e122f1c3",
-  "manifestHash": "0xa8be2ac177a457d2636d1ef705a8b05dac00d18198672eefb00dc75e97d85392",
+  "manifestHash": "0x2c7fd3ec4e7dc461af193e2eda2635042e63b5e2342592c3360c193705d7df6a",
   "build": {
     "profile": "production",
     "solc": "0.8.28",

--- a/packages/contracts/script/deploy/release.ts
+++ b/packages/contracts/script/deploy/release.ts
@@ -443,7 +443,12 @@ Phase B boundary form (not authorized by Phase A):
       assertLockExact(lock);
       console.log(`Frozen release lock matches: ${LOCK_PATH}`);
     }
-    console.log("Safe/Zodiac authority: disabled; no value-authority transaction can be built from this manifest");
+    console.log(
+      manifest.safeAuthority.enabled
+        ? `Safe/Zodiac authority: frozen over ${manifest.safeAuthority.gardenSafes.length} garden Safes; ` +
+            "reserve funding, the Arbitrum CCIP route, and the canary remain separately gated"
+        : "Safe/Zodiac authority: disabled; no value-authority transaction can be built from this manifest",
+    );
     console.log("Indexer deployment: outside this lane; PRD-722 handoff generation is inert");
   }
 
@@ -1318,7 +1323,11 @@ Phase B boundary form (not authorized by Phase A):
 
   private async safePlan(options: ParsedOptions, manifest: ReleaseManifest, lock: ReleaseLock): Promise<void> {
     if (options.network !== "celo") throw new Error("safe-plan requires --network celo");
-    if (options.broadcast) throw new Error("Safe authority has no broadcast path while safeAuthority.enabled is false");
+    if (options.broadcast) {
+      throw new Error(
+        "safe-plan only produces a reviewed plan; Safe authority broadcasts through the release operator",
+      );
+    }
     const executor = identity(lock, "CeloSettlementExecutor", "proxy").address;
     const liveEvidence: Record<string, unknown> = {
       inspected: false,

--- a/packages/contracts/script/release-verify.ts
+++ b/packages/contracts/script/release-verify.ts
@@ -510,7 +510,11 @@ async function main() {
 
   check(checks, "manifest.network.chain-id-string", chain.evmChainId, BigInt(chain.evmChainId).toString());
   check(checks, "manifest.network.selector-string", chain.ccipSelector, BigInt(chain.ccipSelector).toString());
-  check(checks, "manifest.safe-authority-disabled", false, manifest.safeAuthority.enabled);
+  // The Celo Safe/Zodiac ceremony is complete, so this no longer guards an unconfigured authority.
+  // What it guards now is a half-recorded one: the freeze must name every Garden boundary the
+  // ceremony actually configured, and a 19th Garden must not inherit authority without its own run.
+  check(checks, "manifest.safe-authority-frozen", true, manifest.safeAuthority.enabled);
+  check(checks, "manifest.safe-authority-garden-count", 18, manifest.safeAuthority.gardenSafes.length);
   check(checks, "manifest.indexer-activation-disabled", false, manifest.indexer.activationAuthorized);
   check(
     checks,

--- a/packages/contracts/script/utils/release-manifest.test.ts
+++ b/packages/contracts/script/utils/release-manifest.test.ts
@@ -1,4 +1,6 @@
+import { keccak256 } from "ethers";
 import { describe, expect, it } from "vitest";
+import { buildTransferConditions, encodeConditions } from "../deploy/garden-roles";
 import {
   assertManifestMatchesNetworkDirectory,
   buildReleaseLock,
@@ -66,7 +68,32 @@ describe("combined commitment release manifest", () => {
     ]);
   });
 
-  it("rejects numeric selectors, duplicate schemas, and prematurely enabled authority", () => {
+  it("freezes the completed Safe/Zodiac ceremony with a derived condition hash", () => {
+    const manifest = loadReleaseManifest();
+    const authority = manifest.safeAuthority;
+    expect(authority.enabled).toBe(true);
+    expect(() => validateReleaseManifest(manifest)).not.toThrow();
+
+    // The condition hash is proven against the exact tree the ceremony scoped, never transcribed.
+    expect(authority.zodiacRoles.conditionsHash).toBe(keccak256(encodeConditions(buildTransferConditions())));
+
+    // One entry per Garden, each binding a Garden to its own Safe and its own Roles modifier.
+    const gardenSafes = authority.gardenSafes as Array<Record<string, string | number>>;
+    expect(gardenSafes).toHaveLength(18);
+    expect(gardenSafes.map((entry) => entry.tokenId)).toEqual([...Array(18).keys()]);
+    for (const field of ["garden", "safe", "modifier"] as const) {
+      const addresses = gardenSafes.map((entry) => String(entry[field]));
+      expect(addresses.every((address) => /^0x[0-9a-fA-F]{40}$/u.test(address))).toBe(true);
+      expect(new Set(addresses).size).toBe(18);
+    }
+    expect(gardenSafes.every((entry) => /^0x[0-9a-f]{64}$/u.test(String(entry.permissionsConfigHash)))).toBe(true);
+
+    // `module` is the shared Roles v2 mastercopy; the per-Garden proxies live in `gardenSafes`.
+    expect(authority.zodiacRoles.module).toBe("0x9646fDAD06d3e24444381f44362a3B0eB343D337");
+    expect(gardenSafes.some((entry) => entry.modifier === authority.zodiacRoles.module)).toBe(false);
+  });
+
+  it("rejects numeric selectors, duplicate schemas, and half-configured authority", () => {
     const manifest = loadReleaseManifest();
     const numeric = structuredClone(manifest);
     numeric.chains.arbitrum.ccipSelector = Number(numeric.chains.arbitrum.ccipSelector) as unknown as string;
@@ -76,16 +103,22 @@ describe("combined commitment release manifest", () => {
     duplicated.schemas[1].identity = duplicated.schemas[0].identity;
     expect(() => validateReleaseManifest(duplicated)).toThrow(/Duplicate schema identity/);
 
-    // The caps are frozen but the Roles module, keys, and condition hash are not, so enabling
-    // authority must still fail closed on the unset Zodiac identities.
-    const authority = structuredClone(manifest);
-    authority.safeAuthority.enabled = true;
-    expect(() => validateReleaseManifest(authority)).toThrow(/requires zodiacRoles\./);
+    // Authority is enabled against the completed ceremony, so the fail-closed proof is that
+    // clearing any one Zodiac identity still rejects the manifest.
+    for (const key of ["module", "roleKey", "conditionsHash", "allowanceKey"] as const) {
+      const cleared = structuredClone(manifest);
+      cleared.safeAuthority.zodiacRoles[key] = null;
+      expect(() => validateReleaseManifest(cleared)).toThrow(/requires zodiacRoles\./);
+    }
 
     const uncapped = structuredClone(manifest);
-    uncapped.safeAuthority.enabled = true;
     uncapped.safeAuthority.caps.maxPeriodAmount = null;
     expect(() => validateReleaseManifest(uncapped)).toThrow(/requires non-zero/);
+
+    // Authority may never be switched off while the ceremony's garden Safes stay pre-authorized.
+    const halfDisabled = structuredClone(manifest);
+    halfDisabled.safeAuthority.enabled = false;
+    expect(() => validateReleaseManifest(halfDisabled)).toThrow(/may not pre-authorize garden Safes/);
 
     const numericGas = structuredClone(manifest);
     numericGas.chains.arbitrum.destinationGasLimit = 750_000 as unknown as string;

--- a/packages/contracts/script/utils/release-manifest.ts
+++ b/packages/contracts/script/utils/release-manifest.ts
@@ -582,7 +582,10 @@ function artifactPath(relativePath: string): string {
 
 function loadArtifact(relativePath: string): FoundryArtifact {
   const filePath = artifactPath(relativePath);
-  if (!fs.existsSync(filePath)) throw new Error(`Production artifact missing: ${filePath}; run bun run build:full`);
+  // `build:full` alone compiles the test profile; only FOUNDRY_PROFILE=production writes out/production.
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Production artifact missing: ${filePath}; run FOUNDRY_PROFILE=production bun run build`);
+  }
   return readJson<FoundryArtifact>(filePath);
 }
 


### PR DESCRIPTION
## Summary

The 2026-08-20 ceremony configured 18 Zodiac Roles modifiers, enabled them as Safe modules, and bound 18 executor routes — but the release manifest still described that authority as unconfigured, so nothing downstream could tell the ceremony had happened. This is the post-ceremony re-freeze that records it.

`safeAuthority.enabled` is now true, `gardenSafes` names all 18 Garden boundaries, and `zodiacRoles` carries the module, module factory, role key, allowance key, and condition hash. `caps`, `feePolicy`, and `chains.arbitrum.destinationGasLimit` are untouched, and every byte outside the `safeAuthority` block is unchanged.

The lock moved **only** its `manifestHash`, to `0x2c7fd3ec4e7dc461af193e2eda2635042e63b5e2342592c3360c193705d7df6a`. No library, implementation, or proxy address moved, and the identity count stayed at 31.

## Where the values came from

The ceremony receipts, not the prose of the earlier report. Both live verifications were re-run against Celo first and both passed:

```text
Verified 18 Roles modifiers: avatar, target, ownership, membership, allowance, and module state.
All 18 Garden routes match the reviewed plan.
```

All 18 rows of the ceremony report's inventory table were then diffed field by field against the receipt ledger — token id, Garden, Safe, modifier, permission configuration hash — with no mismatch.

`conditionsHash` is **derived**, not transcribed, as the earlier report required: it is `keccak256(encodeConditions(buildTransferConditions()))`, and a test recomputes it from those exported functions on every run so the manifest cannot drift from the condition tree the ceremony scoped.

## Gates that had to move

The checkpoint's seven-step procedure did not account for these. Three places hard-asserted the disabled state and would have failed or lied once authority was enabled:

- `script/release-verify.ts` checked `manifest.safe-authority-disabled` against a literal `false`. It now proves the property that still has teeth — authority is frozen and the freeze names all 18 boundaries, so a nineteenth Garden cannot inherit authority without its own ceremony.
- `script/utils/release-manifest.test.ts` proved authority *could not* be enabled. It now proves the enabled shape fails closed: clearing any one Zodiac identity is rejected, and disabling authority while garden Safes stay listed is rejected.
- Two operator-facing strings in `script/deploy/release.ts` told the operator authority was disabled. Both now reflect the real state.

Found on the way and fixed here: the "production artifact missing" error told the operator to run `bun run build:full`, which compiles the test profile and leaves `out/production` empty — so following it reproduces the same error. It now names `FOUNDRY_PROFILE=production bun run build`.

## One shape decision

`zodiacRoles.module` is a single field but the ceremony deployed 18 modifiers, so `module` holds the shared Roles v2 mastercopy and each Garden's own modifier proxy lives in its `gardenSafes` entry. A test asserts no Garden's modifier is ever the mastercopy itself.

## What this does not authorize

Enabling authority in the manifest records that the ceremony happened. It authorizes no settlement. Reserve funding, the Arbitrum `setCcipRoute` boundary, and the ping/ack plus minimum-value canary remain separate human-owned gates. Ownership transfer, cap increases, and unpause stay behind their own authorizations.

## Validation

- [x] `bun format` — clean, no fixes applied
- [x] `bun lint` — 0 errors
- [x] contracts — 2050 forge tests, 0 failed; 276 script tests, 0 failed
- [x] shared — 322 files, 3728 tests, 0 failed
- [x] client — 90 files, 739 tests · admin — 84 files, 583 tests · agent — 270 tests · docs — 28 tests
- [x] builds — contracts, client, admin green
- [x] `release:verify:plan:arbitrum` — `manifest.safe-authority-frozen: true`, `manifest.safe-authority-garden-count: 18`
- [x] `release:manifest` — "Frozen release lock matches"
- [x] `check:immutable-plan-reports`, `check:guidance-links`, `check:source-structure`
- [ ] indexer test + build — **BLOCKED**, not passing: this worktree has envio v2.32.12 installed against a pinned 3.6.1, so `envio codegen` rejects the (correct) `chains:` key. Environment gap, no indexer code touched here.

## Pre-existing issue found, not fixed here

`release:verify` is already red on develop for an unrelated reason: `indexer-config-hash-recorded` fails because `packages/indexer/config.yaml` changed in the commitment-credit commits without re-freezing `indexer.configHash` (expected `0xb3cfc35d…`, actual `0x94d77e3e…`). Left alone deliberately — that gate exists to catch exactly this drift, and someone should confirm the config change was intended rather than overwrite the hash. It will block the `setCcipRoute` verification step.

Refs PRD-819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
