### PR TITLE
ci(shared,client,admin): enforce nightly coverage floors

### DIFF
--- a/.claude/context/testing.md
+++ b/.claude/context/testing.md
@@ -30,7 +30,9 @@ Alias → `packages/shared/src/__tests__/test-utils/`. Import test helpers from 
 
 ## Coverage
 
-Enforced global thresholds live in each `vitest.config.ts` (source of truth): **shared** 70/70/70/70 · **admin** 70/70/70/70 · **client** 75 branches / 80 funcs·lines·stmts. Policy targets (not config-enforced): critical paths ≥80%, auth/crypto 100%. Contracts use Foundry, not Vitest — see `.claude/context/contracts.md` and `docs/docs/builders/testing/forge.mdx`. Report: `bun run test --coverage` → `coverage/index.html`.
+Enforced global thresholds live in each `vitest.config.ts` (branches/functions/lines/statements): **shared** 52/59/62/61 · **client** 56/62/64/63 · **admin** 47/44/53/51. Pull request Test jobs run plain `bun run test`; `.github/workflows/coverage-nightly.yml` enforces these floors nightly and after every push to `main`. Local coverage commands still generate `coverage/index.html`; CI omits HTML.
+
+The first ratchet review is 2026-09-22. Once coverage supports it, raise every configured metric by two percentage points and update the matching arrays in `scripts/quality/workflow-performance-parity.test.mjs` in the same change. Policy targets remain critical paths ≥80% and auth/crypto 100%. Contracts use Foundry, not Vitest — see `.claude/context/contracts.md` and `docs/docs/builders/testing/forge.mdx`.
 
 ## Critical paths (deepest coverage in `packages/shared/src/`)
 

--- a/.github/workflows/admin.yml
+++ b/.github/workflows/admin.yml
@@ -87,9 +87,9 @@ jobs:
       - name: Setup JavaScript toolchain and dependencies
         uses: ./.github/actions/setup-js
 
-      - name: Run admin tests with coverage
+      - name: Run admin tests
         working-directory: packages/admin
-        run: bun run test:coverage
+        run: bun run test
         env:
           CI: true
 

--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -87,9 +87,9 @@ jobs:
       - name: Setup JavaScript toolchain and dependencies
         uses: ./.github/actions/setup-js
 
-      - name: Run client tests with coverage
+      - name: Run client tests
         working-directory: packages/client
-        run: bun run coverage
+        run: bun run test
         env:
           CI: true
 

--- a/.github/workflows/coverage-nightly.yml
+++ b/.github/workflows/coverage-nightly.yml
@@ -1,0 +1,48 @@
+name: Coverage Nightly
+
+# Pull requests run plain package tests for fast feedback. This lane enforces
+# the measured coverage floors nightly and after every push to main.
+on:
+  schedule:
+    - cron: "43 8 * * *"
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    name: ${{ matrix.name }} Coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Shared
+            package: shared
+            script: coverage
+          - name: Client
+            package: client
+            script: coverage
+          - name: Admin
+            package: admin
+            script: test:coverage
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Setup JavaScript toolchain and dependencies
+        uses: ./.github/actions/setup-js
+
+      - name: Run ${{ matrix.name }} coverage
+        working-directory: packages/${{ matrix.package }}
+        run: bun run ${{ matrix.script }}
+        env:
+          CI: true

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -113,9 +113,9 @@ jobs:
       - name: Setup JavaScript toolchain and dependencies
         uses: ./.github/actions/setup-js
 
-      - name: Run shared tests with coverage
+      - name: Run shared tests
         working-directory: packages/shared
-        run: bun run coverage
+        run: bun run test
         env:
           CI: true
 

--- a/docs/docs/builders/testing/vitest.mdx
+++ b/docs/docs/builders/testing/vitest.mdx
@@ -4,7 +4,7 @@ sidebar_label: Vitest
 slug: /builders/testing/vitest
 audience: developer
 owner: docs
