### PR TITLE
fix(shared): re-enter local CI with pinned toolchain

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dev:doctor": "node scripts/dev/doctor.js",
     "ci:local": "node scripts/dev/ci-local.js",
     "validation:plan": "node scripts/dev/node-cli.js scripts/quality/select-validation.mjs",
-    "test:validation-system": "node scripts/dev/node-cli.js node --test scripts/quality/select-validation.test.mjs scripts/dev/ci-local.test.mjs scripts/dev/surface-leases.test.mjs scripts/quality/ci-gate.test.mjs scripts/quality/workflow-performance-parity.test.mjs",
+    "test:validation-system": "node scripts/dev/node-cli.js node --test scripts/lib/dev-shared.test.mjs scripts/quality/select-validation.test.mjs scripts/dev/ci-local.test.mjs scripts/dev/surface-leases.test.mjs scripts/quality/ci-gate.test.mjs scripts/quality/workflow-performance-parity.test.mjs",
     "env:template:init": "node scripts/dev/env-template-init.js",
     "env:sync": "node scripts/dev/env-sync.js",
     "env:bootstrap": "node scripts/dev/env-bootstrap.js",

--- a/scripts/dev/ci-local.js
+++ b/scripts/dev/ci-local.js
@@ -6,6 +6,10 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
+  reexecUnderCompatibleNodeIfNeeded,
+  reexecUnderSystemNodeIfNeeded,
+} from "../lib/dev-shared.js";
+import {
   buildReceiptInputs,
   fingerprintReceiptInputs,
   resolveGitInputs,
@@ -307,6 +311,11 @@ export function applyCompatibilityFilters(plan, options) {
       automatedSeconds > plan.budget.targetSeconds,
   };
   return { ...plan, checks, status, budget, skipped };
+}
+
+export function isSupportedCiNodeVersion(version) {
+  const major = Number.parseInt(version.split(".")[0], 10);
+  return Number.isInteger(major) && major >= 22;
 }
 
 export function buildLocalValidationPlan(options, gitInputs, environment) {
@@ -722,6 +731,17 @@ async function main() {
 const isDirectRun =
   process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href;
 if (isDirectRun) {
+  reexecUnderSystemNodeIfNeeded({
+    scriptPath: fileURLToPath(import.meta.url),
+    sentinel: "GREEN_GOODS_CI_LOCAL_NODE_REEXEC",
+    cwd: projectRoot,
+  });
+  reexecUnderCompatibleNodeIfNeeded({
+    scriptPath: fileURLToPath(import.meta.url),
+    sentinel: "GREEN_GOODS_CI_LOCAL_COMPAT_REEXEC",
+    cwd: projectRoot,
+    isSupported: isSupportedCiNodeVersion,
+  });
   main().catch((error) => {
     console.error(`${colors.red}${error.message}${colors.reset}`);
     process.exitCode = 1;

--- a/scripts/dev/ci-local.test.mjs
+++ b/scripts/dev/ci-local.test.mjs
@@ -8,10 +8,33 @@ import {
   applyCompatibilityFilters,
   buildLocalValidationPlan,
   executePlan,
+  isSupportedCiNodeVersion,
   loadPassingReceiptStore,
   parseArguments,
   savePassingReceiptStore,
 } from "./ci-local.js";
+
+test("ci-local re-entry is wired only inside the direct-run guard", () => {
+  const source = readFileSync(new URL("./ci-local.js", import.meta.url), "utf8");
+  const directRunGuard = source.indexOf("if (isDirectRun) {");
+  assert.notEqual(directRunGuard, -1);
+
+  const beforeGuard = source.slice(0, directRunGuard);
+  const guardedEntrypoint = source.slice(directRunGuard);
+  assert.doesNotMatch(beforeGuard, /reexecUnder(?:System|Compatible)NodeIfNeeded\(\{/);
+  assert.match(guardedEntrypoint, /reexecUnderSystemNodeIfNeeded\(\{/);
+  assert.match(guardedEntrypoint, /GREEN_GOODS_CI_LOCAL_NODE_REEXEC/);
+  assert.match(guardedEntrypoint, /reexecUnderCompatibleNodeIfNeeded\(\{/);
+  assert.match(guardedEntrypoint, /GREEN_GOODS_CI_LOCAL_COMPAT_REEXEC/);
+  assert.match(guardedEntrypoint, /isSupported: isSupportedCiNodeVersion/);
+});
+
+test("ci-local compatibility accepts Node 22 and newer", () => {
+  assert.equal(isSupportedCiNodeVersion("21.99.0"), false);
+  assert.equal(isSupportedCiNodeVersion("22.0.0"), true);
+  assert.equal(isSupportedCiNodeVersion("23.1.0"), true);
+  assert.equal(isSupportedCiNodeVersion("invalid"), false);
+});
 
 function plan(checks, status = "ready") {
   return {

--- a/scripts/dev/node-cli.js
+++ b/scripts/dev/node-cli.js
@@ -9,12 +9,14 @@
  * itself under a non-Bun Node and then launches the requested local CLI.
  */
 
-import { accessSync, constants, readdirSync, realpathSync } from "node:fs";
-import { homedir } from "node:os";
+import { accessSync, constants, realpathSync } from "node:fs";
 import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
-import { reexecUnderSystemNodeIfNeeded } from "../lib/dev-shared.js";
+import {
+  reexecUnderCompatibleNodeIfNeeded,
+  reexecUnderSystemNodeIfNeeded,
+} from "../lib/dev-shared.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -44,74 +46,6 @@ function executableExists(candidate) {
   } catch {
     return false;
   }
-}
-
-function findCompatibleNode() {
-  const executable = process.platform === "win32" ? "node.exe" : "node";
-  const pathEntries = (process.env.PATH || "").split(path.delimiter).filter(Boolean);
-  const candidates = [process.execPath];
-  if (process.env.NODE) candidates.push(process.env.NODE);
-
-  for (const entry of pathEntries) {
-    if (entry.includes("bun-node") || entry.includes(`${path.sep}.bun${path.sep}bin`)) continue;
-    candidates.push(path.join(entry, executable));
-  }
-
-  const miseShim = path.join(homedir(), ".local/share/mise/shims", executable);
-  candidates.push(miseShim);
-
-  const miseNodeRoot = path.join(homedir(), ".local/share/mise/installs/node");
-  try {
-    for (const version of readdirSync(miseNodeRoot).sort().reverse()) {
-      candidates.push(path.join(miseNodeRoot, version, "bin", executable));
-    }
-  } catch {
-    // mise is optional; PATH candidates above are enough on most machines.
-  }
-
-  const seen = new Set();
-  for (const candidate of candidates) {
-    if (!executableExists(candidate)) continue;
-    const key = `${candidate}:${realpathSync(candidate)}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-
-    const probe = spawnSync(
-      candidate,
-      ["-p", "process.versions.bun ? `bun:${process.versions.bun}` : process.versions.node"],
-      {
-        encoding: "utf8",
-        timeout: 2_000,
-      }
-    );
-    const version = (probe.stdout || "").trim();
-    if (version.startsWith("bun:")) continue;
-    if (version && isSupportedNodeVersion(version)) return candidate;
-  }
-
-  return "";
-}
-
-function reexecUnderCompatibleNodeIfNeeded() {
-  if (!process.versions.bun && isSupportedNodeVersion(process.versions.node)) return;
-  if (process.env.GREEN_GOODS_NODE_CLI_COMPAT_REEXEC === "1") return;
-
-  const compatibleNode = findCompatibleNode();
-  if (!compatibleNode || compatibleNode === realpathSync(process.execPath)) return;
-
-  const result = spawnSync(compatibleNode, [__filename, ...process.argv.slice(2)], {
-    cwd: process.cwd(),
-    env: {
-      ...process.env,
-      GREEN_GOODS_NODE_CLI_COMPAT_REEXEC: "1",
-      NODE: compatibleNode,
-      npm_node_execpath: compatibleNode,
-    },
-    stdio: "inherit",
-  });
-
-  if (result.error) return;
-  process.exit(result.status ?? (result.signal ? 1 : 0));
 }
 
 function assertCompatibleNode() {
@@ -160,7 +94,12 @@ function nodeFirstPath() {
 const [command, ...args] = process.argv.slice(2);
 if (!command || command === "--help" || command === "-h") usage(command ? 0 : 1);
 
-reexecUnderCompatibleNodeIfNeeded();
+reexecUnderCompatibleNodeIfNeeded({
+  scriptPath: __filename,
+  sentinel: "GREEN_GOODS_NODE_CLI_COMPAT_REEXEC",
+  cwd: process.cwd(),
+  isSupported: isSupportedNodeVersion,
+});
 assertCompatibleNode();
 
 const cliPath = resolveLocalCli(command);

--- a/scripts/lib/dev-shared.js
+++ b/scripts/lib/dev-shared.js
@@ -10,7 +10,7 @@ import http from "node:http";
 import https from "node:https";
 import path from "node:path";
 import { homedir } from "node:os";
-import { accessSync, constants, readdirSync, realpathSync } from "node:fs";
+import { accessSync, constants, readFileSync, readdirSync, realpathSync } from "node:fs";
 import { spawnSync } from "node:child_process";
 
 /**
@@ -49,9 +49,14 @@ function isSupportedSystemNode(version) {
   return major !== null && major >= 22;
 }
 
+function miseDataDirectory() {
+  return process.env.MISE_DATA_DIR || path.join(homedir(), ".local/share/mise");
+}
+
 function nodeCandidates() {
   const executable = process.platform === "win32" ? "node.exe" : "node";
-  const candidates = [];
+  const miseData = miseDataDirectory();
+  const candidates = [path.join(miseData, "shims", executable)];
   if (process.env.NODE) candidates.push(process.env.NODE);
 
   const pathEntries = (process.env.PATH || "").split(path.delimiter);
@@ -62,9 +67,7 @@ function nodeCandidates() {
     candidates.push(path.join(entry, executable));
   }
 
-  candidates.push(path.join(homedir(), ".local/share/mise/shims", executable));
-
-  const miseNodeRoot = path.join(homedir(), ".local/share/mise/installs/node");
+  const miseNodeRoot = path.join(miseData, "installs/node");
   try {
     for (const version of readdirSync(miseNodeRoot).sort().reverse()) {
       candidates.push(path.join(miseNodeRoot, version, "bin", executable));
@@ -76,31 +79,136 @@ function nodeCandidates() {
   return candidates;
 }
 
-export function findSystemNode() {
-  const probed = [];
+export function findCompatibleNode({
+  isSupported = isSupportedSystemNode,
+  candidates = nodeCandidates(),
+  probe = probeNodeVersion,
+  exists = executableExists,
+} = {}) {
   const seen = new Set();
 
-  for (const candidate of nodeCandidates()) {
-    if (!executableExists(candidate)) continue;
+  for (const candidate of candidates) {
+    if (!exists(candidate)) continue;
 
     let key = candidate;
     try {
-      key = `${candidate}:${realpathSync(candidate)}`;
+      key = realpathSync(candidate);
     } catch {
       // Fall back to the literal candidate path.
     }
     if (seen.has(key)) continue;
     seen.add(key);
 
-    const version = probeNodeVersion(candidate);
+    let version = "";
+    try {
+      version = probe(candidate);
+    } catch {
+      continue;
+    }
     if (!version || version.startsWith("bun:")) continue;
-    const entry = { candidate, version };
-    probed.push(entry);
-    if (isSupportedSystemNode(version)) return candidate;
+    if (isSupported(version)) return candidate;
   }
 
-  if (probed.length > 0) return probed[0].candidate;
   return "";
+}
+
+export function findSystemNode() {
+  const candidates = nodeCandidates();
+  return (
+    findCompatibleNode({ isSupported: isSupportedSystemNode, candidates }) ||
+    findCompatibleNode({ isSupported: () => true, candidates })
+  );
+}
+
+function findMiseConfig(startDirectory) {
+  let directory = path.resolve(startDirectory || process.cwd());
+  while (true) {
+    try {
+      return readFileSync(path.join(directory, ".mise.toml"), "utf8");
+    } catch {
+      const parent = path.dirname(directory);
+      if (parent === directory) return "";
+      directory = parent;
+    }
+  }
+}
+
+function pinnedMiseTools(cwd) {
+  const tools = {};
+  let inTools = false;
+  for (const line of findMiseConfig(cwd).split("\n")) {
+    const section = line.match(/^\s*\[([^\]]+)]/);
+    if (section) {
+      inTools = section[1] === "tools";
+      continue;
+    }
+    if (!inTools) continue;
+    const tool = line.match(/^\s*(node|bun|foundry)\s*=\s*["']([^"']+)["']/);
+    if (tool) tools[tool[1]] = tool[2];
+  }
+  return tools;
+}
+
+function matchingToolchainPathEntries(node, cwd) {
+  const entries = [];
+  const tools = pinnedMiseTools(cwd);
+  const miseData = miseDataDirectory();
+  if (tools.bun) {
+    const bun = path.join(miseData, "installs/bun", tools.bun, "bin", "bun");
+    if (executableExists(bun)) entries.push(path.dirname(bun));
+  }
+  if (tools.foundry) {
+    for (const forge of [
+      path.join(miseData, "installs/foundry", tools.foundry, "forge"),
+      path.join(miseData, "installs/foundry", tools.foundry, "bin", "forge"),
+    ]) {
+      if (!executableExists(forge)) continue;
+      entries.push(path.dirname(forge));
+      break;
+    }
+  }
+  entries.push(path.dirname(node));
+  return entries;
+}
+
+function reexecEnvironment(node, cwd, sentinel) {
+  const pathEntries = [
+    ...matchingToolchainPathEntries(node, cwd),
+    ...(process.env.PATH || "").split(path.delimiter),
+  ].filter(Boolean);
+  return {
+    ...process.env,
+    [sentinel]: "1",
+    NODE: node,
+    npm_node_execpath: node,
+    PATH: [...new Set(pathEntries)].join(path.delimiter),
+  };
+}
+
+export function reexecUnderCompatibleNodeIfNeeded({
+  scriptPath,
+  sentinel,
+  cwd,
+  isSupported = isSupportedSystemNode,
+  spawn = spawnSync,
+  exit = (code) => process.exit(code),
+  candidates,
+  probe,
+  exists,
+}) {
+  if (process.env[sentinel] === "1") return false;
+  if (!process.versions.bun && isSupported(process.versions.node || "")) return false;
+
+  const compatibleNode = findCompatibleNode({ isSupported, candidates, probe, exists });
+  if (!compatibleNode) return false;
+  const result = spawn(compatibleNode, [scriptPath, ...process.argv.slice(2)], {
+    cwd,
+    env: reexecEnvironment(compatibleNode, cwd, sentinel),
+    stdio: "inherit",
+  });
+  if (result.error) return false;
+  exit(result.status ?? (result.signal ? 1 : 0));
+  return true;
 }
 
 /**
@@ -120,7 +228,7 @@ export function reexecUnderSystemNodeIfNeeded({ scriptPath, sentinel, cwd }) {
   if (!systemNode) return;
   const result = spawnSync(systemNode, [scriptPath, ...process.argv.slice(2)], {
     cwd,
-    env: { ...process.env, [sentinel]: "1" },
+    env: reexecEnvironment(systemNode, cwd, sentinel),
     stdio: "inherit",
   });
   if (result.error) return;

--- a/scripts/lib/dev-shared.test.mjs
+++ b/scripts/lib/dev-shared.test.mjs
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  findCompatibleNode,
+  reexecUnderCompatibleNodeIfNeeded,
+} from "./dev-shared.js";
+
+test("compatible Node selection honors candidate order and skips Bun shims", () => {
+  const versions = new Map([
+    ["/mise-shim/node", "bun:1.3.14"],
+    ["/env/node", "20.18.0"],
+    ["/path/node", "22.22.1"],
+    ["/mise-install/node", "22.21.0"],
+  ]);
+  const probed = [];
+  const selected = findCompatibleNode({
+    isSupported: (version) => version === "22.22.1",
+    candidates: [...versions.keys()],
+    exists: () => true,
+    probe(candidate) {
+      probed.push(candidate);
+      return versions.get(candidate);
+    },
+  });
+
+  assert.equal(selected, "/path/node");
+  assert.deepEqual(probed, ["/mise-shim/node", "/env/node", "/path/node"]);
+});
+
+test("default candidates put mise, NODE, and non-Bun PATH entries in policy order", () => {
+  const original = {
+    miseData: process.env.MISE_DATA_DIR,
+    node: process.env.NODE,
+    path: process.env.PATH,
+  };
+  const executable = process.platform === "win32" ? "node.exe" : "node";
+  const miseData = path.join(tmpdir(), "mise-candidate-order");
+  const pathA = path.join(tmpdir(), "node-path-a");
+  const pathB = path.join(tmpdir(), "node-path-b");
+  process.env.MISE_DATA_DIR = miseData;
+  process.env.NODE = path.join(tmpdir(), "node-from-env");
+  process.env.PATH = [
+    pathA,
+    path.join(tmpdir(), ".bun", "bin"),
+    path.join(tmpdir(), "bun-node-shim"),
+    pathB,
+  ].join(path.delimiter);
+
+  try {
+    const probed = [];
+    findCompatibleNode({
+      isSupported: () => false,
+      exists: () => true,
+      probe(candidate) {
+        probed.push(candidate);
+        return "21.0.0";
+      },
+    });
+
+    assert.deepEqual(probed, [
+      path.join(miseData, "shims", executable),
+      process.env.NODE,
+      path.join(pathA, executable),
+      path.join(pathB, executable),
+    ]);
+  } finally {
+    for (const [name, value] of Object.entries(original)) {
+      const key = name === "miseData" ? "MISE_DATA_DIR" : name.toUpperCase();
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+});
+
+test("missing compatible Node leaves the current process in place", () => {
+  let spawned = false;
+  let exited = false;
+  const reexecuted = reexecUnderCompatibleNodeIfNeeded({
+    scriptPath: "/workspace/ci-local.js",
+    sentinel: "GREEN_GOODS_TEST_MISSING_REEXEC",
+    cwd: "/workspace",
+    isSupported: () => false,
+    candidates: ["/missing/node"],
+    exists: () => false,
+    spawn() {
+      spawned = true;
+    },
+    exit() {
+      exited = true;
+    },
+  });
+
+  assert.equal(reexecuted, false);
+  assert.equal(spawned, false);
+  assert.equal(exited, false);
+});
+
+test("successful re-entry carries the pinned Node, Bun, and Foundry toolchain", (t) => {
+  const directory = mkdtempSync(path.join(tmpdir(), "compatible-node-reexec-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const miseData = path.join(directory, "mise");
+  const node = path.join(miseData, "installs/node/22.22.1/bin/node");
+  const bun = path.join(miseData, "installs/bun/1.3.14/bin/bun");
+  const forge = path.join(miseData, "installs/foundry/1.7.1/forge");
+  for (const executable of [node, bun, forge]) {
+    mkdirSync(path.dirname(executable), { recursive: true });
+    writeFileSync(executable, "");
+    chmodSync(executable, 0o755);
+  }
+  writeFileSync(
+    path.join(directory, ".mise.toml"),
+    '[tools]\nnode = "22.22.1"\nbun = "1.3.14"\nfoundry = "1.7.1"\n',
+  );
+
+  const originalMiseData = process.env.MISE_DATA_DIR;
+  process.env.MISE_DATA_DIR = miseData;
+  let child;
+  let exitCode;
+  try {
+    const reexecuted = reexecUnderCompatibleNodeIfNeeded({
+      scriptPath: path.join(directory, "ci-local.js"),
+      sentinel: "GREEN_GOODS_TEST_SUCCESS_REEXEC",
+      cwd: directory,
+      isSupported: (version) => version === "fixture-node-22",
+      candidates: [node],
+      exists: () => true,
+      probe: () => "fixture-node-22",
+      spawn(command, args, options) {
+        child = { command, args, options };
+        return { status: 7 };
+      },
+      exit(code) {
+        exitCode = code;
+      },
+    });
+    assert.equal(reexecuted, true);
+  } finally {
+    if (originalMiseData === undefined) delete process.env.MISE_DATA_DIR;
+    else process.env.MISE_DATA_DIR = originalMiseData;
+  }
+
+  assert.equal(child.command, node);
+  assert.equal(child.args[0], path.join(directory, "ci-local.js"));
+  assert.equal(child.options.cwd, directory);
+  assert.equal(child.options.env.GREEN_GOODS_TEST_SUCCESS_REEXEC, "1");
+  assert.equal(child.options.env.NODE, node);
+  assert.equal(child.options.env.npm_node_execpath, node);
+  assert.deepEqual(child.options.env.PATH.split(path.delimiter).slice(0, 3), [
+    path.dirname(bun),
+    path.dirname(forge),
+    path.dirname(node),
+  ]);
+  assert.equal(exitCode, 7);
+});
+
+test("the re-entry sentinel prevents an infinite spawn loop", () => {
+  const sentinel = "GREEN_GOODS_TEST_SENTINEL_REEXEC";
+  const original = process.env[sentinel];
+  process.env[sentinel] = "1";
+  try {
+    const reexecuted = reexecUnderCompatibleNodeIfNeeded({
+      scriptPath: "/workspace/ci-local.js",
+      sentinel,
+      cwd: "/workspace",
+      isSupported: () => false,
+      candidates: ["/compatible/node"],
+      exists: () => true,
+      probe: () => "22.22.1",
+      spawn() {
+        assert.fail("sentinel re-entry must not spawn");
+      },
+      exit() {
+        assert.fail("sentinel re-entry must not exit");
+      },
+    });
+    assert.equal(reexecuted, false);
+  } finally {
+    if (original === undefined) delete process.env[sentinel];
+    else process.env[sentinel] = original;
+  }
+});

--- a/scripts/quality/select-validation.mjs
+++ b/scripts/quality/select-validation.mjs
@@ -83,6 +83,7 @@ function isValidationOnlyPath(path) {
 
 const directRootTestChecks = new Map([
   ["scripts/lib/env-schema.test.mjs", "env-schema-test"],
+  ["scripts/lib/dev-shared.test.mjs", "validation-system-test"],
   ["scripts/quality/select-validation.test.mjs", "validation-system-test"],
   ["scripts/dev/ci-local.test.mjs", "validation-system-test"],
   ["scripts/dev/surface-leases.test.mjs", "validation-system-test"],

--- a/scripts/quality/select-validation.test.mjs
+++ b/scripts/quality/select-validation.test.mjs
@@ -207,6 +207,11 @@ test("recognized root tests select their durable acceptance commands", () => {
   for (const [changedPath, checkId, command] of [
     ["scripts/lib/env-schema.test.mjs", "env-schema-test", "bun run test:env-schema"],
     [
+      "scripts/lib/dev-shared.test.mjs",
+      "validation-system-test",
+      "bun run test:validation-system",
+    ],
+    [
       "scripts/quality/select-validation.test.mjs",
       "validation-system-test",
       "bun run test:validation-system",


### PR DESCRIPTION
## Summary
- make `ci-local` re-enter under a compatible Node runtime from non-interactive agent shells
- carry the repository-pinned Node, Bun, and Foundry toolchain through re-entry
- consolidate the injectable runtime-selection helpers and register their regression suite

## Validation
- [x] `bun run test:validation-system` passes 114/114
- [x] `node scripts/dev/ci-local.js --quick --plan-json` reports ready
- [x] `bun run ci:local -- --quick --plan-json` reports the same ready toolchain
- [x] re-entry sentinel and unsupported-host cases pass
- [x] changed paths are clean at `28754385cf91ea5c7e75358504540e12c2b04d8b`

Refs PRD-831