### PR TITLE
test(shared,client,admin,contracts): stabilize loaded tests

### DIFF
--- a/packages/admin/src/__tests__/components/CreateAssessmentDialog.test.tsx
+++ b/packages/admin/src/__tests__/components/CreateAssessmentDialog.test.tsx
@@ -375,8 +375,10 @@ describe("CreateAssessment dialog", () => {
     // Pristine form: Escape must not raise the discard confirm — it exits
     // directly to the Hub workbench the flow was launched from (controller
     // handleCancel → adminRoutes.hub → the default /hub/work stage).
+    await waitFor(() => {
+      expect(router?.state.location.pathname).toBe("/hub/work");
+      expect(screen.queryByRole("dialog", { name: "Submit Assessment" })).not.toBeInTheDocument();
+    });
     expect(screen.queryByRole("button", { name: "Discard" })).not.toBeInTheDocument();
-    expect(screen.queryByRole("dialog", { name: "Submit Assessment" })).not.toBeInTheDocument();
-    expect(router?.state.location.pathname).toBe("/hub/work");
   });
 });

--- a/packages/admin/src/__tests__/components/Garden/AddMembersDialog.test.tsx
+++ b/packages/admin/src/__tests__/components/Garden/AddMembersDialog.test.tsx
@@ -85,11 +85,12 @@ describe("components/Garden/AddMembersDialog", () => {
   });
 
   it("stages resolved addresses into the reserved list and clears the input", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     render(createElement(AddMembersDialog, defaultProps));
 
     const input = screen.getByLabelText(/Ethereum Address or ENS Name/);
-    await user.type(input, ADDRESS_A);
+    await user.click(input);
+    await user.paste(ADDRESS_A);
     await user.click(screen.getByRole("button", { name: "Add" }));
 
     await waitFor(() => {
@@ -101,13 +102,15 @@ describe("components/Garden/AddMembersDialog", () => {
   });
 
   it("commits the staged batch for the selected role and closes on success", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     render(createElement(AddMembersDialog, defaultProps));
 
     const input = screen.getByLabelText(/Ethereum Address or ENS Name/);
-    await user.type(input, ADDRESS_A);
+    await user.click(input);
+    await user.paste(ADDRESS_A);
     await user.click(screen.getByRole("button", { name: "Add" }));
-    await user.type(input, ADDRESS_B);
+    await user.click(input);
+    await user.paste(ADDRESS_B);
 
     // Typed-but-unstaged address folds into the batch — one staged + one typed.
     await user.click(screen.getByRole("button", { name: "Add 2 members" }));
@@ -123,7 +126,7 @@ describe("components/Garden/AddMembersDialog", () => {
   });
 
   it("keeps failed writes staged for retry and stays open", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     const onAdd = vi
       .fn()
       .mockResolvedValueOnce({ success: false })
@@ -131,9 +134,11 @@ describe("components/Garden/AddMembersDialog", () => {
     render(createElement(AddMembersDialog, { ...defaultProps, onAdd }));
 
     const input = screen.getByLabelText(/Ethereum Address or ENS Name/);
-    await user.type(input, ADDRESS_A);
+    await user.click(input);
+    await user.paste(ADDRESS_A);
     await user.click(screen.getByRole("button", { name: "Add" }));
-    await user.type(input, ADDRESS_B);
+    await user.click(input);
+    await user.paste(ADDRESS_B);
     await user.click(screen.getByRole("button", { name: "Add 2 members" }));
 
     // First write failed → its address stays staged, the dialog stays open.
@@ -146,10 +151,12 @@ describe("components/Garden/AddMembersDialog", () => {
   });
 
   it("submits a typed address directly without requiring the stage step", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     render(createElement(AddMembersDialog, defaultProps));
 
-    await user.type(screen.getByLabelText(/Ethereum Address or ENS Name/), ADDRESS_A);
+    const input = screen.getByLabelText(/Ethereum Address or ENS Name/);
+    await user.click(input);
+    await user.paste(ADDRESS_A);
     await user.click(screen.getByRole("button", { name: "Add 1 member" }));
 
     await waitFor(() => {
@@ -158,10 +165,12 @@ describe("components/Garden/AddMembersDialog", () => {
   });
 
   it("keeps invalid typed entries from becoming commit-ready", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     render(createElement(AddMembersDialog, defaultProps));
 
-    await user.type(screen.getByLabelText(/Ethereum Address or ENS Name/), "not-a-wallet");
+    const input = screen.getByLabelText(/Ethereum Address or ENS Name/);
+    await user.click(input);
+    await user.paste("not-a-wallet");
 
     expect(screen.getByRole("button", { name: "Add" })).toBeDisabled();
     expect(screen.getByRole("button", { name: "Add 0 members" })).toBeDisabled();
@@ -169,11 +178,12 @@ describe("components/Garden/AddMembersDialog", () => {
   });
 
   it("confirms before discarding a staged batch on dialog dismiss", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     render(createElement(AddMembersDialog, defaultProps));
 
     const input = screen.getByLabelText(/Ethereum Address or ENS Name/);
-    await user.type(input, ADDRESS_A);
+    await user.click(input);
+    await user.paste(ADDRESS_A);
     await user.click(screen.getByRole("button", { name: "Add" }));
     await waitFor(() => {
       expect(screen.getByTestId("staged-address")).toBeInTheDocument();
@@ -195,10 +205,12 @@ describe("components/Garden/AddMembersDialog", () => {
   });
 
   it("lets the footer Cancel exit directly without a discard confirm", async () => {
-    const user = userEvent.setup();
+    const user = userEvent.setup({ delay: null });
     render(createElement(AddMembersDialog, defaultProps));
 
-    await user.type(screen.getByLabelText(/Ethereum Address or ENS Name/), ADDRESS_A);
+    const input = screen.getByLabelText(/Ethereum Address or ENS Name/);
+    await user.click(input);
+    await user.paste(ADDRESS_A);
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(screen.queryByText("Discard changes?")).not.toBeInTheDocument();

--- a/packages/client/src/__tests__/components/GardenGardeners.test.tsx
+++ b/packages/client/src/__tests__/components/GardenGardeners.test.tsx
@@ -1,8 +1,8 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { createRef, type ReactNode } from "react";
 import { IntlProvider } from "react-intl";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@green-goods/shared", () => ({
   cn: (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(" "),
@@ -63,10 +63,25 @@ const members: GardenMember[] = Array.from({ length: 41 }, (_, index) => ({
   isGardener: true,
 }));
 
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("GardenGardeners", () => {
   it("virtualizes large member lists while preserving selection and list semantics", async () => {
     const user = userEvent.setup();
     const ref = createRef<HTMLUListElement>();
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      bottom: 600,
+      height: 600,
+      left: 0,
+      right: 640,
+      top: 0,
+      width: 640,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    });
 
     render(
       <TestIntl>
@@ -75,11 +90,13 @@ describe("GardenGardeners", () => {
     );
 
     expect(ref.current?.tagName).toBe("UL");
-    const renderedRows = screen.getAllByRole("listitem");
-    expect(renderedRows.length).toBeGreaterThan(0);
-    expect(renderedRows.length).toBeLessThan(members.length);
-    expect(renderedRows[0]).toHaveAttribute("aria-posinset", "1");
-    expect(renderedRows[0]).toHaveAttribute("aria-setsize", "41");
+    await waitFor(() => {
+      const renderedRows = screen.getAllByRole("listitem");
+      expect(renderedRows.length).toBeGreaterThan(0);
+      expect(renderedRows.length).toBeLessThan(members.length);
+      expect(renderedRows[0]).toHaveAttribute("aria-posinset", "1");
+      expect(renderedRows[0]).toHaveAttribute("aria-setsize", "41");
+    });
 
     await user.click(screen.getByRole("button", { name: /Member 0/i }));
 

--- a/packages/contracts/script/deploy/release.test.ts
+++ b/packages/contracts/script/deploy/release.test.ts
@@ -208,7 +208,9 @@ describe("release CLI real entrypoints", () => {
     ).toThrow(/receipt is invalid/);
   });
 
-  it("replays a pure stage plan with the exact CLI salt and never mutates canonical artifacts", () => {
+  it("replays a pure stage plan with the exact CLI salt and never mutates canonical artifacts", {
+    timeout: 60_000,
+  }, () => {
     const arbitrumBefore = fs.readFileSync(ARBITRUM_ARTIFACT);
     const celoBefore = fs.readFileSync(CELO_ARTIFACT);
     const manifest = loadReleaseManifest();

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    dir: "script",
+    environment: "node",
+    hookTimeout: 30_000,
+    testTimeout: 30_000,
+  },
+});

--- a/packages/shared/src/__tests__/i18n/locale-coverage.test.ts
+++ b/packages/shared/src/__tests__/i18n/locale-coverage.test.ts
@@ -80,6 +80,14 @@ const descriptorIdPropNames = new Set([
   "ariaLabelId",
   "actionLabelId",
 ]);
+const sourceMessageTriggerTokens = [
+  "formatMessage",
+  "defineMessage",
+  "defineMessages",
+  "FormattedMessage",
+  "defaultMessage",
+  ...descriptorIdPropNames,
+];
 const allowedIdenticalLocalizedKeys = new Set([
   "app.admin.nav.cookieJars",
   "app.community.weightScheme.linear",
@@ -271,6 +279,10 @@ function walkSourceFiles(dir: string, files: string[] = []): string[] {
   return files;
 }
 
+function containsSourceMessageTrigger(source: string): boolean {
+  return sourceMessageTriggerTokens.some((token) => source.includes(token));
+}
+
 function collectSourceMessageRefs(): SourceMessageRef[] {
   const refs = new Map<string, SourceMessageRef>();
 
@@ -285,7 +297,10 @@ function collectSourceMessageRefs(): SourceMessageRef[] {
   };
 
   for (const file of sourceRoots.flatMap((root) => walkSourceFiles(root))) {
-    const source = parse(fs.readFileSync(file, "utf8"), {
+    const contents = fs.readFileSync(file, "utf8");
+    if (!containsSourceMessageTrigger(contents)) continue;
+
+    const source = parse(contents, {
       sourceFilename: file,
       sourceType: "unambiguous",
       plugins: file.endsWith(".tsx") ? ["typescript", "jsx"] : ["typescript"],
@@ -428,6 +443,19 @@ describe("i18n locale coverage", () => {
   });
 
   describe("Source usage coverage", () => {
+    it("recognizes every direct source message form before parsing", () => {
+      const directForms = [
+        'intl.formatMessage({ id: "app.direct.format" })',
+        'defineMessage({ id: "app.direct.define" })',
+        'defineMessages({ direct: { id: "app.direct.group" } })',
+        'const descriptor = { id: "app.direct.descriptor", defaultMessage: "Direct" }',
+        'const config = { titleId: "app.direct.title" }',
+        '<FormattedMessage id="app.direct.component" />',
+      ];
+
+      expect(directForms.every(containsSourceMessageTrigger)).toBe(true);
+    });
+
     it("should include every statically declared source message id in all locales", () => {
       const refs = collectSourceMessageRefs();
       const catalogs: Record<string, LocaleCatalog> = { en, es, pt };


### PR DESCRIPTION
## Summary
- replace timing-sensitive UI assertions with observable state waits
- reduce address-input event amplification and pin virtualization geometry in tests
- prefilter locale source parsing and give contract script tests bounded local timeouts

## Validation
- [x] Admin focused tests pass 14/14
- [x] Client focused test passes 1/1
- [x] Shared locale suite passes 13/13
- [x] Contracts script suite passes 32/32
- [x] five loaded repetitions per focused file pass, with all background Admin suites green
- [x] filtered and unfiltered locale scans return the same 4,568 references
- [x] changed paths are clean at `ffbed3546cd3d798ff449407f1b35bece479a29c`

The exact pre-change loaded failures did not reproduce; the receipt records that characterization limit without claiming a before/after frequency.

Refs PRD-831