### PR TITLE
style(claude): format the archived plan hub status file

### DIFF
--- a/.plans/archive/client-structure-and-agent-guides/status.json
+++ b/.plans/archive/client-structure-and-agent-guides/status.json
@@ -33,27 +33,9 @@
   },
   "taxonomy": {
     "initiative": "engineering-quality",
-    "tracks": [
-      "client",
-      "admin",
-      "shared",
-      "docs",
-      "ops"
-    ],
-    "work_types": [
-      "implementation",
-      "cleanup",
-      "hardening",
-      "maintenance",
-      "qa"
-    ],
-    "surfaces": [
-      "client",
-      "admin",
-      "shared",
-      "docs",
-      "tooling"
-    ],
+    "tracks": ["client", "admin", "shared", "docs", "ops"],
+    "work_types": ["implementation", "cleanup", "hardening", "maintenance", "qa"],
+    "surfaces": ["client", "admin", "shared", "docs", "tooling"],
     "depends_on_features": []
   },
   "lanes": {


### PR DESCRIPTION
One file, formatting only.

`develop` is red on `format:check` — the archived hub's `status.json` landed unformatted in `134eb984c`, and the gate runs over `.plans` too, so every branch cut from develop inherits it.

The recurring plan-hub shape: mutating hub commands write with `JSON.stringify`, which expands short arrays one element per line; Biome collapses them back. Nothing semantic moved — parsing both revisions and comparing the objects gives an exact match.

`bunx @biomejs/biome format .` now reports no fixes across all 2744 files.

Splitting this out rather than folding it into the beta PR it was blocking, since it is unrelated to that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)