-last_verified: 2026-03-08
+last_verified: 2026-08-23
 feature_status: Live
 source_of_truth:
   - packages/shared/package.json
@@ -46,7 +46,7 @@ graph TB
     end
 
     Support --> Packages
-    Packages --> Coverage["V8 Coverage\n70% threshold"]
+    Packages --> Coverage["V8 Coverage\nnightly package floors"]
 ```
 
 Unit and integration testing framework for all TypeScript packages. Each package has its own `vitest.config.ts` with package-specific aliases, environment settings, and coverage thresholds.
@@ -196,14 +196,21 @@ The default shared test command is intentionally hermetic. Live RPC coverage is 
 
 ## Coverage thresholds
 
-Coverage is enforced per package, not with one monorepo-wide threshold:
+Coverage is enforced per package, not with one monorepo-wide threshold. Pull request Test jobs run
+plain `bun run test` for fast feedback. The Coverage Nightly workflow runs on a daily schedule, after
+every push to `main`, and by manual dispatch; that workflow runs the package coverage scripts with
+`CI=true` and enforces the floors below.
 
 | Package | Branches | Functions | Lines | Statements |
 |---------|----------|-----------|-------|------------|
-| **shared** | 70 | 70 | 70 | 70 |
-| **admin** | 70 | 70 | 70 | 70 |
-| **client** | 75 | 80 | 80 | 80 |
+| **shared** | 52 | 59 | 62 | 61 |
+| **admin** | 47 | 44 | 53 | 51 |
+| **client** | 56 | 62 | 64 | 63 |
 | **agent** | 10 | 20 | 20 | 20 |
+
+The first ratchet review is scheduled for 2026-09-22. Once the measured coverage supports the
+change, raise each configured metric by two percentage points and update its parity-test array in
+the same commit. A floor change is incomplete if the Vitest config and parity fixture disagree.
 
 ## Resources
 

--- a/packages/admin/vitest.config.ts
+++ b/packages/admin/vitest.config.ts
@@ -128,12 +128,10 @@ export default defineConfig({
         "**/index.ts",
       ],
       thresholds: {
-        global: {
-          branches: 70,
-          functions: 70,
-          lines: 70,
-          statements: 70,
-        },
+        branches: 47,
+        functions: 44,
+        lines: 53,
+        statements: 51,
       },
     },
     pool: "threads",

--- a/packages/client/vitest.config.ts
+++ b/packages/client/vitest.config.ts
@@ -55,12 +55,10 @@ export default defineConfig({
         "**/build/**",
       ],
       thresholds: {
-        global: {
-          branches: 75,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
+        branches: 56,
+        functions: 62,
+        lines: 64,
+        statements: 63,
       },
     },
     include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -86,12 +86,10 @@ export default defineConfig({
         "**/dist/**",
       ],
       thresholds: {
-        global: {
-          branches: 70,
-          functions: 70,
-          lines: 70,
-          statements: 70,
-        },
+        branches: 52,
+        functions: 59,
+        lines: 62,
+        statements: 61,
       },
     },
     include: ["src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],

--- a/scripts/quality/workflow-performance-parity.test.mjs
+++ b/scripts/quality/workflow-performance-parity.test.mjs
@@ -66,6 +66,7 @@ test("dependency-installing workflow jobs use shared JS setup", () => {
     "client.yml",
     "contracts-nightly.yml",
     "contracts.yml",
+    "coverage-nightly.yml",
     "design.yml",
     "docs.yml",
     "indexer.yml",
@@ -226,10 +227,10 @@ test("Shared outer routing matches the internal shared-impact detector", () => {
 
 test("CI coverage drops HTML generation without weakening local reports or thresholds", () => {
   const configs = {
-    "packages/admin/vitest.config.ts": [70, 70, 70, 70],
+    "packages/admin/vitest.config.ts": [47, 44, 53, 51],
     "packages/agent/vitest.config.ts": [10, 20, 20, 20],
-    "packages/client/vitest.config.ts": [75, 80, 80, 80],
-    "packages/shared/vitest.config.ts": [70, 70, 70, 70],
+    "packages/client/vitest.config.ts": [56, 62, 64, 63],
+    "packages/shared/vitest.config.ts": [52, 59, 62, 61],
   };
 
   for (const [file, thresholds] of Object.entries(configs)) {
@@ -237,6 +238,7 @@ test("CI coverage drops HTML generation without weakening local reports or thres
     assert.match(source, /process\.env\.CI/);
     assert.match(source, /\["text", "json"\]/);
     assert.match(source, /\["text", "json", "html"\]|\["text", "html", "json"\]/);
+    assert.doesNotMatch(source, /thresholds:\s*\{\s*global:/);
     const actualThresholds = [
       ...source.matchAll(
         /(?:branches|functions|lines|statements):\s*(\d+)(?:,|\n)/g,
@@ -279,6 +281,31 @@ test("consumer Vitest configs share the local resource-aware worker policy", () 
       `${file} must resolve its local worker cap through the shared policy`,
     );
   }
+});
+
+test("PR Test jobs run plain tests; thresholds are enforced nightly and on main", () => {
+  for (const file of ["shared.yml", "client.yml", "admin.yml"]) {
+    const source = read(`.github/workflows/${file}`);
+    const testJob = source.slice(
+      source.indexOf("  test:"),
+      source.indexOf("  lint-", source.indexOf("  test:")),
+    );
+
+    assert.match(testJob, /run:\s*bun run test(?:\s|$)/, `${file} Test must stay plain`);
+    assert.doesNotMatch(testJob, /coverage/, `${file} Test must not collect coverage`);
+  }
+
+  const source = read(".github/workflows/coverage-nightly.yml");
+  assert.match(source, /schedule:\s*\n\s*- cron:/);
+  assert.match(workflowEventBlock(source, "push"), /branches:\s*\[main\]/);
+  assert.match(source, /workflow_dispatch:\s*\{\}/);
+  assert.match(source, /fail-fast:\s*false/);
+  assert.match(source, /package:\s*shared\s*\n\s*script:\s*coverage/);
+  assert.match(source, /package:\s*client\s*\n\s*script:\s*coverage/);
+  assert.match(source, /package:\s*admin\s*\n\s*script:\s*test:coverage/);
+  assert.match(source, /uses:\s*\.\/\.github\/actions\/setup-js/);
+  assert.match(source, /run:\s*bun run \$\{\{ matrix\.script \}\}/);
+  assert.match(source, /CI:\s*true/);
 });
 
 test("contracts realism remains equivalent without unrelated tool setup", () => {


### PR DESCRIPTION
## Summary
- enforce measured Shared, Client, and Admin coverage floors with Vitest's flat threshold shape
- move coverage off pull-request Test jobs into a fail-fast-false nightly, main, and manual matrix
- lock the cadence, floors, and 2026-09-22 ratchet in parity tests and testing guidance

## Validation
- [x] old flattened nominal floors fail only after all package tests pass
- [x] approved floors pass at Shared 61.12/52.17/59.17/62.65, Client 63.36/56.92/62.29/64.95, and Admin 51.54/47.07/44.87/53.24 for statements/branches/functions/lines
- [x] workflow performance parity passes 16/16
- [x] stacked validation-system suite passes 130/130
- [x] Shared, Client, and Admin plain Test commands pass
- [x] full stacked format, lint, test, build, docs build, and constituent contract verification checks pass
- [x] GitHub Agent, Supply Chain, Docs, Client, Shared, Admin, and aggregate CI Gate pass at `05ff122782ae1eed7e69b534492ad355aad72885`
- [x] changed paths are clean and match the pushed head
- [ ] live Coverage Nightly manual dispatch (post-merge observation because the workflow is not yet on the default branch)

Client and Admin retain the known non-fatal V8 `main.tsx` remap warning. The user explicitly approved merging before the first live Coverage Nightly dispatch so Wave 1 can begin; the first default-branch run remains required post-merge observation.

Refs PRD-831