### PR TITLE
perf(shared,client,admin): cap local Vitest workers

### DIFF
--- a/packages/admin/vitest.config.ts
+++ b/packages/admin/vitest.config.ts
@@ -1,8 +1,11 @@
 /// <reference types="vitest" />
 
-import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import { availableParallelism, totalmem } from "node:os";
 import { resolve } from "path";
+import { defineConfig } from "vitest/config";
+
+import { resolveVitestMaxWorkers } from "../../scripts/lib/dev-shared.js";
 
 const localReactPath = resolve(__dirname, "./node_modules/react");
 const localReactDomPath = resolve(__dirname, "./node_modules/react-dom");
@@ -134,6 +137,11 @@ export default defineConfig({
       },
     },
     pool: "threads",
+    maxWorkers: resolveVitestMaxWorkers({
+      cpus: availableParallelism(),
+      totalMemoryBytes: totalmem(),
+      ci: Boolean(process.env.CI),
+    }),
     isolate: true,
     server: {
       deps: {

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -1,7 +1,10 @@
 import react from "@vitejs/plugin-react";
+import { availableParallelism, totalmem } from "node:os";
 import path from "path";
 import type { PluginOption } from "vite";
 import { defineConfig } from "vitest/config";
+
+import { resolveVitestMaxWorkers } from "../../scripts/lib/dev-shared.js";
 
 export default defineConfig({
   plugins: [react()],
@@ -30,6 +33,11 @@ export default defineConfig({
     testTimeout: 10000,
     // Use threads to avoid module pollution between tests
     pool: "threads",
+    maxWorkers: resolveVitestMaxWorkers({
+      cpus: availableParallelism(),
+      totalMemoryBytes: totalmem(),
+      ci: Boolean(process.env.CI),
+    }),
     isolate: true,
     coverage: {
       provider: "v8",

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,7 +1,10 @@
 import react from "@vitejs/plugin-react";
 import fs from "node:fs";
+import { availableParallelism, totalmem } from "node:os";
 import path from "path";
 import { defineConfig } from "vitest/config";
+
+import { resolveVitestMaxWorkers } from "../../scripts/lib/dev-shared.js";
 
 const workspaceRoot = path.resolve(__dirname, "../..");
 const workspaceNodeModules = path.join(workspaceRoot, "node_modules");
@@ -33,6 +36,11 @@ export default defineConfig({
     globals: true,
     testTimeout: 10000,
     pool: "threads",
+    maxWorkers: resolveVitestMaxWorkers({
+      cpus: availableParallelism(),
+      totalMemoryBytes: totalmem(),
+      ci: Boolean(process.env.CI),
+    }),
     isolate: true,
     server: {
       deps: {

--- a/scripts/dev/ci-local.js
+++ b/scripts/dev/ci-local.js
@@ -2,12 +2,14 @@
 
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { availableParallelism, totalmem } from "node:os";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 import {
   reexecUnderCompatibleNodeIfNeeded,
   reexecUnderSystemNodeIfNeeded,
+  resolveVitestMaxWorkers,
 } from "../lib/dev-shared.js";
 import {
   buildReceiptInputs,
@@ -349,6 +351,27 @@ function envForCheck(check) {
   return common;
 }
 
+export function resolveVitestBatchEnvironment(
+  batch,
+  {
+    cpus = availableParallelism(),
+    totalMemoryBytes = totalmem(),
+    ci = Boolean(process.env.CI),
+    explicitMaxWorkers = process.env.VITEST_MAX_WORKERS,
+  } = {},
+) {
+  if (batch.length < 2 || !batch.every((check) => check.id.endsWith("-test"))) return {};
+  if (explicitMaxWorkers) return { VITEST_MAX_WORKERS: explicitMaxWorkers };
+
+  const maxWorkers = resolveVitestMaxWorkers({
+    cpus,
+    totalMemoryBytes,
+    ci,
+    share: batch.length,
+  });
+  return maxWorkers === undefined ? {} : { VITEST_MAX_WORKERS: String(maxWorkers) };
+}
+
 function elapsedSeconds(start) {
   return Number(((Date.now() - start) / 1000).toFixed(3));
 }
@@ -388,7 +411,10 @@ async function runAbiArtifactCheck() {
   return { ok: problems.length === 0, exitCode: problems.length === 0 ? 0 : 1, details: problems };
 }
 
-export async function runCommandCheck(check, { signal, captureOutput = false } = {}) {
+export async function runCommandCheck(
+  check,
+  { signal, captureOutput = false, environment = {} } = {},
+) {
   const start = Date.now();
   if (check.builtin === "abiArtifacts") {
     const result = await runAbiArtifactCheck();
@@ -416,7 +442,7 @@ export async function runCommandCheck(check, { signal, captureOutput = false } =
       // capture instead, so their logs replay in plan order rather than
       // interleaving into noise.
       stdio: captureOutput ? ["ignore", "pipe", "pipe"] : "inherit",
-      env: { ...process.env, ...envForCheck(check) },
+      env: { ...process.env, ...envForCheck(check), ...environment },
       detached: process.platform !== "win32",
     });
     let output = "";
@@ -466,6 +492,8 @@ export async function executePlan(plan, options = {}) {
   const receiptStore = options.receiptStore ?? new Map();
   const reusePassingReceipts = options.reusePassingReceipts === true;
   const concurrency = options.concurrency !== false;
+  const resolveBatchEnvironment =
+    options.resolveBatchEnvironment ?? resolveVitestBatchEnvironment;
 
   if (plan.status === "cancelled" || signal?.aborted) {
     return { status: "cancelled", exitCode: 130, results, blocked };
@@ -555,8 +583,11 @@ export async function executePlan(plan, options = {}) {
     }
 
     options.onBatchStart?.(batch);
+    const environment = resolveBatchEnvironment(batch);
     const settled = await Promise.all(
-      batch.map((member) => runCheck(member, { signal, captureOutput: true })),
+      batch.map((member) =>
+        runCheck(member, { signal, captureOutput: true, environment }),
+      ),
     );
     for (const [position, member] of batch.entries()) {
       const evidence = {

--- a/scripts/dev/ci-local.test.mjs
+++ b/scripts/dev/ci-local.test.mjs
@@ -11,8 +11,11 @@ import {
   isSupportedCiNodeVersion,
   loadPassingReceiptStore,
   parseArguments,
+  resolveVitestBatchEnvironment,
   savePassingReceiptStore,
 } from "./ci-local.js";
+
+const GIBIBYTE = 1024 ** 3;
 
 test("ci-local re-entry is wired only inside the direct-run guard", () => {
   const source = readFileSync(new URL("./ci-local.js", import.meta.url), "utf8");
@@ -281,10 +284,17 @@ function groupedPlan(specs) {
 }
 
 function overlapTracker() {
-  const state = { active: 0, peak: 0, captured: new Map(), order: [] };
+  const state = {
+    active: 0,
+    peak: 0,
+    captured: new Map(),
+    environments: new Map(),
+    order: [],
+  };
   const runCheck = async (check, options = {}) => {
     state.order.push(check.id);
     state.captured.set(check.id, options.captureOutput === true);
+    state.environments.set(check.id, options.environment);
     state.active += 1;
     state.peak = Math.max(state.peak, state.active);
     await new Promise((resolve) => setTimeout(resolve, 15));
@@ -308,6 +318,61 @@ test("adjacent checks sharing a concurrency group run together", async () => {
   assert.equal(state.peak, 2);
   assert.equal(state.captured.get("client-test"), true);
   assert.equal(state.captured.get("admin-test"), true);
+});
+
+test("batched package tests receive a worker cap divided by batch size", () => {
+  const environment = resolveVitestBatchEnvironment(
+    [
+      { id: "client-test" },
+      { id: "admin-test" },
+    ],
+    {
+      cpus: 10,
+      totalMemoryBytes: 16 * GIBIBYTE,
+      ci: false,
+    },
+  );
+
+  assert.deepEqual(environment, { VITEST_MAX_WORKERS: "4" });
+});
+
+test("batched worker environment leaves CI unchanged and preserves explicit overrides", () => {
+  const batch = [{ id: "client-test" }, { id: "admin-test" }];
+  const resources = {
+    cpus: 10,
+    totalMemoryBytes: 16 * GIBIBYTE,
+    ci: true,
+  };
+
+  assert.deepEqual(resolveVitestBatchEnvironment(batch, resources), {});
+  assert.deepEqual(
+    resolveVitestBatchEnvironment(batch, {
+      ...resources,
+      explicitMaxWorkers: "3",
+    }),
+    { VITEST_MAX_WORKERS: "3" },
+  );
+});
+
+test("every member of a concurrent test batch receives the resolved worker environment", async () => {
+  const { state, runCheck } = overlapTracker();
+  await executePlan(
+    groupedPlan([
+      { id: "client-test", group: "package-tests-surface" },
+      { id: "admin-test", group: "package-tests-surface" },
+    ]),
+    {
+      runCheck,
+      resolveBatchEnvironment: () => ({ VITEST_MAX_WORKERS: "2" }),
+    },
+  );
+
+  assert.deepEqual(state.environments.get("client-test"), {
+    VITEST_MAX_WORKERS: "2",
+  });
+  assert.deepEqual(state.environments.get("admin-test"), {
+    VITEST_MAX_WORKERS: "2",
+  });
 });
 
 test("different groups, ungrouped checks, and blocked members never batch", async () => {

--- a/scripts/lib/dev-shared.js
+++ b/scripts/lib/dev-shared.js
@@ -257,6 +257,19 @@ export function majorVersion(version) {
   return match ? Number.parseInt(match[1], 10) : null;
 }
 
+const VITEST_WORKER_MEMORY_BYTES = 2 * 1024 ** 3;
+
+export function resolveVitestMaxWorkers({ cpus, totalMemoryBytes, ci, share = 1 }) {
+  if (ci) return undefined;
+
+  const cpuLimit = Math.max(2, Math.floor(cpus) - 1);
+  const memoryLimit = Math.floor(totalMemoryBytes / VITEST_WORKER_MEMORY_BYTES);
+  const packageShare = Math.max(1, Math.floor(share));
+  const sharedLimit = Math.floor(Math.min(cpuLimit, memoryLimit) / packageShare);
+
+  return Math.min(cpuLimit, Math.max(2, sharedLimit));
+}
+
 /**
  * GET a URL, resolving with `{ ok, statusCode? | error? }`. Self-signed certs
  * are accepted (vite-plugin-mkcert generates one per dev session).

--- a/scripts/lib/dev-shared.test.mjs
+++ b/scripts/lib/dev-shared.test.mjs
@@ -7,7 +7,39 @@ import test from "node:test";
 import {
   findCompatibleNode,
   reexecUnderCompatibleNodeIfNeeded,
+  resolveVitestMaxWorkers,
 } from "./dev-shared.js";
+
+const GIBIBYTE = 1024 ** 3;
+
+test("local Vitest workers respect CPU, memory, and concurrent package share", () => {
+  const cases = [
+    {
+      name: "16 GB and 10 cores",
+      input: { cpus: 10, totalMemoryBytes: 16 * GIBIBYTE, ci: false },
+      expected: 8,
+    },
+    {
+      name: "8 GB is memory bound",
+      input: { cpus: 10, totalMemoryBytes: 8 * GIBIBYTE, ci: false },
+      expected: 4,
+    },
+    {
+      name: "CI keeps its existing worker policy",
+      input: { cpus: 10, totalMemoryBytes: 16 * GIBIBYTE, ci: true },
+      expected: undefined,
+    },
+    {
+      name: "three concurrent packages share the local cap",
+      input: { cpus: 10, totalMemoryBytes: 16 * GIBIBYTE, ci: false, share: 3 },
+      expected: 2,
+    },
+  ];
+
+  for (const { name, input, expected } of cases) {
+    assert.equal(resolveVitestMaxWorkers(input), expected, name);
+  }
+});
 
 test("compatible Node selection honors candidate order and skips Bun shims", () => {
   const versions = new Map([

--- a/scripts/quality/workflow-performance-parity.test.mjs
+++ b/scripts/quality/workflow-performance-parity.test.mjs
@@ -261,6 +261,26 @@ test("CI coverage drops HTML generation without weakening local reports or thres
   );
 });
 
+test("consumer Vitest configs share the local resource-aware worker policy", () => {
+  for (const file of [
+    "packages/shared/vitest.config.ts",
+    "packages/client/vitest.config.ts",
+    "packages/admin/vitest.config.ts",
+  ]) {
+    const source = read(file);
+    assert.match(
+      source,
+      /import \{ resolveVitestMaxWorkers \} from ["']\.\.\/\.\.\/scripts\/lib\/dev-shared\.js["'];/,
+      `${file} must import the shared worker policy`,
+    );
+    assert.match(
+      source,
+      /maxWorkers:\s*resolveVitestMaxWorkers\(\{/,
+      `${file} must resolve its local worker cap through the shared policy`,
+    );
+  }
+});
+
 test("contracts realism remains equivalent without unrelated tool setup", () => {
   const source = read(".github/workflows/contracts.yml");
   const realism = source.slice(


### PR DESCRIPTION
## Summary
- derive a local Vitest worker cap from CPU, memory, and concurrent package share
- leave CI uncapped and preserve explicit `VITEST_MAX_WORKERS` overrides
- pass one shared cap into concurrent package-test batches

## Validation
- [x] focused worker and runner tests pass 45/45
- [x] validation-system suite passes 119/119
- [x] Shared, Client, Admin, and Agent functional suites pass
- [x] CI resolves no config cap and explicit value `3` wins
- [ ] quiet-machine base-versus-lane timing matrix (proof limit accepted by the user on 2026-08-22)
- [x] changed paths are clean at `35e42cc29d9256379aa36512eba38114a1f61057`

The user explicitly approved merging with the quiet-machine timing receipt deferred so Wave 1 can begin. This is recorded as an accepted proof limit, not a passing timing result.

Refs PRD-831