### PR TITLE
docs(claude): record the build review and the client loop dispatch prompt

### DIFF
--- a/.plans/active/commitment-pooling/plan.todo.md
+++ b/.plans/active/commitment-pooling/plan.todo.md
@@ -14,9 +14,10 @@ Linear mirror: project [Commitment Pooling](https://linear.app/greenpill-dev-gui
 
 ## Document map
 
-Every file in this hub, by role — **171 files**: 29 at the hub root, 42 under `artifacts/`,
-25 under `handoffs/`, 22 under `hifi/`, 20 under `operations/`, 32 under `reports/`, and 1 under
-`evidence/`.
+Every file in this hub, by role — **181 files**: 36 at the hub root, 42 under `artifacts/`,
+25 under `handoffs/`, 22 under `hifi/`, 20 under `operations/`, 35 under `reports/` (including
+`reports/linear/`), and 1 under `evidence/`. Counts re-taken 2026-08-21; the previous 171 predated
+the client-UI review prompts and the editorial dispatch prompt.
 **This list is the index — if you add a document here, add its row.** Root files each get their own
 row; the six subtrees get one row apiece naming their own in-tree index, because the row for a
 subtree is only honest if that index actually enumerates the tree (this failed review on
@@ -42,6 +43,14 @@ subtree is only honest if that index actually enumerates the tree (this failed r
 | `flow-audit.md` | Experience audit of the hi-fi prototypes read from the journeys outward: the action map, a walk of every flow, the relay between people, continuity, the emotional arc, and ranked findings | Review findings — **adds no design authority**; decisions land in `uiux-spec.md` and the Decision Log |
 | `flow-audit-prompt.md` | The brief that produced `flow-audit.md`: what to audit for, the six qualities, and the hard limits on what an audit may propose | Audit method — reusable brief, not a spec |
 | `review-prompt.md` | Grounded `/review` brief for PR #732: scoping notes where the skill's defaults miss, the batch plan, the ranked risk surface, the claims to disprove, and what could not be verified | Review method — reusable brief, not a spec |
+| `review-prompt-client-ui.md` | First adversarial review brief for the PR #740 client slice (W1–W5); fixes landed in `dd12817ab` | Review method — dated brief, not a spec |
+| `review-prompt-client-ui-round2.md` | Round-2 client UI review brief; fixes landed in `694a20316` | Review method — dated brief, not a spec |
+| `review-prompt-client-ui-round3.md` | Round-3 client UI review brief; records the deliberately absent W2a / WFLOW / DomainImpact / To-confirm / W28–W31 scope; fixes in `f5e86ae37` | Review method — dated brief; the scope note is the honest record of what #740 left out |
+| `review-prompt-client-ui-round4.md` | Round-4 client UI review brief; fixes in `c984ec5ef` | Review method — dated brief, not a spec |
+| `review-prompt-client-ui-round5.md` | Round-5 client UI review brief; fixes in `5f0f99dee` | Review method — dated brief, not a spec |
+| `prompt-editorial-backend.md` | Codex dispatch prompt for the editorial backend readers (merged as PR #745 / #746) | Dispatch prompt — historical once merged |
+| `prompt-client-loop.md` | Claude Code dispatch prompt to finish the client PWA in a worktree: Phase 0 fixes, D1 close-the-loop (W2a, W4, DomainImpact rows, WFLOW, claims, W25), D2 Offer over time (W32, W34, W35); written from `reports/build-review-2026-08-21.md` | Dispatch prompt — re-verify its "Present state" before use |
+| `reports/build-review-2026-08-21.md` | Layer-by-layer build review of the PRD-650 tree: status board, coverage tables, severity-ordered findings, tracking drift, ranked risks, next moves, and the commands run | Dated review evidence — findings carry file:line anchors as of `develop@665e8a573` |
 | `prototypes-artifact.build.ts` | Generator for the Flow Prototypes artifact; reads the `hifi/` registry alone (the retired `prototypes.md` stays as history, register #96) | Generator — never hand-edit its output |
 | `card-explorations.build.ts` | One-shot cycle/promise card study retained until the Components tab supersedes the review artifact | Design exploration — not canonical implementation truth |
 | `visual-assets.md` | Index of the audience graphics (SVG + 2x PNG) + style contract + regeneration; the ongoing-Offer story and architecture assets are published | Asset index |

--- a/.plans/active/commitment-pooling/prompt-client-loop.md
+++ b/.plans/active/commitment-pooling/prompt-client-loop.md
@@ -39,7 +39,8 @@ them, never run `git` against them. Do not remove this worktree at the end; Afo 
 - Never `git add -A`: stage explicit paths. Before each commit, `git status --short` from the
   worktree root and confirm no `node_modules`, `.env`, or `.generated` stray is staged.
 - The second branch, `feature/commitment-pooling-client-over-time`, is created from this worktree
-  with `git switch -c` only after the D1 PR is open; do not create a second worktree.
+  with `git switch -c` off the updated `develop` only after the D1 PR has merged; do not create a
+  second worktree and do not open D2 against `develop` while D1 is still open.
 
 Worktree creation (Afo runs this before the session starts):
 
@@ -55,6 +56,26 @@ Absolute paths on the `ln` (a relative one once landed a stray symlink inside `h
 non-secret baseline over it; `mise trust` first or Node falls back to v18 and the husky hook dies
 with a misleading `toSorted` error.
 
+## Dispatch gate (check before anything else)
+
+The hub still records the product-UI lane as manually blocked: `status.json` has
+`lanes.ui.manual_blocked: true` and `execution_sub_lanes.ui_client.status: "blocked"`, and
+`handoffs/claude-ui-client.md` names verified live indexer read-back and the admin-foundation
+cleanup as unblock evidence. PR #740 was dispatched under the narrowed option without that
+transition being recorded, which is how its scope went unrecorded. Do not repeat that.
+
+Start only when both are true:
+
+1. Afo has recorded the scope-lock in the hub on this branch, in its own first commit:
+   `node scripts/harness/plan-hub.mjs set-lane --feature commitment-pooling --lane ui --status in_progress --actor human --branch feature/commitment-pooling-client-loop --note "Narrowed client dispatch: Phase 0 + D1 + D2 of prompt-client-loop.md, built against fixtures and the local stack before hosted read-back; rendered live proof deferred to the hosted Envio deployment"`,
+   the `execution_sub_lanes.ui_client` entry updated to match (`status`, `branch`,
+   `blocked_reason` replaced by the same note), then `bunx biome format --write` on `status.json`
+   (the plan-hub command rewrites it with raw `JSON.stringify`).
+2. `git log -1 -- .plans/active/commitment-pooling/status.json` on this branch shows that commit.
+
+If either is missing, stop and report "dispatch gate not recorded"; do not edit product code. The
+ledger flip and the hosted Envio deployment stay outside this lane regardless.
+
 ## Objective
 
 Make the client PWA able to run one real commitment end to end for a member: create (service
@@ -62,10 +83,12 @@ Make the client PWA able to run one real commitment end to end for a member: cre
 "Not yet", and find all of it from the commitments sheet. Then (D2) make "Offer over time" usable:
 saved Offers, an ongoing Offer with finite places, its Story, rest/resume/retire.
 
-Deliver as **two PRs to `develop`**: D1 from `feature/commitment-pooling-client-loop`, D2 from
-`feature/commitment-pooling-client-over-time` (a branch off D1 created in this worktree after the
-D1 PR is open). PR bodies use `Refs PRD-724` and `Refs PRD-650`. Do not change any Linear state or
-create Linear records; Afo does that.
+Deliver as **two PRs to `develop`**: D1 from `feature/commitment-pooling-client-loop`; D2 from
+`feature/commitment-pooling-client-over-time`, opened only after the D1 PR has merged and the D2
+branch is rebased onto the updated `develop` (a stacked PR against `develop` would carry the whole
+D1 diff and trips this repo's CI Gate base-branch filter). Each PR body links exactly one issue
+for resolution: `Refs PRD-724` (partial work), plus `Relates to PRD-650` for context only. Do not
+change any Linear state or create Linear records; Afo does that.
 
 ## Present state (verified 2026-08-21; re-verify cheaply before trusting)
 
@@ -79,7 +102,9 @@ create Linear records; Afo does that.
 - PR #745 and #746 merged the public editorial readers (`usePublicGardenPool`,
   `usePublicCommitmentImpact`, `cycle-metadata.ts`) into `develop`, so cycle-name resolution is
   available to the client.
-- The shared layer is complete and the backend supports everything below: hooks exported from
+- The shared layer supports everything below, with three gaps this prompt closes in Phase 0 and
+  Phase 1 (membership preflight coverage, offline evidence payload, pool pause/readiness fields):
+  hooks exported from
   `packages/shared/src/hooks/commitment-pooling/index.ts` (`useCommitment`, `useCommitmentPool(s)`,
   `useCommitmentCycle(s)`, `useCommitmentClaimRequests`, `useCommitmentSeries`,
   `useCommitmentSeriesDetail`, `useCommitmentsInbox`, `useCommitmentJobs`,
@@ -108,8 +133,14 @@ create Linear records; Afo does that.
   `cancelCommitment(uint256,string reasonCID)`); sheet rows have no `onOpen`
   (`LiveTab.tsx:152-161`, `OverTimeTab.tsx:160-168`) and `needsYou` is hard-coded `false`
   (`GardenPool.tsx:75`); the detail bar reads only `pendingCommitmentIds` so a failed queue read
-  re-arms the act (`GardenCommitment.tsx:76`) and `claim`/`confirmation` jobs carry no identity
-  key (`job-identity.ts:90-130`); `tap-target` is not a defined utility (only `.tap-target-lg`
+  re-arms the act (`GardenCommitment.tsx:76`) — note that queue-level deduplication for
+  claim/evidence/confirmation already exists (`commitmentJobIdentity` in
+  `modules/job-queue/queue-policy.ts:27-48`, enforced by `addJob` at `modules/job-queue/index.ts:147-158`),
+  so the detail-bar problem is the re-armed button, not a missing identity; the membership preflight
+  in `modules/commitment-pooling/job-executor.ts:84-87` runs only when a payload carries
+  `gardenAddress`, which `ClaimJobPayload`, `EvidenceJobPayload`, `WorkLinkJobPayload`, and the
+  confirmation payload do not (`job-types.ts`), so those four jobs skip the waiting-for-membership
+  path and spend retries on a revert instead; `tap-target` is not a defined utility (only `.tap-target-lg`
   exists in `packages/client/src/styles/utilities.css:30-39`; sites `LiveTab.tsx:121`,
   `GardenPool.tsx:125-126`, `ComposeTerms.tsx:46-47`); the bottom nav stays under the
   detail/composer action bars (`AppBar.tsx:22,35` hides it only for `/work/`;
@@ -200,15 +231,27 @@ create Linear records; Afo does that.
    and `resolveDispute` use the same helper.
 3. The sheet opens things: pass `onOpen` from both tabs to `CommitmentRow`, navigating to
    `/home/:gardenId/commitments/:commitmentId` (series rows in D2 go to W34). Derive `needsYou` on
-   the pool tab from `selectCommitmentActKind` for the viewer's seat instead of `false`.
+   the pool tab from `commitmentNeedsSeat` (`acts.ts:153`, which excludes the elective withdraw /
+   take-up / ask-to-take-up / offer-again acts) with the viewer's seat from `selectCommitmentSeat`,
+   not from `selectCommitmentActKind`, which would badge rows nobody is waiting on.
 4. Queue truth on the detail bar: consume `isUnavailable`, `pendingCommitmentIds`, and
    `failedCommitmentIds` from `useCommitmentQueueState`; an unreadable queue disables the act with
-   the existing `app.commitments.*` queue-unreadable copy rather than offering it. Add
-   deterministic identity keys for `claim` and `confirmation` jobs in `job-identity.ts` /
-   `prepareCommitmentJobPayload`, with a RED test in
-   `packages/shared/src/__tests__/commitment-jobs.test.ts` proving a second enqueue of the same act
-   is rejected or deduplicated.
-5. Small fixes: replace `tap-target` with `tap-target-lg` (or define it) at the five sites; hide
+   the existing `app.commitments.*` queue-unreadable copy rather than offering it. Do not add new
+   identity fields to the claim or confirmation payloads: `commitmentJobIdentity`
+   (`queue-policy.ts`) already derives claim identity from commitment + kind + garden context and
+   confirmation identity from action + commitment, and `addJob` returns the existing non-terminal
+   job or throws `offline_job_identity_conflict`. Add regression coverage for that existing policy
+   in `packages/shared/src/__tests__/commitment-jobs.test.ts` (second enqueue of the same claim /
+   confirm returns the existing job id; a differing payload conflicts) and only add an identity
+   dimension if a concrete missing one is demonstrated.
+5. Membership preflight for every membership-gated job: add `gardenAddress` to
+   `ClaimJobPayload`, `EvidenceJobPayload`, `WorkLinkJobPayload`, and the confirmation payload (or
+   resolve it inside `job-executor.ts` from `readCommitment` → pool → garden before the send) so
+   the preflight at `job-executor.ts:84-87` returns `waiting` / `membership-unavailable` instead
+   of spending retries on a revert. RED tests in `commitment-jobs.test.ts` and
+   `modules/job-queue.commitment-policy.test.ts` for each kind; persisted payload shape changes
+   need a read-compatibility test for jobs queued before the change.
+6. Small fixes: replace `tap-target` with `tap-target-lg` (or define it) at the five sites; hide
    the bottom nav on `/home/:id/commitments/*` and add the commitments drawer to
    `isAnyDrawerOpen`; pass the translated unplaced label in `LiveTab`; translate `app.garden.pool`
    in es/pt; `aria-label` on progress bars; single heading on detail; requirement rows show the
@@ -232,15 +275,31 @@ Build in this order; each item names the prototype states it must render (ids fr
    request-work-*`, `validation`, `draft-resume`. `step-advanced` (confirmers, protocol-fallback
    opt-out) is required only if the shared composer form already models confirmers; otherwise
    record it as not built.
-3. **Proof composer (W2a).** New route `commitments/:commitmentId/proof`; states `media,
-   media-preview, details, review, review-request, review-support, review-captured, queued,
-   failed`; enqueue `{ act: "evidence", payload }` with `creditedContributors` carried durably;
-   reuse the Submit Work media / `FormProgress` rhythm. "Add proof" on W2 opens it instead of
-   navigating away; `band.provider.active.b` copy must describe what the screen actually shows.
-4. **Link work (WFLOW).** From W2, a "Link work" act opens a picker of the viewer's approved Work
-   in this garden (`link-picker`) and enqueues `{ act: "workLink", payload }`; the Work Review view
-   gains a read-only "Fulfills" row from `meta.commitmentId` (`WFLOW@review`), navigable both
-   ways, never editable. Remove the linked-work promise from copy if you cannot render it.
+3. **Proof composer (W2a).** Shared first: `EvidenceJobPayload` is `{ commitmentId, cid,
+   creditedContributors }` and its executor calls `attachEvidence` immediately
+   (`job-executors.ts:203-206`), so today nothing can be queued offline without a CID already in
+   hand. Extend the payload with the raw evidence document (note, links, details) and persist the
+   media the way the work job does (`jobQueueDB.getImagesForJob` → upload at execution,
+   `executeWorkJob`, `job-executors.ts:33-45`); the executor publishes the document and media at
+   sync, writes the resulting `cid` back onto the job, then attaches. Keep `cid` optional at
+   enqueue and required at send; RED tests for queue-offline → restart → upload → attach, and for
+   upload failure leaving the job `waiting`, not terminal. Then the screen: new route
+   `commitments/:commitmentId/proof`; states `media, media-preview, details, review,
+   review-request, review-support, review-captured, queued, failed`; enqueue
+   `{ act: "evidence", payload }` with `creditedContributors` carried durably; reuse the Submit Work
+   media / `FormProgress` rhythm. "Add proof" on W2 opens it instead of navigating away;
+   `band.provider.active.b` copy must describe what the screen actually shows.
+4. **Link work (WFLOW).** The Work model has no `meta.commitmentId` (zero readers in shared or
+   client), and the indexer's `CommitmentWorkAttribution` is read only commitment → work
+   (`data-commitments.ts:143`). Add a shared reader that returns attributions by `workUID` (same
+   entity, `where: { workUID }`, plus a query key under `queryKeys.commitmentPooling.*`) and a
+   hook over it; that is the data source for the read-only "Fulfills" row on the Work Review view
+   (`WFLOW@review`), navigable both ways, never editable. From W2, a "Link work" act opens a
+   picker of the viewer's approved Work in this garden (`link-picker`) and enqueues
+   `{ act: "workLink", payload }`. Persisting a commitment reference on Work *submitted from* a
+   commitment deep link (the handoff's `meta.commitmentId` path) touches the work metadata schema
+   outside this lane's paths; treat it as decision 6 below and do not build it unasked. Remove the
+   linked-work promise from copy if you cannot render it.
 5. **Confirmation sheet (W4).** Replace the bare bar button with the sheet: `confirm-domain,
    confirm-support, confirm-request, confirm-request-work, confirm-campaign-request,
    confirm-captured`, evidence preview read-only, direction-aware seat (Offer receiver / Request
@@ -256,10 +315,17 @@ Build in this order; each item names the prototype states it must render (ids fr
    only for eligible stewards, binding `claimant = GardenAccount`, `requestedBy = steward`,
    `gardenContext`; the choice is resolved before the claim job is enqueued and never rewritten
    after.
-7. **Pool readiness and pause (W1).** `not-ready` renders the readiness checklist (charter,
-   qualifying baseline, provider open-commitment cap) from `useCommitmentPool`; `paused` shows the
-   reason; `queued` / `sync-failed` rows from queue state; `waiting-membership`. Keep lifecycle
-   notices as they are.
+7. **Pool readiness and pause (W1).** Shared first: `CommitmentPoolRecord` and
+   `getCommitmentPoolDetail` omit the indexer's `pauseReasonCID` / `pauseReasonBlockNumber`
+   (`schema.graphql:731-733`) and carry no qualifying-Baseline fact, so the states below have no
+   data source yet. Extend the pool read model and query with the pause-reason fields (resolve the
+   CID through the metadata helper, em dash when unresolvable), and source the Baseline from the
+   existing garden assessment reads (the same preflight the admin handoff calls "the app-preflight
+   Baseline"; if no shared selector exists for it, render the checklist without the Baseline row
+   and record that as not built rather than inventing one). Then: `not-ready` renders the
+   readiness checklist (charter, qualifying baseline, provider open-commitment cap); `paused`
+   shows the resolved reason; `queued` / `sync-failed` rows from queue state;
+   `waiting-membership`. Keep lifecycle notices as they are.
 8. **Team (W2b, read side only).** Render the roster (lead + contributors, requirement assignment
    where present) from the read model: `setup, forming, open-member, frozen, recognition`. Roster
    *mutations* are online-only and steward-gated; build the "join" path only if
@@ -306,18 +372,29 @@ Checkpoint after Phase 2 as above, then the D2 PR.
   could not).
 - Locale: `packages/shared/src/__tests__/i18n/locale-coverage.test.ts` green; `bun run lint:vocab`
   green.
-- Types: the client build does not type-check (solution tsconfig, known repo defect). Run
+- Types: the client `build` script's `tsc --noEmit` runs against a solution-style `tsconfig.json`
+  with `"files": []`, so it checks zero files and passes regardless of type errors (known repo
+  defect; `bun run build` is therefore green today and stays satisfiable). That is why you run the
+  real project check by hand:
   `cd packages/client && node ../../scripts/dev/node-cli.js tsc --noEmit -p tsconfig.app.json 2>&1 | grep -E "views/Home/(Garden|CommitmentsDrawer)|Features/Commitments"`
-  and leave zero errors in files you touched; do not try to clear the ~80 pre-existing ones.
+  and leave zero errors in files you touched; do not try to clear the ~80 pre-existing ones, and
+  do not treat them as a Ship Gate failure, because the gate does not see them.
 - Design: `bun run check:design-tokens` green; a `*.stories.tsx` for `CommitmentRow`,
   `CommitmentStateLadder`, `CycleRail`, the proof composer, and the confirmation sheet alongside
   the 20 existing client stories; the prototype build still passes.
 - Rendered proof: `bun run dev` from this worktree, then
   `https://localhost:3001/home?mockAuth=user&presentation=pwa` (and `operator` for steward paths)
-  through the authenticated Brave QA profile via the Claude-in-Chrome extension. Offline states:
-  dispatch `window.dispatchEvent(new Event("offline"))` while the target view is mounted. If the
+  through the authenticated Brave QA profile via the Claude-in-Chrome extension. If the
   authenticated profile is unavailable, report browser QA as BLOCKED; do not substitute an isolated
   Playwright/Browser-pane profile as proof.
+- Offline proof must be real. A synthetic `window.dispatchEvent(new Event("offline"))` only flips
+  the `useOffline` listener; the queue itself reads `navigator.onLine` before processing
+  (`modules/job-queue/index.ts:124,255`, `providers/JobQueue.tsx:321,375`), so jobs would sync
+  immediately and prove nothing. Use an actual offline network state (Brave DevTools → Network →
+  Offline, or the OS network off), enqueue, reload the PWA while still offline, confirm the job
+  and its media survived the restart, then restore the network and watch it send. The handoff's
+  real-device pass (installed PWA, airplane mode, relaunch) is part of D1's evidence, not
+  optional; if no device is available, record it as BLOCKED.
 - Before each PR, the Ship Gate: `bun format && bun lint && bun run test && bun run build`. Re-run
   Biome on touched files before staging (the PostToolUse formatter may reformat with the wrong
   style).
@@ -335,6 +412,9 @@ Checkpoint after Phase 2 as above, then the D2 PR.
    form does not model it yet.
 4. Roster join/leave mutations (steward-gated, online-only) in D1 or deferred.
 5. The local ledger flip for rendered QA, if you need it longer than one QA session.
+6. Whether Work submitted from a commitment deep link should persist a commitment reference in
+   its metadata (the handoff's `meta.commitmentId`), which touches the work metadata schema
+   outside this lane's paths, or whether the indexer attribution is the only source.
 
 ## Stop conditions
 

--- a/.plans/active/commitment-pooling/prompt-client-loop.md
+++ b/.plans/active/commitment-pooling/prompt-client-loop.md
@@ -1,0 +1,346 @@
+# Complete the Commitment Pooling client PWA: close the member loop (D1), then Offer over time (D2)
+
+Dispatch prompt for a fresh Claude Code session. Written 2026-08-21 from the build review in
+`reports/build-review-2026-08-21.md`. Paste it whole; the facts under "Present state" were verified
+that day and should be re-verified cheaply before they are trusted.
+
+You are working in the Green Goods monorepo. Read `CLAUDE.md` and `AGENTS.md` first; they bind
+you. This repo runs concurrent Claude/Codex sessions on the same tree: stay inside the paths named
+below, treat any working-tree change you did not make as another agent's work (stash, never
+revert), never `git add -A`, never switch the primary tree's branch except as instructed here.
+
+## Worktree
+
+You are in the worktree `/Users/afo/Code/greenpill/green-goods/.claude/worktrees/client-loop` on
+`feature/commitment-pooling-client-loop`, branched from `origin/develop`. The primary checkout at
+`/Users/afo/Code/greenpill/green-goods` and every other `.claude/worktrees/*` directory belong to
+other sessions: never read their uncommitted files, never symlink, copy, install into, or clean
+them, never run `git` against them. Do not remove this worktree at the end; Afo does.
+
+- `.env` here is a symlink to the primary repo's `.env`; treat it as read-only. If a secret-backed
+  step fails, report it env-gated rather than editing env.
+- Dependencies were installed with `bun run setup:isolated` (frozen lockfile). Do not run any other
+  install.
+- Run the dev stack **from this worktree** (`bun run dev`, or `bun run dev:web` if Docker is not
+  needed) so the browser serves the code you are editing. PM2 is one daemon for the machine and
+  `scripts/dev/stack.js` deletes same-named apps before starting, so starting here takes over
+  ports 3001–3009 from any other checkout. If `bun run dev:doctor -- --profile web` reports ports
+  in use, stop and tell Afo which tree holds them instead of killing anything. `bun run dev:stop`
+  stops the stack wherever it was started.
+- `dev:web` serves the UI against the indexer named in `.env`, which has no pooling schema yet, so
+  pooling queries land in read-error states. For real pooling data use `bun run dev` (Docker): the
+  local Envio builds from this worktree and mirrors live Arbitrum, where 18 pools are registered;
+  writes go to the Anvil fork.
+- The indexer legs of `bun run test` / `bun run build` may fail on `envio codegen` in a fresh
+  worktree; prove it pre-existing with a stash and report that leg as env-gated. Everything else in
+  the Ship Gate must actually pass here.
+- Repo-root `bun build` invokes Bun's bundler, not the package script; always `bun run build`.
+  Capture a stage's exit code before piping to `tail`.
+- Never `git add -A`: stage explicit paths. Before each commit, `git status --short` from the
+  worktree root and confirm no `node_modules`, `.env`, or `.generated` stray is staged.
+- The second branch, `feature/commitment-pooling-client-over-time`, is created from this worktree
+  with `git switch -c` only after the D1 PR is open; do not create a second worktree.
+
+Worktree creation (Afo runs this before the session starts):
+
+```bash
+git -C /Users/afo/Code/greenpill/green-goods fetch origin develop
+git -C /Users/afo/Code/greenpill/green-goods worktree add /Users/afo/Code/greenpill/green-goods/.claude/worktrees/client-loop -b feature/commitment-pooling-client-loop origin/develop
+ln -s /Users/afo/Code/greenpill/green-goods/.env /Users/afo/Code/greenpill/green-goods/.claude/worktrees/client-loop/.env
+cd /Users/afo/Code/greenpill/green-goods/.claude/worktrees/client-loop && mise trust && bun run setup:isolated
+```
+
+Absolute paths on the `ln` (a relative one once landed a stray symlink inside `hifi/screens/`); the
+`.env` link is a brand-new path and must come before `setup:isolated` so setup does not write its
+non-secret baseline over it; `mise trust` first or Node falls back to v18 and the husky hook dies
+with a misleading `toSorted` error.
+
+## Objective
+
+Make the client PWA able to run one real commitment end to end for a member: create (service
+**or** garden-work), claim, add proof, link approved work, send for confirmation, confirm or say
+"Not yet", and find all of it from the commitments sheet. Then (D2) make "Offer over time" usable:
+saved Offers, an ongoing Offer with finite places, its Story, rest/resume/retire.
+
+Deliver as **two PRs to `develop`**: D1 from `feature/commitment-pooling-client-loop`, D2 from
+`feature/commitment-pooling-client-over-time` (a branch off D1 created in this worktree after the
+D1 PR is open). PR bodies use `Refs PRD-724` and `Refs PRD-650`. Do not change any Linear state or
+create Linear records; Afo does that.
+
+## Present state (verified 2026-08-21; re-verify cheaply before trusting)
+
+- `develop` is at or past `67a32ae41`. PR #740 (`173a2a627`) shipped the client slice:
+  `packages/client/src/views/Home/CommitmentsDrawer/*` (W5 sheet), `views/Home/Garden/Pool/*`
+  (W1), `views/Home/Garden/Commitment/*` (W2 + withdraw), `views/Home/Garden/Compose/*` (W3,
+  service-only), `components/Features/Commitments/*`, routes `commitments/new` and
+  `commitments/:commitmentId` in `packages/client/src/router.config.tsx:215-222`, 225
+  `app.(commitments|commitment|pool|compose).*` keys mirrored in
+  `packages/shared/src/i18n/{en,es,pt}.json`. 12 client test files / 104 tests pass.
+- PR #745 and #746 merged the public editorial readers (`usePublicGardenPool`,
+  `usePublicCommitmentImpact`, `cycle-metadata.ts`) into `develop`, so cycle-name resolution is
+  available to the client.
+- The shared layer is complete and the backend supports everything below: hooks exported from
+  `packages/shared/src/hooks/commitment-pooling/index.ts` (`useCommitment`, `useCommitmentPool(s)`,
+  `useCommitmentCycle(s)`, `useCommitmentClaimRequests`, `useCommitmentSeries`,
+  `useCommitmentSeriesDetail`, `useCommitmentsInbox`, `useCommitmentJobs`,
+  `useCommitmentQueueState`, `useCommitmentMutation`, `useCommitmentComposerForm`,
+  `useCommitmentMetadata(For)`, `useSavedOffers` / `useSavedOffer` / `useSavedOfferPersistence`,
+  `useCommitmentPoolingAvailability`), offline job kinds in
+  `packages/shared/src/modules/commitment-pooling/job-types.ts` (`commitmentSeries, commitment,
+  claim, evidence, workLink, confirmation`), act selector `selectCommitmentActKind` in
+  `modules/commitment-pooling/acts.ts`, identity keys in `modules/commitment-pooling/job-identity.ts`,
+  IPFS pinning via `uploadJSONToIPFS` in `packages/shared/src/modules/data/ipfs/upload.ts` (the
+  create job pins metadata in `modules/job-queue/job-executors.ts`, around lines 300–330).
+- `useCommitmentJobs` accepts
+  `{act: "claim"|"evidence"|"workLink"|"sendForConfirmation"|"confirm"|"create"}`
+  (`useCommitmentJobs.ts:33-40`). There is **no act for `commitmentSeries`** yet; D2 must add one
+  (shared change, allowed).
+- Availability is a build-time ledger: `packages/shared/src/ontology/agent-manifest.generated.json`
+  → `entity:commitment-pool` chain 42161 = `deployed-not-available`, so `addJob` throws for every
+  commitment kind and every authenticated pooling query is disabled, in production **and** in the
+  local stack (the local stack also runs chain 42161). The hosted Envio does not yet serve the
+  pooling schema. This is release work owned elsewhere; do not make it your problem beyond the QA
+  rule below.
+- Known defects in the shipped slice (fix these first, see Phase 0): deep links render "not found"
+  whenever availability is not `available` (`GardenCommitment.tsx:91` runs before the availability
+  branch at `:103`); the withdraw reason is sent raw as `reasonCID` (`WithdrawDialog.tsx:62` →
+  `GardenCommitment.tsx:285-291` → `useCommitmentMutations.ts:103-105` →
+  `cancelCommitment(uint256,string reasonCID)`); sheet rows have no `onOpen`
+  (`LiveTab.tsx:152-161`, `OverTimeTab.tsx:160-168`) and `needsYou` is hard-coded `false`
+  (`GardenPool.tsx:75`); the detail bar reads only `pendingCommitmentIds` so a failed queue read
+  re-arms the act (`GardenCommitment.tsx:76`) and `claim`/`confirmation` jobs carry no identity
+  key (`job-identity.ts:90-130`); `tap-target` is not a defined utility (only `.tap-target-lg`
+  exists in `packages/client/src/styles/utilities.css:30-39`; sites `LiveTab.tsx:121`,
+  `GardenPool.tsx:125-126`, `ComposeTerms.tsx:46-47`); the bottom nav stays under the
+  detail/composer action bars (`AppBar.tsx:22,35` hides it only for `/work/`;
+  `isCommitmentsDrawerOpen` missing from `isAnyDrawerOpen` at `:32-33`); the Live tab's unplaced
+  heading is English in es/pt (`grouping.ts:21` default, `LiveTab.tsx:54` omits the label);
+  `app.garden.pool` is "Pool" in es/pt; progress bars have no accessible name
+  (`CommitmentProgress.tsx:67-73`); the detail heading renders twice
+  (`GardenCommitment.tsx:243,319`); requirement rows read "Requirement N" instead of the action
+  (`CommitmentProgress.tsx:55-58`); `CycleRail.tsx:58-77` omits names and dates the record carries
+  (`types-core.ts:154-156`).
+
+## Authoritative inputs (read in this order, before editing)
+
+1. `.plans/active/commitment-pooling/handoffs/claude-ui-client.md` — the lane contract. Note
+   line 37: the shipped PR took the "narrowed dispatch option" (W1–W5); you are completing that
+   scope and the member loop, not the settlement slices.
+2. `.plans/active/commitment-pooling/uiux-spec.md` §5 (Client PWA) and Appendix F (Offer once /
+   over time). Binding rule at `uiux-spec.md:685-687`: direction is fixed by the entry CTA and
+   never renders as an in-form Direction control.
+3. `.plans/active/commitment-pooling/handoffs/commitment-view-state-reference.md` — generated
+   per-state contract for the commitment detail screen (cast, seat, phase, act). Never hand-edit
+   it.
+4. Prototype source of truth: `.plans/active/commitment-pooling/hifi/screens/client.ts` (W1, W2,
+   W2a, W2b, W3, W4, W25, WFLOW), `hifi/screens/client-wallet.ts` (W5, W32, W34, W35),
+   `hifi/journeys.ts` (flows; sb1/sb42 confirm, sb5/sb47 Not yet, sb13/sb46 garden claim,
+   sb33/sb45 team), `prototypes-coverage.md` § Screen registry (state ids per screen). Build the
+   click-through locally to look at screens:
+   `bun .plans/active/commitment-pooling/prototypes-artifact.build.ts` (or
+   `OUT=/path/out.html bun …`); the build fails on any broken state/journey ref, which is the
+   validator you want.
+5. Design rules: `.claude/skills/design/quick-reference.md`,
+   `.claude/skills/design/client-prompt-contract.md` § Canonical Component Palette,
+   `.claude/skills/design/review-checklist.md` (apply Lenses 1 + 4 per PR; all four for the two
+   new screens), `.claude/rules/react-patterns.md`, `.claude/rules/frontend-design.md`,
+   `.claude/context/client.md` (presentation mode). Reuse shipping client rhythms (`ModalDrawer`,
+   `EmptyState`, `FormProgress`, the Submit Work media composer, `DialogShell`, `Alert`,
+   `StatusBadge`); do not invent parallel patterns. Tokens only (`--spring-*`, `--color-*`,
+   `--radius-*`); no raw easings, durations, colors, or `--m3-*`. Tailwind v4 does not scan
+   `packages/shared/src/**` from the client build: any layout utility a shared component needs
+   goes on the client wrapper or inline.
+6. `packages/contracts/src/interfaces/ICommitmentPoolingModule.sol` for the exact Series, dispute,
+   claim, evidence, and work-link functions;
+   `packages/shared/src/modules/commitment-pooling/{types-core,job-types,acts,job-identity,metadata}.ts`
+   for payload shapes; `.plans/active/commitment-pooling/contract-spec.md` (grep `reasonCID` and
+   `metadataCID`) for the reason/metadata CID shape before pinning anything.
+7. Prior adversarial rounds so you do not reopen closed findings:
+   `.plans/active/commitment-pooling/review-prompt-client-ui-round{2,3,4,5}.md` and fix commits
+   `dd12817ab 694a20316 f5e86ae37 c984ec5ef 5f0f99dee d651dca49`.
+
+## Boundaries
+
+- Hooks live only in `@green-goods/shared`; client gets components and views. Import only declared
+  `@green-goods/shared` export paths.
+- Allowed write paths: `packages/client/src/**`,
+  `packages/shared/src/{hooks/commitment-pooling,modules/commitment-pooling,modules/job-queue,types,i18n,stores}/**`
+  and their tests, `.plans/active/commitment-pooling/handoffs/claude-ui-client.md` (append only:
+  the built/not-built table), and a new `.plans/active/commitment-pooling/reports/client-loop-<date>.md`.
+  No contract, indexer, ontology, `.github`, `package.json`, lockfile, or `.env*` changes. Do not
+  install dependencies.
+- Never commit a change to this worktree's `packages/shared/src/ontology/green-goods-projections.json`
+  or the generated manifest. For rendered QA only, you may flip chain 42161 `entity:commitment-pool`
+  to `integration: integrated, availability: available` locally, regenerate
+  (`bun run ontology:generate`), QA, then revert both files before staging. State in the PR that
+  live authenticated proof is pending the hosted Envio deployment.
+- Every user-facing string lands in `en.json`, `es.json`, and `pt.json` in the same change; public
+  copy says "commitment", never "promise" (`promiseKeptRate` is a code identifier only). No score,
+  rank, reputation, reliability, leaderboard, or inferred participant copy anywhere.
+- No settlement slices (W23 G$ wallet, consideration-status rows on W2, W36 member-funded claim,
+  online `transfer`), no exchange pairs or templates (W28–W31), no declared value / "in exchange
+  for", no admin or editorial work, no Linear writes. If you believe one of these is needed to
+  finish an item, stop and report it as a decision.
+- Offline-first is the top priority in every trade-off: every field act enqueues through
+  `useCommitmentJobs` and survives restart; online-only acts (`raiseDispute`, rest/resume/retire,
+  saved-Offer remote save) say so in copy and degrade honestly offline.
+
+## Method
+
+### Phase 0 — fix the shipped slice (one commit per item, tests first)
+
+1. Availability before not-found: in `GardenCommitment.tsx` test
+   `availability.status !== "available"` before the not-found branch; rewrite the test at
+   `GardenCommitment.test.tsx:231-239` so its fixture returns `detail: null` when unavailable (the
+   real hook never returns a populated `detail` while unavailable). Apply the same ordering to
+   `GardenPool.tsx` and the sheet if they share the shape.
+2. Reasons are CIDs: add a shared helper that pins a versioned reason document (follow the CID
+   shape the spec names) with `uploadJSONToIPFS`, and make withdraw pin before `cancelCommitment`;
+   on pin failure, keep the dialog open with a retry, never submit raw text. `raiseDispute` (D1)
+   and `resolveDispute` use the same helper.
+3. The sheet opens things: pass `onOpen` from both tabs to `CommitmentRow`, navigating to
+   `/home/:gardenId/commitments/:commitmentId` (series rows in D2 go to W34). Derive `needsYou` on
+   the pool tab from `selectCommitmentActKind` for the viewer's seat instead of `false`.
+4. Queue truth on the detail bar: consume `isUnavailable`, `pendingCommitmentIds`, and
+   `failedCommitmentIds` from `useCommitmentQueueState`; an unreadable queue disables the act with
+   the existing `app.commitments.*` queue-unreadable copy rather than offering it. Add
+   deterministic identity keys for `claim` and `confirmation` jobs in `job-identity.ts` /
+   `prepareCommitmentJobPayload`, with a RED test in
+   `packages/shared/src/__tests__/commitment-jobs.test.ts` proving a second enqueue of the same act
+   is rejected or deduplicated.
+5. Small fixes: replace `tap-target` with `tap-target-lg` (or define it) at the five sites; hide
+   the bottom nav on `/home/:id/commitments/*` and add the commitments drawer to
+   `isAnyDrawerOpen`; pass the translated unplaced label in `LiveTab`; translate `app.garden.pool`
+   in es/pt; `aria-label` on progress bars; single heading on detail; requirement rows show the
+   action title via `useCommitmentMetadataFor` / the action registry; `CycleRail` shows start/end
+   dates and the versioned cycle name via `cycle-metadata.ts` (merged in #745).
+
+### Phase 1 — D1, close the loop (each item: RED test → implementation → targeted proof)
+
+Build in this order; each item names the prototype states it must render (ids from
+`prototypes-coverage.md` § Screen registry) and the shared API it consumes.
+
+1. **Two-door entry (W1 → W3).** Replace the single "compose" button and the in-form direction
+   beat (`Compose/ComposeKind.tsx`) with two one-word doors on the pool tab that fix direction by
+   route (`commitments/new?direction=offer|request`), per `uiux-spec.md:685-687` and
+   `hifi/screens/client.ts` (around line 522). Visible change; call it out in the PR.
+2. **Garden-work commitments (W3).** Add the kind choice (`step-what`: garden work vs service) and
+   DomainImpact requirement rows `{ actionUID, requiredCount }` (1..`MAX_REQUIREMENTS`, same-domain
+   actions allowed, derived domain tags shown read-only), with the ordered payload surviving
+   restart/retry. Extend `commitmentComposerSchema` / `buildCommitmentCreationPayload` in shared;
+   states `step-what, step-howmuch, step-details, details-preview, step-review, step-review-read,
+   request-work-*`, `validation`, `draft-resume`. `step-advanced` (confirmers, protocol-fallback
+   opt-out) is required only if the shared composer form already models confirmers; otherwise
+   record it as not built.
+3. **Proof composer (W2a).** New route `commitments/:commitmentId/proof`; states `media,
+   media-preview, details, review, review-request, review-support, review-captured, queued,
+   failed`; enqueue `{ act: "evidence", payload }` with `creditedContributors` carried durably;
+   reuse the Submit Work media / `FormProgress` rhythm. "Add proof" on W2 opens it instead of
+   navigating away; `band.provider.active.b` copy must describe what the screen actually shows.
+4. **Link work (WFLOW).** From W2, a "Link work" act opens a picker of the viewer's approved Work
+   in this garden (`link-picker`) and enqueues `{ act: "workLink", payload }`; the Work Review view
+   gains a read-only "Fulfills" row from `meta.commitmentId` (`WFLOW@review`), navigable both
+   ways, never editable. Remove the linked-work promise from copy if you cannot render it.
+5. **Confirmation sheet (W4).** Replace the bare bar button with the sheet: `confirm-domain,
+   confirm-support, confirm-request, confirm-request-work, confirm-campaign-request,
+   confirm-captured`, evidence preview read-only, direction-aware seat (Offer receiver / Request
+   creator), named-group option only when the confirmer rule names one, `PoolFallback` /
+   `ProtocolFallback` provenance when the indexed record says so, `confirmed-pending*` (queued
+   offline) and `confirmed*`. "Not yet" → `not-yet*` states → online `raiseDispute` via
+   `useCommitmentMutation` with a pinned reason; offline it explains it needs a connection and
+   keeps the draft reason locally; `not-yet-failed*` on revert.
+6. **Claims (W1 + W25).** Claim-request panels from `useCommitmentClaimRequests`: `claim-pending,
+   claim-declined, claim-superseded, claim-accepted`, a fresh re-request after decline, canonical
+   claimant vs `requestedBy` shown when they differ. For protocol-pool claims, the
+   `W25@context-chooser` (`card, context-chooser, pending, accepted`): Personal by default; Garden
+   only for eligible stewards, binding `claimant = GardenAccount`, `requestedBy = steward`,
+   `gardenContext`; the choice is resolved before the claim job is enqueued and never rewritten
+   after.
+7. **Pool readiness and pause (W1).** `not-ready` renders the readiness checklist (charter,
+   qualifying baseline, provider open-commitment cap) from `useCommitmentPool`; `paused` shows the
+   reason; `queued` / `sync-failed` rows from queue state; `waiting-membership`. Keep lifecycle
+   notices as they are.
+8. **Team (W2b, read side only).** Render the roster (lead + contributors, requirement assignment
+   where present) from the read model: `setup, forming, open-member, frozen, recognition`. Roster
+   *mutations* are online-only and steward-gated; build the "join" path only if
+   `useCommitmentMutation` already exposes it, else record as not built.
+9. **"To confirm" tab (W5).** `toconfirm, toconfirm-empty, toconfirm-loading,
+   toconfirm-read-error` from `useCommitmentsInbox`, routing to W4.
+
+Checkpoint after Phase 1: `node scripts/dev/ci-local.js --quick`, then the built/not-built table
+(below), then open the D1 PR.
+
+### Phase 2 — D2, Offer over time (branch off D1)
+
+1. **Series job act.** Add `{ act: "series", payload }` (or the name the spec uses) to
+   `useCommitmentJobs` over the existing `commitmentSeries` job kind and
+   `createSeriesCreationRequestKey`; RED test in `commitment-jobs-hook.test.tsx`.
+2. **Things I can offer (W32).** `compose, choose-path, draft-unsaved, saving, save-failed,
+   offline-local, version-conflict, persistence` over `useSavedOffers` /
+   `useSavedOfferPersistence` / `useSavedOffer`; private by default; every persistence state named
+   truthfully (`LOCAL_DRAFT, SAVING_REMOTE, SAVED_REMOTE, SAVE_FAILED, …` per the handoff
+   acceptance).
+3. **Offer once / over time in the composer (W3).** `saved-offer-edit, saved-offer-review,
+   saved-offer-queued, support-howmuch-ongoing, support-details-ongoing, support-review-ongoing`:
+   the ongoing path chooses a garden pool, creates or reuses its series, adds finite
+   capacity-backed places, and explains "Ask me again next cycle" as the default.
+4. **Ongoing Offer detail (W34, 24 states)** over `useCommitmentSeriesDetail`: `active-two,
+   active-none, active-one, places-queued, places-partial, places-partial-failed, story,
+   participation, ask-again, claimant-view, pool-ready/paused/closed/composted, edit-active*,
+   edit-stopped, stopped*, stop-confirm, preview, loading, read-error`. Claiming accepts an
+   existing place (one pre-created instance) and never creates one. Rest / resume / retire are
+   holder-only online mutations with reason where the ABI requires it; Story is exact linked
+   history with counts, no rate, rank, or inferred participants.
+5. **Places composer (W35)** `compose, queued, mixed-queued, mixed-failed`, and the W5
+   `overtime-ready / overtime-queued / overtime-queued-waiting` states routing to W34.
+
+Checkpoint after Phase 2 as above, then the D2 PR.
+
+## Evidence required in each PR
+
+- Targeted tests for every touched view and hook:
+  `cd packages/client && bun run test -- Commitment GardenPool Compose Proof Confirm Series`
+  (adjust the filter to your files) and `cd packages/shared && bun run test -- commitment i18n`.
+  Tests assert rendered DOM and enqueued payloads; when you mock a shared hook, the fixture must
+  match a shape the real hook can return (the unavailable/not-found bug survived because a fixture
+  could not).
+- Locale: `packages/shared/src/__tests__/i18n/locale-coverage.test.ts` green; `bun run lint:vocab`
+  green.
+- Types: the client build does not type-check (solution tsconfig, known repo defect). Run
+  `cd packages/client && node ../../scripts/dev/node-cli.js tsc --noEmit -p tsconfig.app.json 2>&1 | grep -E "views/Home/(Garden|CommitmentsDrawer)|Features/Commitments"`
+  and leave zero errors in files you touched; do not try to clear the ~80 pre-existing ones.
+- Design: `bun run check:design-tokens` green; a `*.stories.tsx` for `CommitmentRow`,
+  `CommitmentStateLadder`, `CycleRail`, the proof composer, and the confirmation sheet alongside
+  the 20 existing client stories; the prototype build still passes.
+- Rendered proof: `bun run dev` from this worktree, then
+  `https://localhost:3001/home?mockAuth=user&presentation=pwa` (and `operator` for steward paths)
+  through the authenticated Brave QA profile via the Claude-in-Chrome extension. Offline states:
+  dispatch `window.dispatchEvent(new Event("offline"))` while the target view is mounted. If the
+  authenticated profile is unavailable, report browser QA as BLOCKED; do not substitute an isolated
+  Playwright/Browser-pane profile as proof.
+- Before each PR, the Ship Gate: `bun format && bun lint && bun run test && bun run build`. Re-run
+  Biome on touched files before staging (the PostToolUse formatter may reformat with the wrong
+  style).
+- The PR body carries a **built / not built** table keyed to every state id named above and to the
+  acceptance bullets in `claude-ui-client.md`, with one line per "not built" saying why (deferred,
+  blocked, decision). Append the same table to `claude-ui-client.md` under a dated heading and
+  write the session report to `.plans/active/commitment-pooling/reports/client-loop-<date>.md`.
+  This table is the deliverable that was missing from PR #740; a PR without it is not done.
+
+## Decisions that return to Afo (do not guess)
+
+1. Reopen PRD-724 or open a successor issue for this work; you link `Refs PRD-724` either way.
+2. Confirm the two-door entry change (it replaces the shipped in-form direction control).
+3. Whether `step-advanced` (named confirmers, protocol-fallback opt-out) is in D1 if the shared
+   form does not model it yet.
+4. Roster join/leave mutations (steward-gated, online-only) in D1 or deferred.
+5. The local ledger flip for rendered QA, if you need it longer than one QA session.
+
+## Stop conditions
+
+- Complete: both PRs open against `develop` with green Ship Gate, the built/not-built table
+  attached, rendered proof or an explicit BLOCKED line, and no change outside the allowed paths.
+- Blocked: a required shared API is missing in a way that needs a contract or indexer change, the
+  authenticated Brave profile is unavailable, or a decision above is unanswered. Finish everything
+  not dependent on it, then report with the exact file and line.
+- Out of scope: anything listed under Boundaries. Report it; do not build it.

--- a/.plans/active/commitment-pooling/reports/build-review-2026-08-21.md
+++ b/.plans/active/commitment-pooling/reports/build-review-2026-08-21.md
@@ -21,7 +21,7 @@ does not exist yet.
 | Contracts | Live | 86 functions / 48 events / 20 libraries; deployed and unpaused on Arbitrum with 18 pools; 361 unit + 94 fuzz/invariant/integration tests pass; no Critical/High code defect; three Medium ops risks |
 | Settlement & Celo | Built, paused | `SettlementModule` + `CeloSettlementExecutor` deployed, both paused, no Safe/Zodiac value authority; credit registry deployed; `SettlementModule` has 81 bytes of EIP-170 headroom |
 | Indexer | Source complete, not deployed | 119/119 events handled, 28 pooling records, replay and out-of-order proofs, boundary check passes; the hosted Envio still serves the old schema without `CommitmentPool` |
-| Shared state & API | Complete, fail-closed | Types, hooks, mutations, six offline job kinds, Saved Offers; 186/186 tests pass; the capability ledger reads `deployed-not-available`, so every pooling read and write is disabled in production by design |
+| Shared state & API | Complete (one offline gap), fail-closed | Types, hooks, mutations, six offline job kinds (the four membership-gated ones skip the hat preflight; see Shared), Saved Offers; 186/186 tests pass; the capability ledger reads `deployed-not-available`, so every pooling read and write is disabled in production by design |
 | Client PWA | Partial | 4 of 19 prototype screens shipped in PR #740; 104/104 tests pass; three High findings, one of them on-chain data hygiene |
 | Admin | Not started | 0 files against a 16-screen / 196-state prototype; the steward flows Cycle 1 needs have no UI; Linear PRD-725 shows In Progress |
 | Editorial | Backend only | Public readers with the privacy gates intact (8/8 tests); no § 02 section on `/gardens/:id`, no `/impact` band; `PublicEvidencePipeline` i18n is a prerequisite |
@@ -115,11 +115,17 @@ Findings:
   commitment that carries a single credit. Spec-intended for the pilot; the Safe transfer is
   deferred and this wave replaced the external audit with internal review. A known ops decision,
   to be written down where the value tier is gated.
-- **Medium.** Storage-layout and ERC-7201 gates are manual only. Baselines exist and match
-  (`storage-layouts/*.json`, 38 slots + `__gap[12]`), but `.github/workflows/contracts.yml:148` runs
-  only `check:sizes`; `check:storage-layout` and `check-erc7201-layout.ts` are in neither CI nor
-  any deploy/upgrade wrapper, and `script/upgrade.ts` has no named target for the six new proxies.
-  Pooling upgrades also do not require pause, unlike Settlement and Celo.
+- **Medium.** Storage-layout and ERC-7201 gates are not wired for the pooling, settlement, or
+  credit proxies. Baselines exist and match (`storage-layouts/*.json`, 38 slots + `__gap[12]`), but
+  `.github/workflows/contracts.yml:148` runs only `check:sizes`; `check:storage-layout` is invoked
+  only by the assessment and Hats upgrade scripts (`packages/contracts/package.json:175,223,226`),
+  never by CI or by any pooling/settlement/credit path; `check-erc7201-layout.ts` has no caller at
+  all; and `script/upgrade.ts` exposes an explicit `testimony-resolver` target plus the
+  `commitment-pooling` GardenToken/WorkApprovalResolver integration group, but no target for
+  `CommitmentPoolingModule`, `CommitmentRegistry`, `SettlementModule`, `CeloSettlementExecutor`,
+  or `CreditRegistry`. Pooling upgrades also do not require pause, unlike Settlement and Celo.
+  *(Corrected 2026-08-21 after PR #747 review; the first wording overstated the gap as "no
+  upgrade wrapper" and "all six proxies".)*
 - **Medium.** `SettlementModule` has 81 bytes of EIP-170 headroom
   (`check-contract-sizes.ts --skip-build`: 24,495 bytes; CreditRegistry 22,055;
   CommitmentPoolingModule 21,217; CeloSettlementExecutor 20,243).
@@ -168,8 +174,9 @@ pooling block; `distinctProviderCount` is monotonic and publishes a number, neve
 
 ## Shared state & API
 
-**Verdict: Complete, fail-closed.** The offline-first contract is met and the mutation surface is
-disciplined.
+**Verdict: Complete with one offline gap, fail-closed.** The mutation surface is disciplined; the
+offline-first contract holds for creation and series jobs but not yet for the four
+membership-gated field jobs (see the first finding below, added after PR #747 review).
 
 Evidence: `bun run test -- commitment` → 17 files / 186 tests pass; disclosure, saved-offers,
 settlement selectors → 5 files / 63 pass; editorial readers → 3 files / 8 pass.
@@ -189,6 +196,14 @@ deployed-not-available` (verified 2026-08-16). That makes `addJob` throw for eve
 kind, disables authenticated queries, and makes online mutations throw. It is a build-time ledger
 flipped by editing the projection JSON and regenerating, not a runtime read-back probe.
 
+- **Medium (offline jobs; added 2026-08-21 after PR #747 review).** The membership preflight
+  runs only when a payload carries `gardenAddress` (`modules/commitment-pooling/job-executor.ts:84-87`);
+  `CommitmentSeriesJobPayload` and `CommitmentCreationPayload` carry it, but `ClaimJobPayload`,
+  `EvidenceJobPayload`, `WorkLinkJobPayload`, and `ConfirmationJobPayload` do not
+  (`job-types.ts:75-98`). Those four jobs therefore skip the `waiting` / `membership-unavailable`
+  path and spend their retries on a revert when the member's hat is not yet granted. The
+  "six-job offline surface is complete" line in the status board is overstated to that extent;
+  `prompt-client-loop.md` Phase 0 item 5 closes it.
 - **Medium (editorial readers).** The `/impact` "support arrived" sum counts every disbursement
   kind and token: `data-public-impact.ts:73` filters only on `state: CONFIRMED`; `DisbursementKind`
   includes `FUNDING`, `LOAN_PRINCIPAL`, and `REFUND`, and `token` is per row. Filter to
@@ -202,9 +217,12 @@ flipped by editing the projection JSON and regenerating, not a runtime read-back
 - **Low.** `useCommitmentQueueState` builds an ad-hoc query key; `usePublicGardenPool` borrows the
   `gardenDetail` key namespace; `modules/commitment-pooling/index.ts` re-exports two hooks; public
   readers skip the ledger and warn on every public garden page until the deploy; the pool reader
-  awaits every IPFS cycle-name resolution before returning counts; confirm/claim jobs carry no
-  identity key; the `/impact` lifetime totals filtered `state: OPEN` pools only at review time
-  (fixed in PR #746).
+  awaits every IPFS cycle-name resolution before returning counts; the `/impact` lifetime totals
+  filtered `state: OPEN` pools only at review time (fixed in PR #746). *(A first draft of this
+  list said confirm/claim jobs "carry no identity key"; that was wrong — `commitmentJobIdentity`
+  in `modules/job-queue/queue-policy.ts` derives identities for all six kinds and `addJob`
+  deduplicates on them at `index.ts:147-158`. Only `job-identity.ts`'s on-chain request keys are
+  limited to series, commitment, and work-link.)*
 
 ## Client PWA
 
@@ -244,8 +262,10 @@ Findings:
   (`GardenCommitment.tsx:216-218`); `band.provider.active.b` copy points at sections that do not
   render.
 - **Medium (suspected).** A failed queue read re-arms the action bar (`GardenCommitment.tsx:76`
-  reads only `pendingCommitmentIds`); confirm/claim jobs carry no identity key
-  (`job-identity.ts:90-130`).
+  reads only `pendingCommitmentIds`). A second tap is caught by the queue's existing identity
+  dedup (`queue-policy.ts` + `index.ts:147-158`), so the defect is the re-armed, misleading
+  button, not a duplicate send; the detail bar should read `isUnavailable` and
+  `failedCommitmentIds` the way the sheet does.
 - **Medium.** The composer diverges from the locked spec: `uiux-spec.md:685-687` forbids an
   in-form Direction control; `ComposeKind.tsx:17-69` is one, entered from a single button
   (`GardenPool.tsx:135-142`).
@@ -324,7 +344,7 @@ carry 11 states; the admin follow-up list is open.
 2. One EOA owns every proxy and is steward of every pool; Safe transfer deferred; no external
    audit this wave.
 3. Client Highs on the live path (not-found ordering, raw reason as CID, inert inbox).
-4. Upgrade safety unwired (storage-layout / ERC-7201 manual; no named upgrade targets).
+4. Upgrade safety unwired for the pooling, settlement, and credit proxies (storage-layout / ERC-7201 checks run only in the assessment and Hats upgrade scripts; no `upgrade.ts` target for the five new proxies other than `testimony-resolver`).
 5. Admin surface does not exist, and Cycle 1 is a steward act.
 6. `SettlementModule` at 81 bytes of headroom.
 7. Public totals can overstate (`/impact` kinds/tokens; pool reader blocks on IPFS).
@@ -340,8 +360,9 @@ carry 11 states; the admin follow-up list is open.
 2. Land the three client Highs before the flip (`prompt-client-loop.md`, Phase 0).
 3. Scope a narrowed admin dispatch: W7 pool console, W10 detail, W13 confirmation queue, W11 cycle
    open.
-4. Wire `check:storage-layout` and the ERC-7201 check into CI and the upgrade wrapper; add named
-   upgrade targets for the six proxies.
+4. Wire `check:storage-layout` and the ERC-7201 check into CI and into the pooling/settlement/credit
+   upgrade paths; add `upgrade.ts` targets for `CommitmentPoolingModule`, `CommitmentRegistry`,
+   `SettlementModule`, `CeloSettlementExecutor`, and `CreditRegistry` (`testimony-resolver` already has one).
 5. Reconcile the record: PRD-650 body, PRD-725 state, PRD-724 scope comment, the hub's coverage
    table and Track B step 8, the three stale handoffs.
 6. Date the ownership and audit decisions before the value tier unpauses.

--- a/.plans/active/commitment-pooling/reports/build-review-2026-08-21.md
+++ b/.plans/active/commitment-pooling/reports/build-review-2026-08-21.md
@@ -1,0 +1,378 @@
+# Commitment Pooling build review — 2026-08-21
+
+Read-only review of how well Commitment Pooling is implemented in code and design, layer by
+layer, taken from the PRD-650 issue tree. Baseline: `develop@665e8a573` plus the then-uncommitted
+editorial backend on `feature/commitment-pooling-editorial@dea1aa7f6` (merged the same day as
+PR #745 and PR #746). Three scoped review lanes (contracts; indexer + shared; client + design) plus
+direct verification of every High and Medium finding quoted here. Published copy:
+https://claude.ai/code/artifact/bfc7968a-a2dd-4d2c-9af8-c5b9c45b21a8
+
+Every claim was checked against the tree, a test run, or an artifact; items marked *suspected*
+were inferred from code paths without rendered proof.
+
+## Status board
+
+The short version: the backend is real and live, the read model that would make it visible is not
+deployed, the member-facing client shipped a narrowed slice, and the steward-facing admin surface
+does not exist yet.
+
+| Layer | State | One fact |
+| --- | --- | --- |
+| Contracts | Live | 86 functions / 48 events / 20 libraries; deployed and unpaused on Arbitrum with 18 pools; 361 unit + 94 fuzz/invariant/integration tests pass; no Critical/High code defect; three Medium ops risks |
+| Settlement & Celo | Built, paused | `SettlementModule` + `CeloSettlementExecutor` deployed, both paused, no Safe/Zodiac value authority; credit registry deployed; `SettlementModule` has 81 bytes of EIP-170 headroom |
+| Indexer | Source complete, not deployed | 119/119 events handled, 28 pooling records, replay and out-of-order proofs, boundary check passes; the hosted Envio still serves the old schema without `CommitmentPool` |
+| Shared state & API | Complete, fail-closed | Types, hooks, mutations, six offline job kinds, Saved Offers; 186/186 tests pass; the capability ledger reads `deployed-not-available`, so every pooling read and write is disabled in production by design |
+| Client PWA | Partial | 4 of 19 prototype screens shipped in PR #740; 104/104 tests pass; three High findings, one of them on-chain data hygiene |
+| Admin | Not started | 0 files against a 16-screen / 196-state prototype; the steward flows Cycle 1 needs have no UI; Linear PRD-725 shows In Progress |
+| Editorial | Backend only | Public readers with the privacy gates intact (8/8 tests); no § 02 section on `/gardens/:id`, no `/impact` band; `PublicEvidencePipeline` i18n is a prerequisite |
+| Docs, QA, videos | Deferred by design | PRD-727/728/729/730 wait for runtime UI and QA; docs carry one status line; the ontology has 9 pooling entities; no Storybook story exists for any pooling component |
+
+## Outline of the work
+
+**What is being built.** A garden names a Need. Members answer it with an Offer or a Request,
+once or over time (an ongoing Offer is backed internally by a `CommitmentSeries` with finite,
+pre-created places). Someone claims it, work and evidence attach, the person who received the work
+confirms, and recognition follows what actually happened: 20% equal among contributors, 80% by
+verified credit. Units live in a non-transferable register. No scores, ranks, or inferred
+participant counts; the default at cycle end is "Ask me again next cycle"; a holder can rest,
+resume, or retire an ongoing Offer. Two companion tiers sit on the same base: G$ split-state
+settlement (Arbitrum `SettlementModule` sends message-only CCIP commands to a Celo executor that
+moves G$ from per-garden Safes under Zodiac Roles caps) and a records-only credit register. Both
+are deployed and paused.
+
+**Architecture in one line.** `CommitmentPoolingModule` (control plane, 6 facets + 20 libraries) +
+`CommitmentRegistry` (units) + `TestimonyResolver` (EAS) + `SettlementModule` /
+`CeloSettlementExecutor` + `CreditRegistry` → Envio read model (28 pooling records plus settlement
+and credit entities) → `@green-goods/shared` types, hooks, mutations, offline jobs → client PWA,
+admin console, editorial site.
+
+### The issue tree under PRD-650
+
+| Issue | Lane | Linear | Code says | Verdict |
+| --- | --- | --- | --- | --- |
+| PRD-796 Freeze compatibility boundary | architecture | Done | `exchange-architecture-brief.md`, registers #86–#89 | accurate |
+| PRD-788 Offer once / over time | architecture | Done | `SeriesLib.sol`, `CommitmentSeries` entity, `commitmentSeries` job kind | accurate |
+| PRD-789 Prototype + gallery | design | Done | `hifi/` kit builds 37 screens / 516 states | accurate |
+| PRD-721 Contracts | contracts | Done | Merged via #694/#705; 86 ABI functions resolve; deployed | accurate |
+| PRD-686 Settlement | settlement | Done | Source + tests complete; proxies paused | accurate (value tier not activated) |
+| PRD-800 Payer identity | settlement | Done | `payerGarden`, beneficiary shapes in PlanLib + schema | accurate |
+| PRD-799 Resolver wiring | contracts | Done | `testimonyResolver` 0x2897… in artifact | accurate |
+| PRD-814 Member-funded claims | contracts | Done | `FundingLib.sol` pledge → deposit → consume → refund; 21 + 9 tests | accurate |
+| PRD-722 Indexer | indexer | Done | Source complete; hosted deployment not performed | accurate for source; release step open |
+| PRD-723 Shared state/API | state_api | Done | Complete; ledger fail-closed pending read-back | accurate |
+| PRD-724 Client UI | ui_client | Done (20 Aug) | W1/W2/W3/W5 shipped; 15 prototype screens and most acceptance items not built | **narrowed** — Done reflects the W1–W5 dispatch, not the acceptance list |
+| PRD-725 Admin UI | ui_admin | In Progress (since 19 Aug) | No admin pooling code; hub says `blocked` | **mismatch** |
+| PRD-726 Editorial | editorial | In Progress | Backend readers (merged as #745/#746 the same day); no UI | accurate |
+| PRD-729 QA pass 1 | qa | Todo | Blocked on runtime UI | accurate |
+| PRD-727 Docs · PRD-730 QA 2 · PRD-728 Videos | docs / qa | Todo | Sequenced after QA 1 by design | accurate |
+| PRD-731 Release ops (spine, parentless) | release_ops | In Progress | Pooling unpaused 13 Aug; PRD-819 Celo Garden Safes open; PRD-733/821 done | accurate |
+| COM-11 Settlement evidence | human | Backlog | Operational-assignment gate, due 30 Sep | accurate |
+| PRD-697 Credit companion (related) | credit | In Progress | `CreditRegistry` deployed; PRD-786 state/API done | accurate |
+
+Against the parent's own delivery order: steps 1–3 are done; step 4 is half done (contracts
+activated and receipt-verified, hosted reindex and live read-back pending); steps 5–6 (PRD-737,
+PRD-760) are done; step 7 is one-third done (client only).
+
+## Contracts
+
+**Verdict: Live.** Complete against the frozen spec, well tested, and deployed. The risks are
+operational, not in the Solidity.
+
+Evidence: `ICommitmentPoolingModule.sol` declares 86 functions, 48 events, 108 errors; with 6
+registry and 4 funding events this reconciles the hub's "58 events". Targeted run: 25 suites / 361
+unit tests and 94 fuzz + invariant + integration tests pass; 1,885 test declarations in the lane
+(the hub's "1,754" predates the library split). Bounds frozen at 40 with the cold 8/16/24/32/40
+matrix (`CommonLib.sol:35-39`, `CommitmentPoolingBounds.t.sol:421-541`). Deployed on Arbitrum:
+module 0x6BB5…470a (unpaused), registry 0x6630…3959, settlement 0x15c8…935D (paused), credit
+0xcfF1…6A34, testimony 0x2897…2329. Celo executor 0xB8a7…a84F (paused, `authorityEnabled: false`).
+Unpause tx 0x6912…27a4 at block 493,999,183.
+
+| Capability | Where | Tests | State |
+| --- | --- | --- | --- |
+| Pools: register, charter, ready/open/pause/resume/close/compost, provider cap | `PoolsLib`, `Admin.sol` | 19 + 7 | done |
+| Cycles: Season/Campaign, one-open-Season guard, allocation + recognition policy at open | `CyclesLib` | 11 | done |
+| Create Offer/Request, idempotent `creationRequestKey`, frozen payload hash, derived requirements | `CreationLib`, `CreationChecksLib` | 19 + 12 | done |
+| Claim (open / approval-gated × individual / garden), priced-Offer steward gate | `ClaimsLib`, `AcceptanceLib` | 5+ | done |
+| Roster + atomic freeze at ReadyForConfirmation | `RosterLib`, `CreditLib.sol:53-81` | 10 + 2 invariants | done |
+| Evidence, assessment v3 attachment, Work-credit bridge | `ProofLib`, `WorkCreditLib`, `SyncLib` | 17 | done |
+| Confirmation: named/default, pool and protocol fallback | `ConfirmLib` | — | done |
+| Recognition 20/80 canonical validator | `RecognitionLib` | 13 + 7 fuzz | done |
+| Series: rest/resume/retire, holder-only, idempotent | `SeriesLib` | 17 | done (places are ordinary Offer instances) |
+| Bilateral `acceptExchange` | `ExchangeLib` | 15 | done, free Offers only by design |
+| Terminal: cancel / expire / dispute / resolve | `TerminalLib` | 11 | done |
+| Terms: consideration, declared value, confirmer rule | `TermsLib` | 13 | done |
+| Member-funded claims with refund | `Settlement/FundingLib` | 21 + 9 invariants | done, value tier paused |
+| Payout plans, disbursements, batches, CCIP dispatch + ack | `Settlement/*Lib` | 21 + 22 + 5 + 9 | done, paused in prod |
+| Celo executor: Zodiac Roles transfer, caps, balance-delta proof | `CeloSettlement/Execution.sol` | 9 + 27 | done, no authority |
+| Credit register | `registries/Credit.sol` | 31 + 25 | done |
+
+Findings:
+
+- **Medium.** One EOA is upgrade authority, dependency admin, and steward of every pool.
+  `GuardLib.sol:47,64` and `CreationChecksLib.sol:24-25` treat `env.owner` as steward of all 18
+  pools; `_authorizeUpgrade` is bare `onlyOwner` on the module, registry, and resolver. With the
+  `markReadyForConfirmation` and `resolveDispute(Fulfilled)` overrides, one key can fulfil any
+  commitment that carries a single credit. Spec-intended for the pilot; the Safe transfer is
+  deferred and this wave replaced the external audit with internal review. A known ops decision,
+  to be written down where the value tier is gated.
+- **Medium.** Storage-layout and ERC-7201 gates are manual only. Baselines exist and match
+  (`storage-layouts/*.json`, 38 slots + `__gap[12]`), but `.github/workflows/contracts.yml:148` runs
+  only `check:sizes`; `check:storage-layout` and `check-erc7201-layout.ts` are in neither CI nor
+  any deploy/upgrade wrapper, and `script/upgrade.ts` has no named target for the six new proxies.
+  Pooling upgrades also do not require pause, unlike Settlement and Celo.
+- **Medium.** `SettlementModule` has 81 bytes of EIP-170 headroom
+  (`check-contract-sizes.ts --skip-build`: 24,495 bytes; CreditRegistry 22,055;
+  CommitmentPoolingModule 21,217; CeloSettlementExecutor 20,243).
+- **Medium (product).** Permissionless, irreversible expiry of a ReadyForConfirmation commitment:
+  `expireCommitment` accepts it with no auth (`TerminalLib.sol:64-72`) and a formerly-expired record
+  can never resolve to Fulfilled (`:147-150`). Spec-accepted (`contract-spec.md:250`); the product
+  copy and confirmation window should make this visible.
+- **Low.** Error reuse hides the failing condition (`SourceMustBePaused` in both directions,
+  `ReasonRequired` for empty series metadata, `InvalidAllocation` 7×); confirmer rules that can
+  never reach threshold pass creation and edit (`CreationChecksLib.sol:297-312`) and fail at claim
+  time; recognition fuzz depth pinned to 96 inline; NatSpec names retired facets; the artifact
+  records no paused flag for settlement/executor and no unpause receipt; `deployments/README.md`
+  never mentions pooling.
+
+What is right: the module, its 20 libraries, the registry, and the resolver contain no
+token-moving primitive; G$ moves only from a garden Safe through Zodiac Roles with pre-flight caps
+and post-transfer balance proof; every `catch` converts to a named error or deferral code with
+state; no string reverts, no TODOs; the facet-plus-library structure is a clean answer to the size
+wall.
+
+## Indexer
+
+**Verdict: Source complete, not deployed.** The read model is thorough and honest; it is simply
+not serving production yet.
+
+Evidence: interface events, `config.yaml`, and handler registrations agree at 119 events across
+five contracts (48 module, 6 registry, 36 settlement, 15 Celo, 14 credit); `routeEvent` throws on
+anything unrouted. 26 pooling records (plus one handler-internal index) + `CommitmentFunding` /
+`CommitmentFundingIndex` = the 28 records. `node scripts/check-indexing-boundary.mjs` → "15
+contracts validated, 3 chains validated". Addresses match the deployment artifacts.
+
+Design holds up: every pooling event passes an audit row keyed `chainId-txHash-logIndex` before it
+mutates anything, so replay is idempotent; eight lifecycle events that arrive before
+`CommitmentCreated` park in `CommitmentPendingLifecycleProjection` and drain in order; no pooling
+handler deletes, fetches, catches, or logs; no `score`, `rank`, or `rate` field exists in the
+pooling block; `distinctProviderCount` is monotonic and publishes a number, never a list.
+
+- **Release.** The hosted Envio serves the old schema; the production indexer has no
+  `CommitmentPool`. Order is forced: merge the editorial readers (done, #745/#746) → deploy hosted
+  Envio → full reindex → live read-back → flip the ontology projection.
+- **Medium.** `CreditRegistry` is not statically pinned on 42161 (`config.yaml:232-234` discovers
+  it from `SettlementModule.CreditRegistryUpdated`, which misses `CreditRegistryInitialized`).
+- **Low.** `codex-indexer.md` promises 421614/11142220 chains the config does not carry. Event
+  signatures were matched by name and count and spot-checked structurally for three events, not
+  byte-compared against the compiled ABI for all 119.
+
+## Shared state & API
+
+**Verdict: Complete, fail-closed.** The offline-first contract is met and the mutation surface is
+disciplined.
+
+Evidence: `bun run test -- commitment` → 17 files / 186 tests pass; disclosure, saved-offers,
+settlement selectors → 5 files / 63 pass; editorial readers → 3 files / 8 pass.
+
+In place: six offline job kinds gated and prepared in `addJob` and routed to
+`executeCommitmentQueueJob`; request keys derive deterministically at enqueue and recovery reads
+the on-chain id-by-request-key before any send; offline enqueue is network-free; all five
+contract-mutation hooks use `createMutationErrorHandler`; no `console.*`, no log-only catch;
+invalidation through `queryKeys.commitmentPooling.*`; `PoolMemberHistory` has exactly one consumer
+and a test that walks `client/src` and `admin/src`; the public kept-rate selector gates at 5 due /
+3 distinct providers and returns a pair, never a float; Saved Offers are AES-256-GCM in the agent
+with `SAVED_OFFERS_ENCRYPTION_KEY` + `SAVED_OFFERS_AUDIENCE` required in production.
+
+How availability works: `useCommitmentPoolingAvailability` reads the generated ontology manifest,
+where `entity:commitment-pool` on 42161 is `integration: partial, availability:
+deployed-not-available` (verified 2026-08-16). That makes `addJob` throw for every commitment
+kind, disables authenticated queries, and makes online mutations throw. It is a build-time ledger
+flipped by editing the projection JSON and regenerating, not a runtime read-back probe.
+
+- **Medium (editorial readers).** The `/impact` "support arrived" sum counts every disbursement
+  kind and token: `data-public-impact.ts:73` filters only on `state: CONFIRMED`; `DisbursementKind`
+  includes `FUNDING`, `LOAN_PRINCIPAL`, and `REFUND`, and `token` is per row. Filter to
+  consideration kinds and one token before the band ships. Still open on `origin/develop` after
+  PR #746 (`data-public-impact.ts:77`); #746 fixed the separate open-pools-only scope of the
+  lifetime totals.
+- **Medium.** No cross-package vector for the creation payload hash
+  (`hashCommitmentCreationPayload` in `job-identity.ts:159-252` vs
+  `CreationChecksLib.creationPayloadHash`); silent drift surfaces as a terminal `identity-conflict`
+  on the first exact replay.
+- **Low.** `useCommitmentQueueState` builds an ad-hoc query key; `usePublicGardenPool` borrows the
+  `gardenDetail` key namespace; `modules/commitment-pooling/index.ts` re-exports two hooks; public
+  readers skip the ledger and warn on every public garden page until the deploy; the pool reader
+  awaits every IPFS cycle-name resolution before returning counts; confirm/claim jobs carry no
+  identity key; the `/impact` lifetime totals filtered `state: OPEN` pools only at review time
+  (fixed in PR #746).
+
+## Client PWA
+
+**Verdict: Partial.** A clean, token-true slice of the member journey that stops short of the
+acceptance list, with three High findings that should land before anyone deep-links into a live
+pool.
+
+Evidence: PR #740 shipped W5 (commitments sheet), W1 (pool tab), W2 (detail), W3 (composer) and
+the shared seat/inbox/queue layer; it touched no shared component. Targeted run: 12 files / 104
+tests pass. Five adversarial review rounds closed (sampled six round-3 findings: five closed, one
+open on the detail bar).
+
+| Prototype | States | Shipped | Status |
+| --- | ---: | --- | --- |
+| W5 Commitments sheet | 19 | `Home/CommitmentsDrawer/*` | shipped (Live, Over time); no steward "To confirm" tab; rows do not open anything |
+| W1 Pool tab | 33 | `Garden/Pool/*` | partial: lifecycle notices, rail, direction chips, list; no cycle names/dates, no claim-request panels, no queued/sync-failed rows, single entry button instead of two doors |
+| W2 Commitment detail | 85 | `Garden/Commitment/*` | partial: seat band, one act, requirement rows, withdraw; no support rows, dispute states, timeline, linked work, evidence preview |
+| W3 Composer | 34 | `Garden/Compose/*` | partial: four beats, service-only; no templates, saved offers, once/ongoing, DomainImpact rows, declared value, named confirmers |
+| W2b Team | 13 | `CommitmentPeople.tsx` | lead + helper count only |
+| W4 Confirmation | 29 | bar button | no sheet, no "Not yet" → `raiseDispute` |
+| W1C · W2a · W23 · W25 · W28–W31 · W32 · W34 · W35 · W36 · WFLOW | 96 | — | not started |
+
+Findings:
+
+- **High.** On a deployed-but-unavailable chain, every deep link says "commitment not found".
+  `useCommitment` disables its query unless available, returning `detail = null, isLoading =
+  false, isError = false`; `GardenCommitment.tsx:91` tests that shape as "not found" before the
+  availability branch at `:103`. This is the exact production state today. The test passes only
+  because its fixture keeps `detail` populated while unavailable.
+- **High.** The withdraw reason goes on-chain as a fake CID. `WithdrawDialog.tsx:62` emits the raw
+  textarea text; `GardenCommitment.tsx:285-291` forwards it as `reasonCID`;
+  `useCommitmentMutations.ts:103-105` passes it unchanged to
+  `cancelCommitment(uint256, string reasonCID)`.
+- **High.** The inbox has no door. Neither tab passes `onOpen` (`LiveTab.tsx:152-161`,
+  `OverTimeTab.tsx:160-168`); `needsYou` is hard-coded `false` (`GardenPool.tsx:75`).
+- **Medium.** "Add proof" and "Offer it again" both navigate back to the garden
+  (`GardenCommitment.tsx:216-218`); `band.provider.active.b` copy points at sections that do not
+  render.
+- **Medium (suspected).** A failed queue read re-arms the action bar (`GardenCommitment.tsx:76`
+  reads only `pendingCommitmentIds`); confirm/claim jobs carry no identity key
+  (`job-identity.ts:90-130`).
+- **Medium.** The composer diverges from the locked spec: `uiux-spec.md:685-687` forbids an
+  in-form Direction control; `ComposeKind.tsx:17-69` is one, entered from a single button
+  (`GardenPool.tsx:135-142`).
+- **Low.** `tap-target` is not a defined utility (five chip sites below 44 px); the bottom nav
+  stays under the action bars (`AppBar.tsx:22,35`); the commitments drawer is missing from
+  `isAnyDrawerOpen`; untranslated "Other" (`grouping.ts:21`) and "Pool" in es/pt; progress bars
+  without accessible names; duplicated heading; block content inside `<button>` rows; duplicated
+  chip group; `CycleRail` omits names and dates; requirement rows read "Requirement N".
+
+What is right: zero hardcoded easings, durations, colors, or `--m3-*`; one primary CTA per screen
+and no green flooding; reduced motion covered by the global clamp; `lint:vocab` clean; 225 pooling
+keys with full es/pt parity; no hooks defined in the client; no effects or timers; presentation
+split into `presentation.ts` / `statusBand.ts` / `commitmentActions.ts`; the ladder handles
+unavailable → loading → error → offline → empty with the right roles.
+
+## Admin console
+
+**Verdict: Not started.** The steward half of the product exists only as a prototype, and it is
+the half Cycle 1 cannot run without.
+
+`packages/admin/src` contains no pooling view, hook consumer, or test; the only "pool" file
+(`views/Garden/SignalPool.tsx`) is Community Needs. The three RED-first test files named in
+`claude-ui-admin.md` do not exist. The hub lane is `blocked`; Linear PRD-725 moved to In Progress
+on 19 Aug. The prototype covers the whole scope (W7, W7C, W7M, W8, W9, W10, W11, W12, W13, W14,
+W37, W21, W22, W24, W26, HUBWORK); `reports/admin-prototype-follow-up-2026-08-11.md` lists seven
+unapplied corrections. Opening Cycle 1 requires a steward to seed a pool, open a cycle with an
+allocation, accept or decline claims, and confirm or resolve; none of those acts has a UI. The
+admin needs the same kind of narrowed dispatch the client got (W7 + W10 + W13 + W11).
+
+## Editorial website
+
+**Verdict: Backend only.** The privacy-preserving readers are done and well tested (merged in
+#745/#746); the two public surfaces that consume them are not started, and one prerequisite is
+open. `views/Public/GardenDetailSections.tsx` renders § 02 Certificates and § 03 Operators; no
+commitments section and no client consumer of either hook. `PublicEvidencePipeline.tsx:125` is
+still `md:grid-cols-3` with only the caption internationalised.
+
+## Design
+
+The prototype system is unusually rigorous: `hifi/` builds 37 presentation-visible screens / 516
+states, 55 flows / 323 scenes, 743 hotspots, a Components tab with 101 entries, and validates
+itself (`RETIRED_VOCABULARY`, `ALLOWED_ENTRY`, echo pairing, the generated
+`commitment-view-state-reference.md`). PRD-760 is closed. Thin spots: the two editorial screens
+carry 11 states; the admin follow-up list is open.
+
+| Lens | Result | Evidence |
+| --- | --- | --- |
+| Tokens (motion, color, radius) | Clean | No `cubic-bezier`, ms durations, hex, `rgba(`, or `--m3-*` in pooling views |
+| Volume hierarchy | Clean | `bg-primary-action` ×4 (one CTA per screen); `success-*` only on the kept band |
+| Concentricity | Nit | Uniform 16 px on cards, buttons, inputs, notices; inner icon tile 8 px where the formula gives 4 px |
+| Component palette | Mostly | Built from `Alert`, `StatusBadge`, `DialogShell`, `ModalDrawer`, `EmptyState`, `FormProgress`; form fields hand-rolled without `aria-invalid` / `aria-describedby` |
+| Storybook | Missing | No story for `CommitmentRow`, `CommitmentStateLadder`, `CycleRail`, or any pooling view |
+| PWA vs browser chrome | Suspected | Bottom nav remains under in-flow action bars |
+| Accessibility | Mostly | Dialog/tab roles, focus trap, `role="status"` queue notes, labelled inputs; gaps: undefined `tap-target`, unnamed progress bars, block content in buttons, no `aria-labelledby` on the inherited drawer |
+| Copy & vocabulary | Clean | `lint:vocab` passes; no promise/score/rank/reputation; es/pt parity complete; two untranslated labels |
+| Prototype fidelity | Diverges | In-form direction control and single entry button vs the spec's two doors; inbox rows inert; cycle rail without names/dates |
+
+## Tracking drift
+
+- PRD-650's body still says "The product has not been implemented or deployed yet" and names
+  PRD-721 as the next lane; four build lanes are Done and the contracts are live.
+- PRD-725 is In Progress with no admin code; the hub lane is `blocked` (the hub is right).
+- PRD-724 Done covers the narrowed W1–W5 dispatch while the issue body's acceptance list is largely
+  unbuilt.
+- `plan.todo.md` Requirements Coverage still shows ⏳ for PRD-721, PRD-686, and PRD-724; Track B
+  step 8 is unchecked although the unpause is receipt-verified.
+- `codex-state-api.md:9` calls the seat amendment open (it landed); `codex-indexer.md` names chains
+  the config does not have; `handoffs/README.md` still lists client/admin/editorial as blocked
+  behind state/API.
+- The deployment JSON records no paused flag for settlement/executor and no unpause receipt; the
+  hub's "1,754 tests / 135 suites" predates the library split.
+
+## Ranked risks
+
+1. The product is dark in production: live contracts, no hosted read model, ledger fail-closed.
+2. One EOA owns every proxy and is steward of every pool; Safe transfer deferred; no external
+   audit this wave.
+3. Client Highs on the live path (not-found ordering, raw reason as CID, inert inbox).
+4. Upgrade safety unwired (storage-layout / ERC-7201 manual; no named upgrade targets).
+5. Admin surface does not exist, and Cycle 1 is a steward act.
+6. `SettlementModule` at 81 bytes of headroom.
+7. Public totals can overstate (`/impact` kinds/tokens; pool reader blocks on IPFS).
+8. `CreditRegistry` not statically pinned in the indexer.
+9. Permissionless expiry of ready commitments.
+10. Hygiene: no Storybook stories, stale handoffs and tables, error reuse, NatSpec, no
+    cross-package payload-hash vector.
+
+## Suggested next moves
+
+1. Deploy the hosted Envio with the pooling schema, full reindex, live read-back, then flip the
+   ontology projection; pin `CreditRegistry` in `config.yaml` at the same time.
+2. Land the three client Highs before the flip (`prompt-client-loop.md`, Phase 0).
+3. Scope a narrowed admin dispatch: W7 pool console, W10 detail, W13 confirmation queue, W11 cycle
+   open.
+4. Wire `check:storage-layout` and the ERC-7201 check into CI and the upgrade wrapper; add named
+   upgrade targets for the six proxies.
+5. Reconcile the record: PRD-650 body, PRD-725 state, PRD-724 scope comment, the hub's coverage
+   table and Track B step 8, the three stale handoffs.
+6. Date the ownership and audit decisions before the value tier unpauses.
+7. Add stories for the pooling components and a Storybook pass on the composer's two-door entry.
+
+## Evidence
+
+Commands run (all read-only):
+
+```
+packages/contracts  bun run test:solidity -- --match-path 'test/unit/{CommitmentPooling*,…}.t.sol'
+                    → 25 suites · 361 passed · 0 failed (0.83 s, test profile, no recompile)
+packages/contracts  fuzz / invariant / integration / bounds set
+                    → 94 passed · 0 failed (7.06 s; invariants 16 runs × 96 depth)
+packages/contracts  bun script/utils/check-contract-sizes.ts --skip-build
+                    → all fit; WARN SettlementModule 24495 B (margin 81)
+packages/indexer    node scripts/check-indexing-boundary.mjs
+                    → passed: 15 contracts, 3 chains
+packages/shared     bun run test -- commitment
+                    → 17 files · 186 passed (8.53 s)
+packages/shared     bun run test -- pool-member-history-disclosure saved-offers settlement-selectors settlement-aa-profile
+                    → 5 files · 63 passed
+packages/shared     bun run test -- usePublicCommitmentImpact usePublicGardenPool cycle-metadata
+                    → 3 files · 8 passed
+packages/client     bun run test -- Commitment GardenPool PublicGardenDetail commitmentActions commitmentGrouping HomeGarden Home.test
+                    → 12 files · 104 passed (27.8 s)
+root                bun run lint:vocab
+                    → no banned vocabulary found in 3 i18n file(s)
+```
+
+Not verified here: the hosted Envio schema (taken from the editorial handoff and the ontology
+ledger); fork suites (`ArbitrumCommitmentPooling.t.sol` 36 tests, `CrossChainSettlementLane.t.sol`
+7) need RPC; event signatures matched by name and count; no rendered browser proof; no chain state
+queried.


### PR DESCRIPTION
## What

Two files into the Commitment Pooling plan hub, plus an honest document map:

- `reports/build-review-2026-08-21.md` — the layer-by-layer build review of the PRD-650 tree (contracts, indexer, shared, client, admin, editorial, design), with a status board, coverage tables, severity-ordered findings anchored to file:line, tracking drift, ranked risks, next moves, and the exact commands run. Baseline `develop@665e8a573`; findings re-checked against `origin/develop` after #746.
- `prompt-client-loop.md` — the worktree-ready Claude Code dispatch prompt that finishes the client PWA: a dispatch gate (recorded hub lane transition first), Phase 0 fixes to the #740 slice, D1 close-the-loop (proof composer with offline media, confirmation sheet with Not yet, DomainImpact rows, WFLOW Fulfills row from a work-UID attribution reader, claim panels, W25 chooser, pool pause/readiness fields), D2 Offer over time (W32/W34/W35). Same precedent as `prompt-editorial-backend.md`.
- `plan.todo.md` document map: counts re-taken (181 files, was 171) and rows for the two new files and the six prompt files that had none (`prompt-editorial-backend.md`, `review-prompt-client-ui*.md`).

## Why

The review found the client "Done" state on PRD-724 covers a narrowed W1–W5 dispatch while most of the acceptance list is unbuilt, and that nothing in the hub recorded that narrowing. The review and the prompt are the durable record so the next session starts from verified facts rather than from Linear's state.

## Review

The Codex review's twelve threads were checked against the code, not taken on trust: eleven were right and are fixed in `c79d430dd` (dispatch gate, real offline proof, one issue per PR, D2 after D1 merges, reuse the existing queue identity dedup, membership-preflight gap for four job payloads, work-UID attribution reader, offline evidence payload, pool pause/Baseline fields, `commitmentNeedsSeat`, narrowed upgrade-tooling finding). One (the Ship Gate being unsatisfiable) is unsupported because the client build's `tsc` step checks zero files; the wording is clarified and that thread is left open with the evidence.

## Validation

Docs-only (`.plans/**`). Full Ship Gate run on the final tree: `bun format` · `bun lint` · `bun run test` (shared 3,741, client 741, admin 583, agent 265, indexer 276, contracts) · `bun run build`, all exit 0. Hub file counts verified against the tree (`find . -type f` = 181). No code, config, or workflow changes.

Refs PRD-724
Relates to PRD-650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
