### PR TITLE
fix(admin): send the garden redirect to the deployment's own client

### DIFF
--- a/packages/admin/src/__tests__/routing/public-garden-redirect.test.ts
+++ b/packages/admin/src/__tests__/routing/public-garden-redirect.test.ts
@@ -19,6 +19,41 @@ describe("public garden redirects", () => {
     ).toBe("https://greengoods.app/gardens/0xGarden%2FSeason%20One?utm_source=admin#impact");
   });
 
+  // The edge redirect in vercel.json used to hardcode https://greengoods.app,
+  // so admin on any non-production host sent people to the production client.
+  // This route owns the hop now, and falls back to the paired client host.
+  it("pairs each admin host with its own client host when no base URL is set", () => {
+    const pairs: Array<[string, string]> = [
+      ["admin.greengoods.app", "https://greengoods.app/gardens"],
+      ["beta-admin.greengoods.app", "https://beta.greengoods.app/gardens"],
+      ["staging-admin.greengoods.app", "https://staging.greengoods.app/gardens"],
+    ];
+    for (const [hostname, expected] of pairs) {
+      expect(buildClientGardenRedirectUrl(undefined, "", "", undefined, "", hostname)).toBe(
+        expected
+      );
+    }
+  });
+
+  it("falls back to production for hosts with no derivable pair", () => {
+    expect(buildClientGardenRedirectUrl(undefined, "", "", undefined, "", "localhost")).toBe(
+      "https://greengoods.app/gardens"
+    );
+  });
+
+  it("prefers an explicit base URL over the host pairing", () => {
+    expect(
+      buildClientGardenRedirectUrl(
+        undefined,
+        "",
+        "",
+        "https://beta.greengoods.app",
+        "",
+        "admin.greengoods.app"
+      )
+    ).toBe("https://beta.greengoods.app/gardens");
+  });
+
   it("builds nested public garden redirects", () => {
     expect(
       buildClientGardenRedirectUrl(

--- a/packages/admin/src/routes/PublicGardenRedirect.tsx
+++ b/packages/admin/src/routes/PublicGardenRedirect.tsx
@@ -3,8 +3,25 @@ import { useLocation, useParams } from "react-router-dom";
 
 const DEFAULT_CLIENT_APP_URL = "https://greengoods.app";
 
-function normalizeClientBaseUrl(baseUrl?: string): string {
-  return (baseUrl || DEFAULT_CLIENT_APP_URL).replace(/\/+$/, "");
+/**
+ * The client origin that pairs with an admin host, so a deployment sends people
+ * to its own client rather than to production.
+ *
+ * `admin.greengoods.app` pairs with the apex, and every prefixed admin host
+ * pairs with the matching client host — `beta-admin` with `beta`,
+ * `staging-admin` with `staging`. Anything else (localhost, a preview URL) has
+ * no derivable pair and returns undefined so the caller falls through.
+ */
+function clientOriginForAdminHost(hostname?: string): string | undefined {
+  if (!hostname?.endsWith(".greengoods.app")) return undefined;
+  if (hostname === "admin.greengoods.app") return DEFAULT_CLIENT_APP_URL;
+  const prefixed = /^(.+)-admin\.greengoods\.app$/.exec(hostname);
+  return prefixed ? `https://${prefixed[1]}.greengoods.app` : undefined;
+}
+
+function normalizeClientBaseUrl(baseUrl?: string, adminHostname?: string): string {
+  const resolved = baseUrl || clientOriginForAdminHost(adminHostname) || DEFAULT_CLIENT_APP_URL;
+  return resolved.replace(/\/+$/, "");
 }
 
 function encodePathSuffix(pathSuffix?: string): string {
@@ -21,9 +38,10 @@ export function buildClientGardenRedirectUrl(
   locationSearch = "",
   locationHash = "",
   clientBaseUrl = import.meta.env.VITE_CLIENT_APP_URL,
-  pathSuffix = ""
+  pathSuffix = "",
+  adminHostname = typeof window === "undefined" ? undefined : window.location.hostname
 ): string {
-  const baseUrl = normalizeClientBaseUrl(clientBaseUrl);
+  const baseUrl = normalizeClientBaseUrl(clientBaseUrl, adminHostname);
   const nestedPath = encodePathSuffix(pathSuffix);
   const gardenPath = gardenId
     ? `/gardens/${encodeURIComponent(gardenId)}${nestedPath ? `/${nestedPath}` : ""}`

--- a/packages/admin/vercel.json
+++ b/packages/admin/vercel.json
@@ -9,23 +9,6 @@
       "status": 404
     }
   ],
-  "redirects": [
-    {
-      "source": "/gardens",
-      "destination": "https://greengoods.app/gardens",
-      "permanent": true
-    },
-    {
-      "source": "/gardens/:gardenId",
-      "destination": "https://greengoods.app/gardens/:gardenId",
-      "permanent": true
-    },
-    {
-      "source": "/gardens/:gardenId/:path*",
-      "destination": "https://greengoods.app/gardens/:gardenId/:path*",
-      "permanent": true
-    }
-  ],
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Admin redirected `/gardens*` to `https://greengoods.app` at the edge, so admin on any host other than production handed people to the **production** client. Staging admin does this today; a beta admin would do it from day one.

## What changed

The three redirects in `packages/admin/vercel.json` duplicated routes the SPA already owns — `router.tsx` maps `gardens`, `gardens/:gardenId` and `gardens/:gardenId/*` to `PublicGardenRedirect`, which resolves its target from `VITE_CLIENT_APP_URL`. Removed them; the catch-all rewrite already sends those paths to `index.html`, so one place decides now instead of two.

The fallback was the other half. With `VITE_CLIENT_APP_URL` unset it returned production, so deleting the edge rule alone would have relocated the bug rather than fixed it. It now derives the paired client host from the admin host:

| admin host | client host |
|---|---|
| `admin.greengoods.app` | `greengoods.app` |
| `beta-admin.greengoods.app` | `beta.greengoods.app` |
| `staging-admin.greengoods.app` | `staging.greengoods.app` |
| anything else | `greengoods.app` (default) |

An explicit `VITE_CLIENT_APP_URL` still wins over the pairing.

## Pairing is deliberately narrow

It requires a `.greengoods.app` suffix **and** an exact `-admin` prefix, so a lookalike host cannot be read as a sibling. `evil-greengoods.app` and `admin.greengoods.app.evil.com` both fall through to the default. Both were checked alongside the six ordinary cases by executing the resolver directly:

```
ok  host=admin.greengoods.app           -> https://greengoods.app
ok  host=beta-admin.greengoods.app      -> https://beta.greengoods.app
ok  host=staging-admin.greengoods.app   -> https://staging.greengoods.app
ok  host=localhost                      -> https://greengoods.app
ok  host=greengoods.app                 -> https://greengoods.app
ok  host=evil-greengoods.app            -> https://greengoods.app
ok  host=admin.greengoods.app.evil.com  -> https://greengoods.app
ok  host=admin.greengoods.app  base=https://beta.greengoods.app/  -> https://beta.greengoods.app
```

Three test cases cover the pairing, the fallback, and explicit-base precedence.

## Trade-off

One SPA load before the hop, where the edge rule was immediate. Acceptable on an operator surface, and it buys per-environment correctness. If the latency ever matters, the edge rule can come back as a host-matched rule rather than a hardcoded destination.

## Context

Found while auditing what a public-facing `beta.greengoods.app` would need. This is the one item that is a live bug today rather than beta-only setup; the rest is captured on the Linear issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
