### PR TITLE
docs(plans): scope Cosmo-Local Credit voucher interoperability

### DIFF
--- a/.plans/backlog/cosmo-local-credit-interop/brief.md
+++ b/.plans/backlog/cosmo-local-credit-interop/brief.md
@@ -42,7 +42,11 @@ fit.
 - A gardener's confirmed contribution mints a Gnosis-native voucher they can transfer to someone
   else, who can use it.
 - A garden gets an effective credit line — how much of its voucher a pool will absorb — set by its
-  delivery record rather than by collateral it does not have.
+  delivery record rather than by collateral it does not have. **The evidence link is the promise, so
+  it needs a gate**: the limit request must cite named delivery figures (kept rate, distinct
+  providers, confirmed volume over a stated window) drawn from the pool passport, and that citation
+  must be recorded. Without it an arbitrary manually chosen cap satisfies every check while the
+  core outcome goes undemonstrated. See `eval.md` AC-13.
 - Value moves between gardens without converting to cash.
 - A funder inspects a garden's pool from outside Green Goods, with their own tools, against a
   machine-readable profile.

--- a/.plans/backlog/cosmo-local-credit-interop/brief.md
+++ b/.plans/backlog/cosmo-local-credit-interop/brief.md
@@ -5,6 +5,9 @@
 **Priority**: `p2`
 **Created**: `2026-08-25`
 **Posture**: scoping and architecture only. **No implementation is authorized by this hub.**
+**Linear**: [RESR-73](https://linear.app/greenpill-dev-guild/issue/RESR-73) design record ·
+[RESR-74](https://linear.app/greenpill-dev-guild/issue/RESR-74) Slice 0 due diligence ·
+[GROW-43](https://linear.app/greenpill-dev-guild/issue/GROW-43) hackathon entry
 **Related hubs**: [`commitment-pooling`](../../active/commitment-pooling/),
 [`commitment-credit-follow-on`](../../active/commitment-credit-follow-on/),
 [`community-interface`](../../active/community-interface/),

--- a/.plans/backlog/cosmo-local-credit-interop/brief.md
+++ b/.plans/backlog/cosmo-local-credit-interop/brief.md
@@ -1,0 +1,82 @@
+# Cosmo-Local Credit Voucher Interoperability
+
+**Slug**: `cosmo-local-credit-interop`
+**Stage**: `backlog`
+**Priority**: `p2`
+**Created**: `2026-08-25`
+**Posture**: scoping and architecture only. **No implementation is authorized by this hub.**
+**Related hubs**: [`commitment-pooling`](../../active/commitment-pooling/),
+[`commitment-credit-follow-on`](../../active/commitment-credit-follow-on/),
+[`community-interface`](../../active/community-interface/),
+[`celo-garden-account-safe-ownership`](../../active/celo-garden-account-safe-ownership/)
+
+## Problem
+
+Green Goods records contribution and never lets it move. A gardener's confirmed work — teaching a
+session, cooking for the hub, running a workshop — becomes an attested record that is visible only
+inside Green Goods and usable by no one, including the person who did it.
+
+Two consequences follow.
+
+**Inside a hub**, contribution that already happens informally stays incoherent. It may be
+*recognized* — someone says thanks — but it is not *valued*, and it is not valued **against other
+things**, so it cannot be reciprocated fairly, aggregated, or compared. Unpaid care and teaching
+labor is the part that disappears most reliably.
+
+**Outside a hub**, funders cannot see any of it without a Green Goods login. There is no
+machine-readable surface a bank, council, or foundation can inspect with its own tools, so a
+place-based organisation with a strong delivery record still reads as unbanked and uncollateralised.
+
+Grassroots Economics' Cosmo-Local Credit network solves the second half — a deployed clearing
+network for redeemable commitments on Gnosis — and has no source of truth for whether a commitment
+was actually kept. Green Goods is that source of truth and has no exchange layer. The two halves
+fit.
+
+## Desired Outcome
+
+**Should become possible**
+
+- A gardener's confirmed contribution mints a Gnosis-native voucher they can transfer to someone
+  else, who can use it.
+- A garden gets an effective credit line — how much of its voucher a pool will absorb — set by its
+  delivery record rather than by collateral it does not have.
+- Value moves between gardens without converting to cash.
+- A funder inspects a garden's pool from outside Green Goods, with their own tools, against a
+  machine-readable profile.
+
+**Should become easier or safer**
+
+- Green Goods inherits a reviewed, deployed exchange layer (pool, router, quoters, limiter) instead
+  of building and auditing an AMM.
+- Contribution weighting becomes an explicit, frozen, published governance act instead of an
+  implicit hierarchy.
+
+**Should not change**
+
+- `CommitmentRegistry` stays non-transferable and authoritative for promises. Vouchers are
+  settlement instruments, never ownership of a promise.
+- No custody in `CommitmentPoolingModule` or `CommitmentRegistry`.
+- No per-person score, ordered participant comparison, or protocol-consumed individual standing.
+- No bridged value. Vouchers are Gnosis-native; only authorization crosses.
+- Clean-room boundary: no AGPL source is read, imported, or vendored.
+
+## Scope Notes
+
+**In scope for this hub**: architecture, the CPP crosswalk, the tension analysis, the slice
+sequence, evidence gates, and the resource record.
+
+**Out of scope for this hub**: every line of implementation, any deployment, any mainnet
+transaction, any partnership commitment, any custody or authority change, and any Linear execution
+issue. Those require their own scope lock and explicit human dispatch.
+
+## Success Signal
+
+One Green Goods garden's confirmed contributions mint a Gnosis-native voucher that is listed,
+priced, and exchangeable in a Cosmo-Local Credit pool, and the pool is discoverable from outside
+Green Goods through a machine-readable profile whose fulfilment figures trace back to counterparty
+confirmations on Arbitrum.
+
+The falsifiable version, which the pilot must actually answer: **do vouchers move through a third
+party, or does everything settle bilaterally?** If it is all bilateral, the finding is that the
+token was not needed — and per `commitment-pooling/pilot-evidence-spec.md` §8 that is a valid
+result, not a failure.

--- a/.plans/backlog/cosmo-local-credit-interop/eval.md
+++ b/.plans/backlog/cosmo-local-credit-interop/eval.md
@@ -1,0 +1,91 @@
+# Cosmo-Local Credit Voucher Interoperability — Evaluation Plan
+
+**Posture**: no implementation authorized. These gates describe what each slice must prove *if and
+when* it is dispatched.
+
+## Slice Gates
+
+Each slice has an exit condition that must be met before the next may be scoped. They are not
+schedule milestones.
+
+| Slice | Gate |
+|---|---|
+| 0 — Due diligence | Live CLC configuration read and recorded; `burn`-after-expiry settled on a fork; §10 questions answered; pool ownership established; documented go / no-go on network membership |
+| 1 — Interfaces + read bridgehead | Green Goods renders live CLC pool state. Zero writes, zero custody. No AGPL source in the tree |
+| 2 — `ValuationPolicy` + voice | A garden declares, publishes and freezes a weighted valuation; gardeners see it before committing and register alignment or dissent; layer-1 hour records provably unchanged by any layer-2 revision |
+| 3 — Pool passport | An external party inspects a Green Goods pool with their own tools; every fulfilment figure traces to counterparty confirmations on Arbitrum; no address enumeration on public surfaces |
+| 4 — Mint authorization | A confirmed Arbitrum contribution produces a weighted Gnosis-native voucher at the contributor's same-address account; the same facts cannot authorize a second mint |
+| 5 — Listing + exchange | A voucher moves through a third party and is redeemed, with the full path traceable and every failure mode (de-list, rate change, limit change, insolvency) handled explicitly |
+
+## Release Gates
+
+1. **Correctness** — weight arithmetic is deterministic and bounded; no double consumption of
+   fulfilment facts; a layer-2 revision never mutates a layer-1 record.
+2. **Usability** — a gardener understands what their contribution is worth and why before they
+   commit; a steward understands what they are freezing.
+3. **Regression safety** — `CommitmentRegistry` remains non-transferable with no transfer or
+   approval surface; no custody enters `CommitmentPoolingModule`; existing pooling behavior unchanged.
+4. **Evidence quality** — research evidence and open assumptions recorded before implementation;
+   every external fact re-verified against its primary source at implementation time.
+5. **Human judgment** — protected surfaces and maintainer-call decisions named before merge; the
+   open decisions in `plan.todo.md` resolved by Afo, not inferred.
+6. **Licensing** — no AGPL source read, imported, or vendored; interfaces traceable to
+   `docs/SPEC.md`.
+
+## Acceptance Checks
+
+| ID | Behavior Boundary | Check | Owner | Evidence |
+|---|---|---|---|---|
+| AC-1 | Valuation authoring | Steward sets weights; cycle opens; weights are immutable for the cycle's life | `ui` | |
+| AC-2 | See-before-commit | The frozen table is visible on the commit path before a gardener commits | `ui` | |
+| AC-3 | Two-sided signal | Align and dissent both record against the cycle policy; aggregate readable; non-binding | `ui` | |
+| AC-4 | Layer separation | A revised equivalence table produces a new version; prior hour records byte-identical | `state_api` | |
+| AC-5 | CLC read client | Listing, limit, rate, fee and inventory read correctly from live Gnosis state | `state_api` | |
+| AC-6 | MCC profile | Profile validates against the MCC field set; freshness bounds present; no address enumeration | `state_api` | |
+| AC-7 | Mint authorization | Confirmed contribution → bounded weighted mint; replay of the same facts rejected | `contracts` | |
+| AC-8 | Cross-chain identity | Gardener's Gnosis account derives to the exact Arbitrum address on a pinned fork | `contracts` | |
+| AC-9 | Non-transferability preserved | `CommitmentRegistry` exposes no transfer or approval function after all changes | `contracts` | |
+| AC-10 | Bounded swap only | Every exchange path uses the `minAmountOut` + `deadline` form | `contracts` | |
+| AC-11 | Failure modes | De-listing with a held balance, rate change mid-flight, limit exhaustion and pool insolvency each produce a defined, surfaced outcome | `qa_pass_1` | |
+| AC-12 | Regression review | Existing pooling, settlement and credit behavior unchanged | `qa_pass_2` | |
+
+## Test Strategy
+
+- **Unit**: weight arithmetic and rounding bounds; double-spend prevention; `ValuationPolicy` freeze
+  semantics; interface encode/decode against documented shapes.
+- **Integration**: cycle open → weighted authorization → CCIP command → Gnosis mint on forked
+  Arbitrum + Chiado; MCC profile assembly from indexer output.
+- **Fork**: exact-address GardenAccount derivation on Gnosis; `GiftableToken` expiry and burn;
+  bounded-swap slippage and deadline; de-listing with a held balance.
+- **E2E**: steward authors and freezes → gardener sees → commits → confirmed → voucher appears →
+  transfers to a third party → third party redeems.
+- **Manual**: locale tone en/es/pt; the contribution ledger reading as a ledger, not a wallet.
+- **TDD proof**: RED/GREEN commands and evidence recorded in lane handoffs and summarized in
+  `status.json` when lanes are dispatched.
+
+## QA Sequence
+
+### Claude QA Pass 1
+
+Focus on failure modes, UX comprehension of the valuation table, missing requirements, and test
+gaps. The motivation-crowding and measurement-capture risks in `spec.md` §10 are QA concerns, not
+only design concerns — check whether the surfaces read as recognition or as transaction.
+
+### Codex QA Pass 2
+
+Starts only after `qa_pass_1` passes. Re-run targeted validation; close remaining defects; verify
+no AGPL source entered the tree and that every interface is traceable to `docs/SPEC.md`.
+
+## Pilot Evidence Alignment
+
+This work feeds, and does not bypass, `commitment-pooling/pilot-evidence-spec.md`:
+
+- §3 reciprocity — what reciprocal relation remains after fulfilment
+- §5 exchange demand — repeated bilateral or multilateral demand, not one-off feature interest
+- §6 safeguards — who is disadvantaged by transferability and how repair works without scoring people
+- §8 circulation — in-pool use, redemption, reseed, leak and hoarding; **low volume or mixed findings
+  are valid evidence**
+- §9 privacy — publication rules for event-derived pair and holding data
+- §11 the September evidence packet
+
+A pilot that shows all exchange settling bilaterally is a successful evaluation, not a failed one.

--- a/.plans/backlog/cosmo-local-credit-interop/eval.md
+++ b/.plans/backlog/cosmo-local-credit-interop/eval.md
@@ -14,8 +14,9 @@ schedule milestones.
 | 1 — Interfaces + read bridgehead | Green Goods renders live CLC pool state. Zero writes, zero custody. No AGPL source in the tree |
 | 2 — `ValuationPolicy` + voice | A garden declares, publishes and freezes a weighted valuation; gardeners see it before committing and register alignment or dissent; layer-1 hour records provably unchanged by any layer-2 revision |
 | 3 — Pool passport | An external party inspects a Green Goods pool with their own tools; every fulfilment figure traces to counterparty confirmations on Arbitrum; no address enumeration on public surfaces |
-| 4 — Mint authorization | A confirmed Arbitrum contribution produces a weighted Gnosis-native voucher at the contributor's same-address account; the same facts cannot authorize a second mint |
-| 5 — Listing + exchange | A voucher moves through a third party and is redeemed, with the full path traceable and every failure mode (de-list, rate change, limit change, insolvency) handled explicitly |
+| 4 — Mint authorization | A confirmed Arbitrum contribution produces a weighted Gnosis-native voucher in the contributor's own Gnosis Kernel account; the same facts cannot authorize a second mint |
+| 5a — Exchange mechanics | A voucher moves through a third party and is redeemed, with the full path traceable, against our own Chiado deployment of the published CPP implementations or interface-conformant mocks |
+| 5b — CLC venue behaviour | Against the live mainnet venue: de-listing with a held balance, rate change mid-flight, limit exhaustion and pool insolvency each produce a defined, surfaced outcome. **Mainnet-only and gate-bound — not provable on a venue we control** |
 
 ## Release Gates
 
@@ -42,12 +43,15 @@ schedule milestones.
 | AC-4 | Layer separation | A revised equivalence table produces a new version; prior hour records byte-identical | `state_api` | |
 | AC-5 | CLC read client | Listing, limit, rate, fee and inventory read correctly from live Gnosis state | `state_api` | |
 | AC-6 | MCC profile | Profile validates against the MCC field set; freshness bounds present; no address enumeration | `state_api` | |
-| AC-7 | Mint authorization | Confirmed contribution → bounded weighted mint; replay of the same facts rejected | `contracts` | |
-| AC-8 | Cross-chain identity | Gardener's Gnosis account derives to the exact Arbitrum address on a pinned fork | `contracts` | |
+| AC-7 | Mint authorization | Confirmed contribution → bounded weighted mint; a repeated `messageId` **and** a distinct message reusing a consumed `authorizationId` are both rejected | `contracts` | |
+| AC-8 | Cross-chain **garden** identity | On a pinned fork, the Gnosis garden account matches the Arbitrum address **and** its bound `(chainId, tokenContract, tokenId)` tuple, deployed runtime code hash, and owner/Safe topology all match the expected values. Covers garden accounts only — gardener accounts are AC-15 | `contracts` | |
 | AC-9 | Non-transferability preserved | `CommitmentRegistry` exposes no transfer or approval function after all changes | `contracts` | |
 | AC-10 | Bounded swap only | Every exchange path uses the `minAmountOut` + `deadline` form | `contracts` | |
-| AC-11 | Failure modes | De-listing with a held balance, rate change mid-flight, limit exhaustion and pool insolvency each produce a defined, surfaced outcome | `qa_pass_1` | |
+| AC-11 | Failure modes | De-listing with a held balance, rate change mid-flight, limit exhaustion and pool insolvency each produce a defined, surfaced outcome. Adapter-side handling is provable on a controlled venue; the venue's own behaviour is Slice 5b, mainnet-only | `qa_pass_1` | |
 | AC-12 | Regression review | Existing pooling, settlement and credit behavior unchanged | `qa_pass_2` | |
+| AC-13 | Credit line traces to evidence | The limit request cites named delivery figures from the pool passport over a stated window, and the citation is recorded. A cap with no evidence input fails this check even if the limit reads back correctly | `state_api` | |
+| AC-14 | Per-contributor quantity | Every mint amount traces to a recorded per-contributor quantity. No allocation is inferred by splitting `targetUnits` across contributors | `contracts` | |
+| AC-15 | Gardener recipient path | Vouchers for individuals land in the contributor's own Kernel account, never a garden account. Proven on a fork with a multi-contributor commitment | `contracts` | |
 
 ## Test Strategy
 
@@ -55,7 +59,8 @@ schedule milestones.
   semantics; interface encode/decode against documented shapes.
 - **Integration**: cycle open → weighted authorization → CCIP command → Gnosis mint on forked
   Arbitrum + Chiado; MCC profile assembly from indexer output.
-- **Fork**: exact-address GardenAccount derivation on Gnosis; `GiftableToken` expiry and burn;
+- **Fork**: exact-address GardenAccount derivation on Gnosis; gardener Kernel-account derivation,
+  proven separately; `GiftableToken` expiry and burn;
   bounded-swap slippage and deadline; de-listing with a held balance.
 - **E2E**: steward authors and freezes → gardener sees → commits → confirmed → voucher appears →
   transfers to a third party → third party redeems.

--- a/.plans/backlog/cosmo-local-credit-interop/handoffs/README.md
+++ b/.plans/backlog/cosmo-local-credit-interop/handoffs/README.md
@@ -1,0 +1,7 @@
+# Handoffs
+
+Empty by design. No lane is dispatched and no implementation is authorized.
+
+A handoff is written when a slice from [`../plan.todo.md`](../plan.todo.md) is scope-locked and
+explicitly dispatched by Afo. Slice 0 (due diligence and the Grassroots Economics conversation)
+blocks every later slice.

--- a/.plans/backlog/cosmo-local-credit-interop/plan.todo.md
+++ b/.plans/backlog/cosmo-local-credit-interop/plan.todo.md
@@ -1,6 +1,9 @@
 # Cosmo-Local Credit Voucher Interoperability Plan
 
 **Feature Slug**: `cosmo-local-credit-interop`
+**Linear Issue**: [RESR-73](https://linear.app/greenpill-dev-guild/issue/RESR-73) (parent-only mirror)
+**Linear Project**: Commitment Pooling
+**Linear Source**: source:plans
 **Status**: BLOCKED — scoping and architecture only. **No implementation is authorized.**
 **Created**: 2026-08-25
 **Last Updated**: 2026-08-25

--- a/.plans/backlog/cosmo-local-credit-interop/plan.todo.md
+++ b/.plans/backlog/cosmo-local-credit-interop/plan.todo.md
@@ -29,10 +29,10 @@
 | 9 | The voucher's unit is a **weighted contribution unit, not an hour** | Follows from #8. Hours stay unconverted in layer 1 forever |
 | 10 | Three valuation layers: record (native units) / commensuration (declared) / exchange — and a layer-2 change **never** rewrites layer 1 | The difference between a group revising its values and a group retroactively revaluing people's past contributions |
 | 11 | Basis is **time**, for v1 | Education is unusually time-legible. Prove the basis where it works before stressing it |
-| 12 | `ValuationPolicy` is a cycle snapshot frozen at `CycleOpened`, keyed to action UIDs or domains, never identities | Follows the proven `AllocationBps` / `RecognitionPolicy` pattern exactly. Freeze-at-open is the consent mechanism |
+| 12 | `ValuationPolicy` is a cycle snapshot frozen at `CycleOpened`, keyed to action UIDs or domains, never identities, and carrying `version` + `authority` + `rationaleCID` as mandatory fields | Follows the `AllocationBps` / `RecognitionPolicy` freeze-at-open pattern, which is the consent mechanism. The three identity fields are additional to that pattern and required by §2.2–§2.3: without them nothing can prove the table a mint was weighted by is the table the steward froze |
 | 13 | Stewards hold the pen; gardeners get **see-before-commit** plus a **two-sided align/dissent signal** | Afo's call. Consultation and ratification deferred — but see #14 |
-| 14 | The two-sided signal reuses the `NeedSignal` primitive | Same shape, different object. One mechanism, not two |
-| 15 | Add `PoolType.GardenToGarden` and `PoolType.Community`, inert, now | Precedent: `DisbursementKind.LoanPrincipal` shipped as an unqueueable enum member. Avoids a later upgrade |
+| 14 | The two-sided signal follows the `NeedSignal` **pattern** as a sibling schema and resolver branch — it does not reuse that schema UID | Corrected 2026-08-25. The NeedSignal resolver branch fails closed: `refUID` must resolve to an attestation with the exact Need schema and the same recipient, so a valuation-policy UID is rejected and nothing is recorded. One pattern and one UI, two schemas. See `spec.md` §2.3 |
+| 15 | `PoolType` gains `GardenToGarden` and `Community` — but **only together with guards and consumer updates**, never appended bare | Corrected 2026-08-25. The `LoanPrincipal` precedent relies on a fail-closed consumer, which `PoolType` does not have: `PoolsLib.sol:43` sends every non-`Protocol` value down the `Garden` path, so a bare append silently grants garden-steward semantics. `ConsiderationRail` *is* fail-closed (`CreationChecksLib.sol:286` reverts on an unhandled rail) and may be appended ahead of use. See `spec.md` §3 |
 | 16 | Spin up a pool when **membership differs from the garden**; otherwise use a cycle | A cohort including non-members is a pool; the same people doing focused work is a cycle. Keeps the common case simple |
 | 17 | **Never build a global cross-pool rate table** | Each pool decides what it accepts and at what rate *to itself*. A shared index would break the no-universal-price guardrail and foreclose federation simultaneously |
 | 18 | Federation starts hub-and-spoke through the Protocol pool, not mesh | N rates instead of N². The Protocol pool already exists and is already cross-garden |
@@ -45,6 +45,7 @@
 
 | Question | Blocks |
 |---|---|
+| **Where does a per-contributor quantity come from?** Work-record field, per-contributor units on the commitment, or single-contributor-only for v1 | **Everything.** `spec.md` §2.0 — layer 1 does not exist on chain today, so weighted minting cannot be specified until this is chosen. Only the third option fits the hackathon window |
 | Does learning count, and at what weight relative to facilitating? | The whole education weights table. Values decision, not technical |
 | Do concurrent campaigns need a bound? | Slice 2. The exit check ("a campaign nobody joins is inert") may suffice at hub scale |
 | Does `GiftableToken.burn` survive expiry? | Slice 0 fork verification. Determines whether a redemption path survives an expired class |
@@ -93,8 +94,12 @@ bilateral, the finding is that the token was not needed, and that is a valid res
 - `networks.json` Gnosis (100) entry: RPC, explorer, CCIP router and selector `465200170687744372`.
 - Read-only CLC client in `shared`: resolve registry, read listing state, limit, quoted rate, fee
   configuration and pool inventory for a given token.
-- `PoolType.GardenToGarden` and `PoolType.Community` appended inert; `ConsiderationRail` Gnosis
-  member appended inert.
+- `ConsiderationRail` Gnosis member appended ahead of use — safe, because the rail dispatch is
+  fail-closed.
+- **`PoolType` stays two-valued in this slice.** Adding `GardenToGarden` or `Community` requires a
+  per-value contract guard replacing the `else` fallthrough, plus indexer, GraphQL-schema,
+  shared-type and client mappings and round-trip coverage, all in one change. That belongs to
+  Slice 6+, not here. See decision 15.
 
 **Exit**: Green Goods can read the live CLC pool's state and render it. Nothing is written anywhere.
 
@@ -102,18 +107,28 @@ bilateral, the finding is that the token was not needed, and that is a valid res
 
 **Arbitrum + app layer. Green Goods-native — no CLC dependency. Valuable standalone.**
 
-Two implementation shapes, and the cheap one is genuinely viable for a pilot:
+**Blocking prerequisite**: `spec.md` §2.0. There is no per-contributor quantity anywhere on chain,
+so layer 1 as the architecture describes it does not yet exist. Slice 2 must pick one of the three
+resolutions there before Slice 4 is dispatchable.
+
+`spec.md` §2.1 defines the **contract** — the five mandatory fields and freeze-at-open semantics.
+2a and 2b are two **carriers** of that same contract, not competing architectures; decision 12
+governs the contract, the slice governs the carrier. Phase B selects 2a. Whichever carrier ships,
+the fields and their immutability are identical.
 
 - **2a — `metadataCID`-carried.** The weights table is published in the cycle's existing
   `metadataCID`, frozen at open by convention and enforced by the indexer. No contract change, no
-  upgrade, no gate. Preserves the semantics that matter: published, versioned, frozen at open,
-  authority named.
+  upgrade, no gate. Requires a **mandatory, versioned schema** carrying `version`, `authority`,
+  `rationaleCID`, `basis` and `weights` — see `spec.md` §2.1. A table missing any of those cannot be
+  proven to be the one the steward froze, and the indexer must reject it rather than project a
+  partial policy.
 - **2b — on-chain struct.** `ValuationPolicy` as a third `Cycle` snapshot emitted in `CycleOpened`,
-  alongside `AllocationBps` and `RecognitionPolicy`. A UUPS upgrade to a deployed, unpaused module,
-  with every gate that implies.
+  alongside `AllocationBps` and `RecognitionPolicy`, carrying the same five fields. A UUPS upgrade
+  to a deployed, unpaused module, with every gate that implies.
 
 Plus, in either shape: steward authoring UI in admin; see-before-commit surface in client; the
-two-sided align/dissent signal reusing `NeedSignal`; indexer entities; i18n with en/es/pt mirrors.
+two-sided align/dissent signal as a `NeedSignal`-pattern sibling schema and resolver branch
+(decision 14); indexer entities; i18n with en/es/pt mirrors.
 
 **Exit**: a garden can declare, publish and freeze a weighted valuation for a cycle, gardeners can
 see it before committing and register alignment or dissent, and the signal aggregate is readable.
@@ -142,15 +157,33 @@ fulfilment figures trace to counterparty confirmations on Arbitrum.
 
 - Gnosis `GiftableToken` class per campaign, `expiresAt = 0`, Green Goods as owner, mint adapter as
   `writer`.
-- Mint adapter: reads eligible fulfilment facts, applies the frozen cycle weights, prevents double
-  consumption of the same facts.
+- Mint adapter: reads eligible fulfilment facts, applies the frozen cycle weights, and enforces the
+  replay invariant below.
+- **Replay invariant.** Each authorization carries a stable `authorizationId` derived from the facts
+  it consumes — pool, cycle, commitment set, policy version — not from the message that carried it.
+  The Gnosis receiver records the consumed `authorizationId` **and** the CCIP `messageId` atomically
+  with the mint, and rejects both a repeated `messageId` and a distinct message reusing a consumed
+  `authorizationId`. This is the `CeloGardenAccountRelay` shape:
+  [`processedMessages[messageId]`](../../../packages/contracts/src/accounts/CeloGardenAccountRelay.sol)
+  plus `actionStatus[actionId]`, `nextActionNonce`, and a stored action digest, guarded by
+  `CcipMessageReplay`, `InvalidActionNonce` and `ActionHashMismatch`. Message-level dedup alone is
+  insufficient — CCIP can deliver the same authorization under a new `messageId` after a retry.
 - CCIP Arbitrum → Gnosis lane: executor deployment, published and verified lane, reviewed UUPS
   upgrade — following `SettlementMessageCodec` and `CeloGardenAccountRelay` patterns.
-- Gnosis GardenAccount deployment: sibling of `CeloGardenAccountDeploymentCoordinator`, same
-  exact-address CREATE2 technique; Pimlico Gnosis bundler and paymaster configuration.
+- **Two distinct account paths — do not conflate them.**
+  - *Garden* accounts: sibling of `CeloGardenAccountDeploymentCoordinator`, same exact-address
+    CREATE2 technique. That coordinator deploys exactly `GARDEN_COUNT = 18` ERC-6551 accounts keyed
+    by `GardenToken` token IDs. It produces **garden organisation accounts and nothing else.**
+  - *Gardener* accounts: individual contributors authenticate with per-person Pimlico Kernel
+    accounts ([`auth-passkey-adapters.ts`](../../../packages/shared/src/workflows/auth-passkey-adapters.ts)),
+    a completely different derivation. Vouchers minted to individuals land here, not in a garden
+    account, so the Kernel-account Gnosis derivation and deployment path must be specified and
+    proven on its own. Reusing the coordinator would reproduce garden accounts and silently mint to
+    the wrong recipients.
+- Pimlico Gnosis bundler and paymaster configuration and funding, for the gardener path.
 
 **Exit**: a confirmed contribution on Arbitrum produces a weighted, Gnosis-native voucher held by
-the contributor at their same-address account.
+the contributor in their own Gnosis Kernel account.
 
 ### Slice 5 — Listing, exchange, redemption
 
@@ -165,6 +198,25 @@ the contributor at their same-address account.
 - Outstanding-obligation figure published.
 
 **Exit**: a voucher moves through a third party and is redeemed, with the whole path traceable.
+
+**Venue availability constrains where this slice can run.** Cosmo-Local Credit publishes a Gnosis
+**mainnet** deployment only (`resources.md`); no Chiado addresses exist, and pool proxy instances
+require separate discovery even on mainnet. So Slice 5 splits:
+
+- **5a, testnet-provable** — the exchange *mechanics* against a Chiado venue we stand up ourselves.
+  A repo-wide search finds no CLC Chiado address, config, artifact, or deploy command, so this is
+  not a matter of looking one up. The path has to be built, and Slice 1 must produce it:
+  deploy the published implementations to Chiado with their `ge-publish` tool run **externally**
+  (never vendored — `docs/DEPLOY.md` gives the exact command sequence and requires
+  `--admin != --owner`), record the resulting addresses in `networks.json` and a deployment
+  artifact, and pin them here. Interface-conformant mocks are the fallback if that proves
+  impractical inside the window. Either way the venue is ours, not CLC's.
+- **5b, mainnet-only** — real CLC venue *behaviour*: their quoter's rates, their limiter's caps,
+  their fee policy, and de-listing with a held balance. None of it is observable on a venue we
+  control, so none of it can be proven in Phase C.
+
+Decision 4 commits to transacting against their live deployment. That deployment is mainnet, and
+mainnet is gated. 5b therefore lands in Phase D or later, never in the hackathon.
 
 ### Slice 6+ — Later, each separately gated
 
@@ -183,15 +235,16 @@ the contributor at their same-address account.
 |---|---|---|
 | **A — Understand and decide** | now → mid Sept | Slice 0 |
 | **B — Foundations** | Sept → 15 Oct | Slice 1, Slice 2a |
-| **C — Hackathon** | 16–27 Oct | Slice 4 + minimal Slice 5 on **Gnosis Chiado testnet** with fixture data; Slice 3 as the pitch surface |
+| **C — Hackathon** | 16–27 Oct | Slice 4 + Slice **5a** on **Gnosis Chiado**, against our own deployment of the published CPP implementations or interface-conformant mocks; Slice 3 as the pitch surface. Slice 5b is excluded — see Slice 5 |
 | **D — Pilot readiness** | Nov → Q1 | Legal (jurisdiction, transferable instrument, KYC tier), external audit, custody model, repair and insurance design, pilot-garden consent and governance, CLC partnership terms, mainnet gates |
 | **E — Later** | beyond | Slice 6+ |
 
 ### Explicitly **not** in the hackathon
 
 Mainnet anything. Real value. Custody. Slice 2b's contract upgrade. Credit and negative balances.
-Cross-garden routing. `GardenToGarden` or `Community` pools in use. Multi-steward authority.
-Community-app pool integration.
+Cross-garden routing. `GardenToGarden` or `Community` pool types — added at all, let alone in use.
+Multi-steward authority. Community-app pool integration. **Slice 5b — any claim about the live CLC
+venue's rates, limits, fees, or de-listing behaviour**, since that venue exists only on mainnet.
 
 The hackathon deliverable the organisers actually ask for is *"MVPs, platform concepts, and customer
 journeys"* — not a deployed protocol. An honest testnet loop plus the funder surface is a stronger
@@ -205,7 +258,8 @@ submission than a rushed mainnet claim, and it does not spend gates that cannot 
   encode/decode against `docs/SPEC.md` shapes; `ValuationPolicy` freeze semantics.
 - **Integration**: cycle open → weighted mint authorization → CCIP command → Gnosis mint, on forked
   Arbitrum and Chiado; MCC profile assembly from indexer output.
-- **Fork**: exact-address GardenAccount derivation on Gnosis; `GiftableToken` expiry and burn
+- **Fork**: exact-address GardenAccount derivation on Gnosis; gardener Kernel-account derivation and
+  deployment on Gnosis, proven separately; `GiftableToken` expiry and burn
   behavior; bounded-swap slippage and deadline paths; de-listing behavior with a held balance.
 - **E2E**: steward authors and freezes a valuation policy → gardener sees it → gardener commits →
   contribution confirmed → voucher appears → transfers to a third party → third party redeems.
@@ -227,7 +281,8 @@ submission than a rushed mainnet claim, and it does not spend gates that cannot 
 
 - `packages/contracts/src/interfaces/I{SwapPool,Limiter,Quoter,GiftableToken,TokenIndex}.sol`
 - Gnosis executor and mint-authorization adapter under `packages/contracts/src/modules/`
-- A Gnosis GardenAccount deployment coordinator, sibling of the Celo one
+- A Gnosis GardenAccount deployment coordinator, sibling of the Celo one, plus a separate gardener
+  Kernel-account derivation and deployment path
 - `shared` CLC read client and MCC profile assembler
 - Admin valuation-policy authoring views; client see-before-commit and signal surfaces
 - Public funder view

--- a/.plans/backlog/cosmo-local-credit-interop/plan.todo.md
+++ b/.plans/backlog/cosmo-local-credit-interop/plan.todo.md
@@ -1,0 +1,237 @@
+# Cosmo-Local Credit Voucher Interoperability Plan
+
+**Feature Slug**: `cosmo-local-credit-interop`
+**Status**: BLOCKED — scoping and architecture only. **No implementation is authorized.**
+**Created**: 2026-08-25
+**Last Updated**: 2026-08-25
+**Companion documents**: [`brief.md`](./brief.md) · [`spec.md`](./spec.md) ·
+[`tensions.md`](./tensions.md) · [`resources.md`](./resources.md) · [`eval.md`](./eval.md)
+
+> Every slice below requires its own scope lock and explicit human dispatch before any code is
+> written. Slice ordering is a dependency statement, not a schedule commitment. The PRD-651 gates
+> are unchanged by anything in this hub.
+
+## Decision Log
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Target Problem Statement 2 of the SustainableFinance.Live hackathon | The brief names Sarafu and commitment pools directly and asks for exactly the funder-legibility surface Green Goods lacks |
+| 2 | Green Goods enters solo | Afo's call. Solo entry does not mean solo architecture — the GE relationship remains live and the §10 questions still need answering |
+| 3 | All work lands in the Green Goods repo | Afo's call. In-repo does **not** grant deployment authority; mainnet and custody remain separately gated |
+| 4 | Transact against CLC's **live** Gnosis deployment rather than deploying our own instances | Interoperability is the goal; network membership is the point. Accepts the rake and the CLC-governance dependency knowingly (`tensions.md` §1) |
+| 5 | Constrain the marketplaces Green Goods creates; enable the market aspects CLC supports | Green Goods vocabulary and design rules cannot follow an ERC20. Constrain what we build, acknowledge what we don't control (`tensions.md` §2) |
+| 6 | Introduce transferability | It is the core of the change. Bilateral exchange needs no token; multilateral does, and third-party transfer is the entire justification |
+| 7 | Record on Arbitrum, instrument on Gnosis, **nothing bridges** | Same split-state command/ack shape as Celo G$. Arbitrum emits a mint authorization; Gnosis mints natively. "No bridged value ever" holds unamended |
+| 8 | Apply weights **at mint**, not at exchange | Keeps the governance in Green Goods where cycles, freezing and authority already live. CLC's `RelativeQuoter` is global, per-token and owner-mutable — it cannot hold cycle-scoped, activity-typed weights |
+| 9 | The voucher's unit is a **weighted contribution unit, not an hour** | Follows from #8. Hours stay unconverted in layer 1 forever |
+| 10 | Three valuation layers: record (native units) / commensuration (declared) / exchange — and a layer-2 change **never** rewrites layer 1 | The difference between a group revising its values and a group retroactively revaluing people's past contributions |
+| 11 | Basis is **time**, for v1 | Education is unusually time-legible. Prove the basis where it works before stressing it |
+| 12 | `ValuationPolicy` is a cycle snapshot frozen at `CycleOpened`, keyed to action UIDs or domains, never identities | Follows the proven `AllocationBps` / `RecognitionPolicy` pattern exactly. Freeze-at-open is the consent mechanism |
+| 13 | Stewards hold the pen; gardeners get **see-before-commit** plus a **two-sided align/dissent signal** | Afo's call. Consultation and ratification deferred — but see #14 |
+| 14 | The two-sided signal reuses the `NeedSignal` primitive | Same shape, different object. One mechanism, not two |
+| 15 | Add `PoolType.GardenToGarden` and `PoolType.Community`, inert, now | Precedent: `DisbursementKind.LoanPrincipal` shipped as an unqueueable enum member. Avoids a later upgrade |
+| 16 | Spin up a pool when **membership differs from the garden**; otherwise use a cycle | A cohort including non-members is a pool; the same people doing focused work is a cycle. Keeps the common case simple |
+| 17 | **Never build a global cross-pool rate table** | Each pool decides what it accepts and at what rate *to itself*. A shared index would break the no-universal-price guardrail and foreclose federation simultaneously |
+| 18 | Federation starts hub-and-spoke through the Protocol pool, not mesh | N rates instead of N². The Protocol pool already exists and is already cross-garden |
+| 19 | `expiresAt = 0` — do not use token expiry | The cliff confiscates from whoever redeems slowest, and erases the outstanding-obligation figure that is itself the funder signal (`tensions.md` §5) |
+| 20 | Backing mode is `FulfilledBacking`; `ReservedCapacity` stays disabled | The labor already happened. The job is to record and count it, not to finance future delivery |
+| 21 | Per-member limits stay Green Goods-side | CLC's `Limiter` caps `(token, holder-contract)` and rejects EOAs. Pool absorption is the *community* credit line — correct granularity; per-person is ours and stays anti-score |
+| 22 | Clean room: hand-write interfaces from `docs/SPEC.md`, never import `src/`, never vendor `ge-publish` | `src/` is AGPL-3.0. Interface implementation is not derivation; vendoring is. Matches the existing pattern for ~30 external protocols |
+
+**Open decisions** (do not resolve without Afo):
+
+| Question | Blocks |
+|---|---|
+| Does learning count, and at what weight relative to facilitating? | The whole education weights table. Values decision, not technical |
+| Do concurrent campaigns need a bound? | Slice 2. The exit check ("a campaign nobody joins is inert") may suffice at hub scale |
+| Does `GiftableToken.burn` survive expiry? | Slice 0 fork verification. Determines whether a redemption path survives an expired class |
+| What is the second confirmer on a redemption event? | Slice 5. Transferability breaks counterparty-first confirmation (`tensions.md` §4) |
+
+---
+
+## MVP definition
+
+**The smallest thing that proves the thesis:**
+
+> One garden's confirmed contributions, weighted by a published cycle policy, mint a Gnosis-native
+> voucher that is listed and exchangeable in a Cosmo-Local Credit pool — and a third party actually
+> receives one.
+
+Everything else is either a precondition (Slice 1), the funder surface (Slice 3), or later
+(Slice 6+). The falsifiable half is in `brief.md` § Success Signal: if all exchange turns out
+bilateral, the finding is that the token was not needed, and that is a valid result.
+
+---
+
+## Slices
+
+### Slice 0 — Due diligence and the GE conversation
+
+**No code. Blocking for every later slice.**
+
+- Read on-chain, Gnosis mainnet, for each of the six live CLC contracts: `owner` vs ERC1967 admin
+  slot; `ProtocolFeeController.isActive()` and `getProtocolFee()`; `FeePolicy.getDefaultFee()`;
+  `SwapPool.isSealed(0)`; whether a live pool *proxy instance* exists (the README lists
+  implementations) and how it is configured.
+- Fork-verify whether `GiftableToken.burn` functions after expiry.
+- Answer `exchange-architecture-brief.md` §10 questions 1–5 with Will Ruddick / Grassroots
+  Economics — and establish whether the 2026-08-19 conversation happened and what it produced.
+- Establish whether Green Goods would list into an existing pool or have one created, and who owns
+  the resulting `SwapPool`.
+
+**Exit**: a findings record plus a documented go / no-go on network membership under known terms.
+
+### Slice 1 — Interfaces and Gnosis read bridgehead
+
+**In-repo. No deploy, no writes, no custody.**
+
+- Hand-written `ISwapPool`, `ILimiter`, `IQuoter`, `IGiftableToken`, `ITokenIndex`,
+  `IAccountsIndex`, `IContractRegistry` from `docs/SPEC.md`.
+- `networks.json` Gnosis (100) entry: RPC, explorer, CCIP router and selector `465200170687744372`.
+- Read-only CLC client in `shared`: resolve registry, read listing state, limit, quoted rate, fee
+  configuration and pool inventory for a given token.
+- `PoolType.GardenToGarden` and `PoolType.Community` appended inert; `ConsiderationRail` Gnosis
+  member appended inert.
+
+**Exit**: Green Goods can read the live CLC pool's state and render it. Nothing is written anywhere.
+
+### Slice 2 — `ValuationPolicy` and gardener voice
+
+**Arbitrum + app layer. Green Goods-native — no CLC dependency. Valuable standalone.**
+
+Two implementation shapes, and the cheap one is genuinely viable for a pilot:
+
+- **2a — `metadataCID`-carried.** The weights table is published in the cycle's existing
+  `metadataCID`, frozen at open by convention and enforced by the indexer. No contract change, no
+  upgrade, no gate. Preserves the semantics that matter: published, versioned, frozen at open,
+  authority named.
+- **2b — on-chain struct.** `ValuationPolicy` as a third `Cycle` snapshot emitted in `CycleOpened`,
+  alongside `AllocationBps` and `RecognitionPolicy`. A UUPS upgrade to a deployed, unpaused module,
+  with every gate that implies.
+
+Plus, in either shape: steward authoring UI in admin; see-before-commit surface in client; the
+two-sided align/dissent signal reusing `NeedSignal`; indexer entities; i18n with en/es/pt mirrors.
+
+**Exit**: a garden can declare, publish and freeze a weighted valuation for a cycle, gardeners can
+see it before committing and register alignment or dissent, and the signal aggregate is readable.
+
+### Slice 3 — Pool passport (MCC profile) and funder view
+
+**Public, read-only.**
+
+- Machine-readable MCC-shaped profile per pool: registry roots, receipt standard, health endpoints
+  with freshness bounds, policy constraints, deterministic failure codes.
+- The `evidence` extension block CLC has no equivalent for: EAS schema UIDs, attestation counts,
+  confirmation path, Hats-gated roles.
+- Funder-facing view: circulation, distinct participants, needs met without cash, outstanding
+  obligation, **capability progression** (learner → peer teacher → facilitator, visible without
+  ranking anyone).
+
+**Dependency**: hosted Envio has no pooling schema. Until that ships and reindexes, this runs on
+local or fixture data.
+
+**Exit**: a bank, council or funder can inspect a Green Goods pool with their own tools, and the
+fulfilment figures trace to counterparty confirmations on Arbitrum.
+
+### Slice 4 — Voucher mint authorization
+
+**The interop core. Gated on Slices 0–2.**
+
+- Gnosis `GiftableToken` class per campaign, `expiresAt = 0`, Green Goods as owner, mint adapter as
+  `writer`.
+- Mint adapter: reads eligible fulfilment facts, applies the frozen cycle weights, prevents double
+  consumption of the same facts.
+- CCIP Arbitrum → Gnosis lane: executor deployment, published and verified lane, reviewed UUPS
+  upgrade — following `SettlementMessageCodec` and `CeloGardenAccountRelay` patterns.
+- Gnosis GardenAccount deployment: sibling of `CeloGardenAccountDeploymentCoordinator`, same
+  exact-address CREATE2 technique; Pimlico Gnosis bundler and paymaster configuration.
+
+**Exit**: a confirmed contribution on Arbitrum produces a weighted, Gnosis-native voucher held by
+the contributor at their same-address account.
+
+### Slice 5 — Listing, exchange, redemption
+
+**Gated on Slice 4 and on Slice 0's ownership answer.**
+
+- Listing and limit negotiated with CLC; rate set in `RelativeQuoter`.
+- Exchange in and out through `SwapPool`; bounded swap form only
+  (`withdraw(tokenOut, tokenIn, value, recipient, minAmountOut, deadline)` — the unbounded forms
+  have no protection against a price move between quote and settlement).
+- Redemption path, including the **second-confirmer design** for a bearer instrument.
+- Explicit failure handling for de-listing, rate change, limit change, pool insolvency.
+- Outstanding-obligation figure published.
+
+**Exit**: a voucher moves through a third party and is redeemed, with the whole path traceable.
+
+### Slice 6+ — Later, each separately gated
+
+- `GardenToGarden` and `Community` pool types activated; pool-scoped authority predicate for
+  multi-steward pools (and the consultation rung it pulls forward — `spec.md` §3.3).
+- Routing: intra-garden first via two pools, then hub-and-spoke through the Protocol pool.
+- Mutual credit proper — negative balances cleared by service, per-member caps, the exit-with-debt
+  problem.
+- Community pool via the community app, after needs-surfacing v1 proves needs actually get met.
+
+---
+
+## Phasing
+
+| Phase | Window | Contents |
+|---|---|---|
+| **A — Understand and decide** | now → mid Sept | Slice 0 |
+| **B — Foundations** | Sept → 15 Oct | Slice 1, Slice 2a |
+| **C — Hackathon** | 16–27 Oct | Slice 4 + minimal Slice 5 on **Gnosis Chiado testnet** with fixture data; Slice 3 as the pitch surface |
+| **D — Pilot readiness** | Nov → Q1 | Legal (jurisdiction, transferable instrument, KYC tier), external audit, custody model, repair and insurance design, pilot-garden consent and governance, CLC partnership terms, mainnet gates |
+| **E — Later** | beyond | Slice 6+ |
+
+### Explicitly **not** in the hackathon
+
+Mainnet anything. Real value. Custody. Slice 2b's contract upgrade. Credit and negative balances.
+Cross-garden routing. `GardenToGarden` or `Community` pools in use. Multi-steward authority.
+Community-app pool integration.
+
+The hackathon deliverable the organisers actually ask for is *"MVPs, platform concepts, and customer
+journeys"* — not a deployed protocol. An honest testnet loop plus the funder surface is a stronger
+submission than a rushed mainnet claim, and it does not spend gates that cannot be un-spent.
+
+---
+
+## Test Strategy
+
+- **Unit**: weight arithmetic and rounding; mint-authorization double-spend prevention; interface
+  encode/decode against `docs/SPEC.md` shapes; `ValuationPolicy` freeze semantics.
+- **Integration**: cycle open → weighted mint authorization → CCIP command → Gnosis mint, on forked
+  Arbitrum and Chiado; MCC profile assembly from indexer output.
+- **Fork**: exact-address GardenAccount derivation on Gnosis; `GiftableToken` expiry and burn
+  behavior; bounded-swap slippage and deadline paths; de-listing behavior with a held balance.
+- **E2E**: steward authors and freezes a valuation policy → gardener sees it → gardener commits →
+  contribution confirmed → voucher appears → transfers to a third party → third party redeems.
+- **Manual**: locale tone across en/es/pt; the contribution ledger reading as a ledger rather than a
+  wallet (motivation-crowding mitigation).
+
+## CLAUDE.md Compliance
+
+- [ ] Hooks in shared package
+- [ ] i18n for all UI strings, en + es + pt mirrors, 4-part locale gate
+- [ ] Deployment artifacts for every address; no hardcoded addresses
+- [ ] Implementation Quality Contract applied; no speculative abstractions
+- [ ] No AGPL source read, imported, or vendored
+- [ ] No `#<number>` PR references in source comments (design-tokens hex false positive)
+
+## Impact Analysis
+
+### Likely to create
+
+- `packages/contracts/src/interfaces/I{SwapPool,Limiter,Quoter,GiftableToken,TokenIndex}.sol`
+- Gnosis executor and mint-authorization adapter under `packages/contracts/src/modules/`
+- A Gnosis GardenAccount deployment coordinator, sibling of the Celo one
+- `shared` CLC read client and MCC profile assembler
+- Admin valuation-policy authoring views; client see-before-commit and signal surfaces
+- Public funder view
+
+### Likely to modify
+
+- `packages/contracts/deployments/networks.json` — Gnosis (100)
+- `ICommitmentPoolingModule.sol` — `PoolType`, `ConsiderationRail`, and in 2b `Cycle`
+- Indexer schema — valuation policy, signals, voucher classes, outstanding obligation
+- `packages/shared` hooks and selectors

--- a/.plans/backlog/cosmo-local-credit-interop/resources.md
+++ b/.plans/backlog/cosmo-local-credit-interop/resources.md
@@ -109,6 +109,11 @@ solc 0.8.36, EVM fork osaka, optimizer 200 runs (Calibur 1000). Deployer
 These are **implementation** addresses as published in the README. Proxy instances for a specific
 pool are separate and must be resolved through `ContractRegistry` / discovery before use.
 
+**No testnet deployment is published.** The README and `docs/DEPLOY.md` cover Gnosis mainnet only;
+there are no Chiado addresses. Any testnet work runs against our own deployment of the published
+implementations or against interface-conformant mocks, and cannot observe the live venue's rates,
+limits, fees, or de-listing behaviour. See `plan.todo.md` Slice 5 for the 5a/5b split this forces.
+
 ### Writing from Will Ruddick
 
 - *What Makes a Pool a Pool?* (2026-08-01) — the five-rung ladder (tracking → verification →

--- a/.plans/backlog/cosmo-local-credit-interop/resources.md
+++ b/.plans/backlog/cosmo-local-credit-interop/resources.md
@@ -1,0 +1,184 @@
+# Resources
+
+Verified 2026-08-24/25. Addresses and facts below were read from primary sources; anything inferred
+is marked. Re-verify before any transaction.
+
+## Event: SustainableFinance.Live 2026 Hackathon
+
+Finextra Research. London and online. Theme: *"a coordination layer for community, place, and
+stewardship"*, aligned to the UK Government's Pride in Place programme.
+
+- Hackathon page: <https://www.sustainablefinance.live/hackathon>
+  (returns 403 to plain HTTP clients — read it through a browser)
+- Agenda / key dates: <https://www.sustainablefinance.live/hackathon-agenda>
+- Contact: `events@finextra.com`
+
+| Date | Event |
+|---|---|
+| 1 Sep 2026 | Webinar |
+| **16 Oct** | Bootcamp — full problem briefings released here |
+| 16–27 Oct | Build window (~11 days) |
+| 20 Oct | Sustainable Finance Live Conference, London + online |
+| 27 Oct, 14:00–15:00 | Submission deadline |
+| 28 Oct | Pitches 10:00–12:00, judging 13:00–14:00, awards 15:00–16:00 |
+
+**Target track — Problem Statement 2, "From Underbanked to Understood — Community Credit and
+Commitment Pools"**, verbatim:
+
+> Community organisations — such as sports clubs, charities, housing groups, and local producers —
+> hold real value through relationships, skills, and local demand. However, traditional financial
+> systems often see them as low value or high risk because of their fragmented records, limited
+> collateral, and volatile cash flow. How might we make these assets, commitments, and histories
+> visible to support fair finance, mutual credit, and better coordination? Can we build tools that
+> help banks and funders understand place-based organisations, while enabling communities and meet
+> local needs without relying solely on cash?
+>
+> **Idea Starter** — The Sarafu Network enables communities to issue redeemable vouchers for goods,
+> services, and labour, creating transparent and auditable commitment pools. Could you build on
+> Sarafu, or design a compatible solution, to help communities coordinate resources, route support,
+> and make local capacity visible? Could this data also help banks, councils, and investors identify
+> which projects are resilient, trustworthy, and investable?
+
+Adjacent statements: **PS3** ("From Satellite to Community Space") explicitly invites a geospatial
+add-on to *"the One Planet or Sarafu system"*. **PS1 / Collaboration Reverse Challenge** is a
+One Planet knowledge-graph plus agentic-AI brief that overlaps the Regen Coordination Knowledge
+Commons ontology work.
+
+Judging criteria and prizes were still unpublished as of 2026-08-24; the PS2 briefing is introduced
+by an unnamed "established actor" at the 16 Oct bootcamp. Stated deliverable is *"MVPs, platform
+concepts, and customer journeys"* — not a deployed protocol.
+
+## Cosmo-Local Credit (Grassroots Economics, Will Ruddick)
+
+- Site: <https://cosmolocal.credit>
+- Whitepaper as machine-readable text: <https://cosmolocal.credit/llms-full.txt>
+  (the richest single source — carries CPP interfaces, the MCC, fee waterfall, KPIs, governance)
+- Simulator: <https://sim.cosmolocal.credit> (Streamlit; not text-readable)
+- GitHub org: <https://github.com/cosmo-local-credit>
+
+| Repo | Contents |
+|---|---|
+| `protocol` | Core Solidity. **AGPL-3.0.** Last push 2026-08-18 |
+| `docs` | Documentation |
+| `sim` | Python simulation/modelling |
+| `eth-tracker` | Go — EVM tx/event/deployment tracker |
+| `eth-indexer` | Go — indexes GE activity on Celo |
+| `ens-offchain-resolver` | Go — ENS offchain resolver gateway |
+| `storage-server` | Go — content storage |
+
+Documentation safe to read (not `src/`): `README.md`, `docs/SPEC.md`, `docs/DEPLOY.md`,
+`docs/PUBLISH.md`. `docs/SPEC.md` is a complete public interface reference — functions, events,
+errors, seal bitmasks, fee math — sufficient to hand-write interfaces without touching AGPL source.
+
+**Licensing** — `LICENSE` is present and is AGPL-3.0 for everything under `src/`; unmodified Solady
+snippets stay MIT; `NOTICE` carries attributions to Louis Holbrook, 0xSplits and Solady. This
+supersedes the 2026-07-02 "missing LICENSE file" observation recorded in
+`commitment-pooling/exchange-architecture-brief.md` §6.
+
+**Security review** — `audits/Sarafu-Protocol-Security-Audit.pdf`, at commit `f0944d9`. The README
+states it is an *internal engineering review*, explicitly **"not an independent third-party
+certification."** It does not satisfy the Green Goods external-audit gate.
+
+### Deployed — Gnosis mainnet, chain 100, v1.0.0
+
+solc 0.8.36, EVM fork osaka, optimizer 200 runs (Calibur 1000). Deployer
+`0x33a573149db22e759fb9a38bcc461c12855c2645`.
+
+| Contract | Address |
+|---|---|
+| Calibur | `0x48A910C8e9FF0b14051b78d0c96dB069E57f0729` |
+| ERC1967Factory | `0xB286994c648F98fD3a3BA6C43934828a5b88162b` |
+| AccountsIndex | `0x3cA9AB9b8628b43f1A1c53f29e969BA84Ef88BeE` |
+| CAT | `0xA12148B6eeb347298F17eCC5AC0377592850202E` |
+| ContractRegistry | `0x273B65EA845E2832f41d8d4366E6Cc3a9Fc67186` |
+| EthFaucet | `0x3dF58d637f03CD5174c5533FB89cb9B6fd855Ad3` |
+| FeePolicy | `0x1b97FfFAF2D2e16C8F7de6826F4F658dc898E5b6` |
+| GiftableToken | `0x34445d13F112A11f72C1d353a7dcdc407F3df2d8` |
+| Limiter | `0x258AAd6c933F70D7F071E112800a41Fb60434048` |
+| OracleQuoter | `0x3334fd1eA4c7e4dCA51f5E62EE3F5f7Dcbd098BA` |
+| PeriodSimple | `0x8608051473603279EE982E87f765A78d3D080b00` |
+| ProtocolFeeController | `0x302E6d520e7D7AeFceA4813e456234B5daA23B4d` |
+| RelativeQuoter | `0x0B0986c0E580377389337C453Cc65A3933511165` |
+| Splitter | `0x3b1F9bCC82f2dA5607dcDFCb21E47Cf64Ee54274` |
+| SwapPool | `0x9e694D342Cab02e295262B2290b0E64A0334160D` |
+| TokenUniqueSymbolIndex | `0x0CEB18BA6562D3227717D98c044A5849bE8362EF` |
+| DecimalQuoter | `0x336f493d5472FD59e9E05128804E2D05Be89c4B7` |
+| SwapRouter | `0x16e3F29dDe22eF75C081A764C4d200Cd48647bcC` |
+| RescueVault | `0x3E5D8d8f63c57EA5DD62cF5aeC7212C50bDA69EF` |
+
+These are **implementation** addresses as published in the README. Proxy instances for a specific
+pool are separate and must be resolved through `ContractRegistry` / discovery before use.
+
+### Writing from Will Ruddick
+
+- *What Makes a Pool a Pool?* (2026-08-01) — the five-rung ladder (tracking → verification →
+  rewarding → coordination → pooling), pool anatomy (curation / valuation / limitation / exchange /
+  settlement / memory+repair), and the three tests.
+- *Bioregional Cosmo-Local Credit Flows* — the six cross-pool transaction patterns and the live
+  Kenyan chama data (5 pools, 4,606 transactions Jan–Aug 2026, on Celo).
+- Recipe library: <https://recipes.grassecon.org>
+
+## Chainlink CCIP — Gnosis
+
+<https://docs.chain.link/ccip/directory/mainnet/chain/xdai-mainnet>
+
+- Chain selector: `465200170687744372`
+- **Arbitrum One lane live, OnRamp v1.5.0** (same version family as the Celo lane in use)
+- Fee tokens: GHO, LINK, WXDAI, native XDAI
+- Router, RMN, token admin registry addresses are truncated in the rendered docs page — read the
+  full values from the Chainlink directory at implementation time rather than transcribing them here
+
+## Green Goods — current state (verified 2026-08-24/25)
+
+- `packages/contracts/deployments/networks.json` covers mainnet(1), sepolia(11155111),
+  localhost(31337), arbitrum(42161), celo(42220). **No Gnosis(100) entry.**
+- Pooling contracts deployed and **unpaused on Arbitrum** since 2026-08-13: `commitmentPoolingModule`,
+  `commitmentRegistry`, `creditRegistry`, `settlementModule`, `poolingLibraries`,
+  `settlementLibraries`, `testimonyResolver`.
+- `SettlementModule` and the Celo executor are deployed but **paused**, `authorityEnabled: false`.
+- Ownership is still deployer-EOA across the pooling surface; Safe transfer deferred.
+- Hosted Envio has **no pooling schema** — pooling queries remain gated off.
+- `enum PoolType { Garden, Protocol }` — [ICommitmentPoolingModule.sol:8](../../../packages/contracts/src/interfaces/ICommitmentPoolingModule.sol)
+- `enum CycleType { Season, Campaign }`; one open Season per pool, unlimited concurrent Campaigns —
+  [CyclesLib.sol:11](../../../packages/contracts/src/lib/CommitmentPooling/CyclesLib.sol)
+- `enum ConsiderationRail { None, ArbitrumExternal, CeloSettlement }`
+- `Cycle` carries `metadataCID`, `AllocationBps allocation` (snapshot emitted in `CycleOpened`),
+  and `RecognitionPolicy { equalParticipationBps, verifiedContributionBps }`.
+
+## Cross-chain identity precedent
+
+- [`CeloGardenAccountDeploymentCoordinator.sol`](../../../packages/contracts/src/accounts/CeloGardenAccountDeploymentCoordinator.sol)
+  — one-shot coordinator reconstructing the frozen CREATE2 dependency closure and deploying all 18
+  foreign-tuple GardenAccounts at their **exact Arbitrum addresses** on Celo, rejecting any init
+  code that fails the frozen length, hash, CREATE2-target and runtime-hash checks.
+- [`CeloGardenAccountRelay.sol`](../../../packages/contracts/src/accounts/CeloGardenAccountRelay.sol)
+  — authenticated CCIP proposal/finalisation; deliberately not a Safe owner, module, guard, Zodiac
+  member, executor, spender or administrator.
+- [`SettlementMessageCodec.sol`](../../../packages/contracts/src/libraries/SettlementMessageCodec.sol)
+  — frozen v1 data-only command/ack payload codec.
+- Plan hub: [`celo-garden-account-safe-ownership`](../../active/celo-garden-account-safe-ownership/),
+  Linear PRD-821. Target topology is a 2-of-3 Safe of GardenAccount + protocol recovery Safe + Dev
+  Guild recovery Safe, verified on pinned forks.
+
+## Prior Green Goods analysis this hub builds on
+
+- `commitment-pooling/exchange-architecture-brief.md` — the compatibility contract (three separate
+  identities), backing modes, quoter, limiter, venue, the buy-vs-build fork (§6), settlement-rail
+  generality (§7), guardrails (§8), evidence gates (§9), and the five GE questions (§10).
+- `commitment-pooling/settlement-spec.md` — the split-state command/ack pattern and §10.3 gates.
+- `commitment-pooling/pilot-evidence-spec.md` — §3 reciprocity, §5 exchange demand, §6 safeguards,
+  §8 circulation, §9 privacy, §11 the September evidence packet.
+- Linear [PRD-651](https://linear.app/greenpill-dev-guild/issue/PRD-651) — the four-stage
+  evidence-gated path to exchange, redemption and federation.
+- Linear [PRD-796](https://linear.app/greenpill-dev-guild/issue/PRD-796) — the compatibility freeze.
+
+## Open / unverified
+
+- Whether the **2026-08-19 Grassroots Economics conversation happened**, and what was said. No
+  meeting notes and no calendar entry were found. `exchange-architecture-brief.md` §10 lists five
+  prepared questions that remain the sharpest open items.
+- Whether `GiftableToken.burn` still functions after expiry (docs say every transfer *including
+  mint* reverts; burn-to-zero is ambiguous). Must be settled on a fork.
+- Live configuration of the CLC Gnosis deployment: owner vs ERC1967 admin on each proxy,
+  `ProtocolFeeController.isActive()` / `getProtocolFee()`, `FeePolicy.getDefaultFee()`,
+  `SwapPool.isSealed(0)`. All readable on-chain today — see `plan.todo.md` Slice 0.

--- a/.plans/backlog/cosmo-local-credit-interop/spec.md
+++ b/.plans/backlog/cosmo-local-credit-interop/spec.md
@@ -41,8 +41,9 @@ mints locally, exactly as `SettlementMessageCodec`'s frozen v1 command/ack does 
 bridged value ever" posture holds without amendment because there is no value in transit, only an
 authorization.
 
-`ConsiderationRail` gains a Gnosis member. Precedent for shipping an enum member inert ahead of use
-is `DisbursementKind.LoanPrincipal`.
+`ConsiderationRail` gains a Gnosis member. Shipping it ahead of use is safe because the rail
+dispatch is fail-closed — see §3, which also explains why the same move is **not** safe for
+`PoolType`.
 
 ## 2. The valuation model — three layers that must not collapse
 
@@ -52,6 +53,9 @@ contribution comparable without pricing care work.
 **Layer 1 — Record, in native units, never converted.** Ada cooked three meals. Chidi taught five
 design hours. Stored as recorded, permanently. `unlike-label units never aggregate` stays true here
 forever. This is the contribution ledger and it is what makes unpaid labor *visible*.
+
+> **Layer 1 is aspirational today.** No per-contributor quantity exists anywhere in the current data
+> model — see §2.0, which is the blocking prerequisite for the rest of this document.
 
 **Layer 2 — Commensuration, declared by the pool.** A versioned, governed, publicly visible
 equivalence table with a named authority. This is what makes contribution *comparable*. It is
@@ -69,6 +73,38 @@ The escape hatch already exists in the frozen design —
 versioned explicit conversion declaration names both bases and its authority."* Layer 2 is that
 declaration.
 
+### 2.0 Layer 1 does not exist yet — the per-contributor quantity gap
+
+**This is the foundational prerequisite for everything else in this hub, and it is not currently
+satisfied by the data model.**
+
+Layer 1 assumes a record of the form "Chidi taught five hours". Nothing on chain carries that:
+
+| Where you would look | What is actually there |
+|---|---|
+| `WorkSchema` ([Schemas.sol](../../../packages/contracts/src/Schemas.sol)) | `actionUID`, `title`, `feedback`, `metadata`, `media` — **no hours, no unit amount** |
+| `Commitment` | `unitLabel` ("hours, tasks, meals, rides, plants…") and `targetUnits` — **commitment-wide, not per person** |
+| `ContributorRecord` | `approvedWorkCredits`, `evidenceCredits`, `uncountedLinkedWorkCount` — **counts, not quantities** |
+
+So for a multi-contributor commitment the adapter cannot recover what any individual actually
+contributed, and cannot derive a mint amount without inventing an allocation rule. Splitting
+`targetUnits` evenly across contributors would be exactly such an invention, and it would issue
+value against work nobody recorded.
+
+Three candidate resolutions, none yet chosen:
+
+1. **Carry the quantity on the Work record** — a per-Work unit amount in the assessment or work
+   schema. Truthful and the largest change; touches a deployed EAS schema.
+2. **Per-contributor declared units on the commitment** — extend `ContributorRecord` from counts to
+   quantities. Smaller, still a contract change, and it must not become a per-person score.
+3. **Single-contributor commitments only for v1** — vouchers mint only where
+   `contributorCount == 1`, so `targetUnits` unambiguously belongs to one person. No contract change;
+   materially narrows the pilot and excludes exactly the group work the design is meant to surface.
+
+**Until one is chosen and built, weighted minting cannot be specified honestly.** Slice 2 must
+resolve this before Slice 4 is dispatchable, and (3) is the only option that fits the hackathon
+window.
+
 ### 2.1 `ValuationPolicy` — a third cycle snapshot
 
 `Cycle` already carries two steward-set policies frozen at open and emitted in `CycleOpened`:
@@ -80,6 +116,9 @@ split rather than a global principle).
 
 ```text
 ValuationPolicy {
+  version                    // monotonic per pool; identifies this exact table
+  authority                  // the steward account that froze it
+  rationaleCID               // §2.2 invariant 3; the stated reason
   basis                      // Time for v1
   weights[actionUID|domain]  // declared relevance to this cycle's purpose
 }
@@ -88,6 +127,13 @@ ValuationPolicy {
 Frozen at `CycleOpened`, emitted with the rest, keyed to **action UIDs or domains** —
 which `CommitmentCreated` already carries — and **never to identities**, the same way
 `AllocationBps` weights role classes rather than people.
+
+`version`, `authority` and `rationaleCID` are **mandatory, not decorative**. §2.2 requires a
+versioned table with a named authority and §2.3 requires the rationale in the record; without those
+three fields on the emitted policy, the mint adapter and the indexer cannot prove that the table a
+mint was weighted by is the table the steward actually froze. In the 2a shape (§ Slices) these
+fields live in `metadataCID` under a schema that is equally mandatory — the carrier may change, the
+contract may not.
 
 **Basis for v1 is time.** Education is unusually time-legible: facilitating, preparing, mentoring,
 attending and reviewing all record naturally in hours, where growing food or building infrastructure
@@ -114,8 +160,16 @@ Stewards hold the pen. Two rungs are in scope; two are deferred.
 | Consultation required before open | Deferred — but see §3.3 |
 | Ratification / gardener block | Deferred |
 
-The signal is the same primitive as `NeedSignal` in the community-interface spec, pointed at a
-different object. Build one mechanism, not two.
+The signal follows the `NeedSignal` **pattern**, but it cannot literally reuse that schema.
+`community-interface/spec.md` §NeedSignal branch requires `refUID != 0` and that the referenced
+attestation *"exists, has the exact Need schema, has the same recipient, and is neither revoked nor
+expired"* — a resolver check that fails closed. A cycle or valuation-policy UID is rejected outright,
+so pointing the existing schema at one records nothing.
+
+A sibling schema and resolver branch is therefore in scope for Slice 2: same two-sided
+support/dissent shape, same revocability and single-attestation discipline, new reference target and
+new validation branch. "One mechanism, not two" applies to the *pattern and the UI*, not to the
+schema UID.
 
 The aggregate reading is useful in three directions at once: the steward learns whether a weighting
 landed, gardeners see they are not alone in a view, and a funder sees whether a campaign's
@@ -132,8 +186,22 @@ priorities were shared by the people doing the work.
 | `GardenToGarden` | stewards from multiple gardens | **to add** |
 | `Community` | surfaced from the community app | **to add** |
 
-Append both now, inert, following the `DisbursementKind.LoanPrincipal` precedent — it costs nothing
-and avoids an upgrade later.
+**Appending these is not free, and the `DisbursementKind.LoanPrincipal` precedent does not carry.**
+That enum shipped safely because its consumer is fail-closed. `PoolType`'s is not:
+[PoolsLib.sol:43](../../../packages/contracts/src/lib/CommitmentPooling/PoolsLib.sol) branches on
+`poolType == Protocol` and sends **everything else** down the `Garden` path, so a `GardenToGarden`
+pool would silently inherit garden-steward authorization. The indexer's `commitmentPoolType` maps
+anything `>= 2` to `UNKNOWN`, and neither `schema.graphql`'s `CommitmentPoolType` nor
+`types-vocabulary.ts` defines the new members.
+
+So the members may only be added together with, in the same change: an explicit contract guard for
+each new value rather than an `else` fallthrough; indexer, GraphQL-schema, shared-type and client
+mappings; and round-trip coverage. Until then the enum stays two-valued.
+
+`ConsiderationRail` is the opposite case and *is* safe to append ahead of use:
+[CreationChecksLib.sol:286](../../../packages/contracts/src/lib/CommitmentPooling/CreationChecksLib.sol)
+ends its rail dispatch in `else { revert InvalidConsiderationConfiguration(); }`, so an unhandled
+rail is rejected at creation. That is the property the `LoanPrincipal` precedent actually relied on.
 
 ### 3.1 The discriminator: when to spin up a pool
 
@@ -181,8 +249,16 @@ minimum viable process. Multi-steward pools and the heavier governance rungs arr
 
 - **Backing mode**: `FulfilledBacking`. Confirmed contribution authorizes a bounded mint. The
   labor already happened; the job is to record and count it. `ReservedCapacity` stays disabled.
-- **Class unit**: one voucher class per campaign, wrapping a `commitmentSeriesId` as issuer context.
-  A series — "one pool-scoped Offer used over time" — is the natural class boundary.
+- **Class unit — campaign-keyed, not series-keyed.** `voucherClassId` is keyed to `(poolId, cycleId)`.
+  A series is issuer *context* recorded on the backing receipt, never the class boundary.
+
+  The two are not interchangeable and cannot both be the key: `CommitmentSeries` is pool-scoped and
+  carries **no `cycleId`**, while each `Commitment` independently carries both `cycleId` and
+  `commitmentSeriesId`. So one campaign holds many series and one ongoing series spans campaigns.
+  Campaign-keying is forced by the valuation model — weights are frozen per cycle, so a class must
+  map to exactly one policy version for replay prevention, policy provenance, and
+  outstanding-obligation totals to be unambiguous. A series-keyed class would straddle several
+  frozen tables at once.
 - **Unit label**: a **weighted contribution unit, not an hour.** Weights are applied at mint per
   §2.1; hours stay unconverted in layer 1 forever.
 - **Expiry**: `expiresAt = 0`. See [`tensions.md`](./tensions.md) §5 — the expiry cliff is a
@@ -221,8 +297,9 @@ truth. Green Goods' Hats-gated attestation graph is that missing source.
 4. Every pool publishes a machine-readable MCC-shaped profile — registry roots, receipt standard,
    health endpoints with freshness bounds, policy constraints, failure codes — plus an `evidence`
    block CLC has no equivalent for.
-5. Gardeners hold, transfer and redeem vouchers from a Gnosis account at the same address as their
-   Arbitrum account.
+5. Gardeners hold, transfer and redeem vouchers from their own Gnosis Kernel account — not a garden
+   account. Address parity with their Arbitrum account is desirable but unproven; see
+   [`tensions.md`](./tensions.md) §7.
 6. Outstanding unredeemed obligation is a first-class published figure.
 7. Marketplace surfaces built by Green Goods obey Green Goods vocabulary and design rules; external
    surfaces are acknowledged as outside that control.
@@ -237,9 +314,12 @@ truth. Green Goods' Hats-gated attestation graph is that missing source.
 | Weights at mint vs at exchange | **Decided: at mint** |
 | Basis | **Decided: time, for v1** |
 | Who holds the pen | **Decided: stewards**, with see-before-commit + two-sided signal |
+| Voucher class identity | **Decided: campaign-keyed** `(poolId, cycleId)`. Series is issuer context only — §4 |
+| **Where a per-contributor quantity comes from** | **Open, and it blocks everything.** §2.0 — nothing on chain carries it today. Three candidates; only single-contributor-only fits the hackathon window |
 | Does learning count, and at what weight relative to facilitating? | **Open.** Values decision; everything else in the education weights table follows from it |
 | Do concurrent campaigns need a bound? | **Open.** Exit check ("a campaign nobody joins is inert") may be sufficient at hub scale |
 | Whether `GiftableToken.burn` survives expiry | **Open.** Fork verification |
+| The second confirmer on a redemption event | **Open.** Transferability breaks counterparty-first confirmation — `tensions.md` §4 |
 
 ## 8. Non-functional constraints
 

--- a/.plans/backlog/cosmo-local-credit-interop/spec.md
+++ b/.plans/backlog/cosmo-local-credit-interop/spec.md
@@ -1,0 +1,286 @@
+# Cosmo-Local Credit Voucher Interoperability — Architecture Spec
+
+**Posture**: design only. Authorizes no implementation, deployment, dependency install, custody
+change, venue integration, or partner commitment.
+**Companion documents**: [`brief.md`](./brief.md) · [`resources.md`](./resources.md) ·
+[`tensions.md`](./tensions.md) · [`plan.todo.md`](./plan.todo.md) · [`eval.md`](./eval.md)
+
+## Summary
+
+Green Goods keeps the promise and the evidence; Cosmo-Local Credit provides the exchange venue.
+Confirmed contribution on Arbitrum authorizes the mint of a **Gnosis-native voucher** through a CCIP
+command, in the same split-state shape already used for Celo G$ settlement. The voucher is listed,
+priced, limited, and exchanged inside CLC's deployed Commitment Pooling Protocol contracts. Nothing
+bridges: only authorization crosses, and the instrument is native to the chain it lives on.
+
+Contribution weight is applied **at mint, not at exchange** — a cycle-scoped, steward-set, frozen
+`ValuationPolicy` decides how many voucher units an hour of a given activity yields, inside Green
+Goods where the governance is. CLC's quoter then only needs one rate per garden voucher.
+
+## Users
+
+- **Primary**: hub members who already provide services and skills to one another informally —
+  teaching, facilitating, mentoring, cooking, hosting — whose labor is currently recognized but not
+  valued, and never valued against anything else.
+- **Secondary**: garden stewards, who set and publish the valuation policy; funders, councils and
+  banks who need to assess a place-based organisation from outside Green Goods; Cosmo-Local Credit
+  pool operators and routers who need a source of truth for fulfilment.
+
+## 1. Where things live
+
+| Layer | Chain | Owner |
+|---|---|---|
+| Commitments, cycles, evidence, EAS, Hats, Hypercerts, confirmation | Arbitrum One (42161) | Green Goods |
+| Valuation policy, weights, per-member limits, mint authorization | Arbitrum One | Green Goods |
+| Voucher token (`GiftableToken` instance) | Gnosis (100) | Green Goods |
+| Pool, router, quoters, limiter, fee policy | Gnosis (100) | **Cosmo-Local Credit** |
+| G$ settlement (existing, paused) | Celo (42220) | Green Goods |
+
+**Nothing bridges.** Arbitrum emits a mint authorization — class, amount, recipient — and Gnosis
+mints locally, exactly as `SettlementMessageCodec`'s frozen v1 command/ack does for G$. The "no
+bridged value ever" posture holds without amendment because there is no value in transit, only an
+authorization.
+
+`ConsiderationRail` gains a Gnosis member. Precedent for shipping an enum member inert ahead of use
+is `DisbursementKind.LoanPrincipal`.
+
+## 2. The valuation model — three layers that must not collapse
+
+This is the core architectural commitment of the hub, and it is what allows Green Goods to make
+contribution comparable without pricing care work.
+
+**Layer 1 — Record, in native units, never converted.** Ada cooked three meals. Chidi taught five
+design hours. Stored as recorded, permanently. `unlike-label units never aggregate` stays true here
+forever. This is the contribution ledger and it is what makes unpaid labor *visible*.
+
+**Layer 2 — Commensuration, declared by the pool.** A versioned, governed, publicly visible
+equivalence table with a named authority. This is what makes contribution *comparable*. It is
+explicitly not a price, not portable outside the pool, and never convertible to money at protocol
+level.
+
+**Layer 3 — Exchange**, which consumes layer 2: vouchers, quoter, limiter, routing.
+
+**The critical property: a layer-2 change never rewrites layer 1.** Revising equivalences produces a
+new versioned table; the record of what actually happened is untouched. That is the difference
+between a group revising its values and a group retroactively revaluing people's past contributions.
+
+The escape hatch already exists in the frozen design —
+`exchange-architecture-brief.md` §3 permits a quoter to accept an incompatible basis when *"a
+versioned explicit conversion declaration names both bases and its authority."* Layer 2 is that
+declaration.
+
+### 2.1 `ValuationPolicy` — a third cycle snapshot
+
+`Cycle` already carries two steward-set policies frozen at open and emitted in `CycleOpened`:
+`AllocationBps` (six role shares) and `RecognitionPolicy` (`equalParticipationBps` /
+`verifiedContributionBps` — already the egalitarian-versus-merit dial, already settled as a per-cycle
+split rather than a global principle).
+
+`ValuationPolicy` is the third, in the same shape:
+
+```text
+ValuationPolicy {
+  basis                      // Time for v1
+  weights[actionUID|domain]  // declared relevance to this cycle's purpose
+}
+```
+
+Frozen at `CycleOpened`, emitted with the rest, keyed to **action UIDs or domains** —
+which `CommitmentCreated` already carries — and **never to identities**, the same way
+`AllocationBps` weights role classes rather than people.
+
+**Basis for v1 is time.** Education is unusually time-legible: facilitating, preparing, mentoring,
+attending and reviewing all record naturally in hours, where growing food or building infrastructure
+separate effort from output. Prove the basis where it works before stressing it.
+
+### 2.2 Invariants on the pen
+
+1. **Weights are set before cycle open and never move mid-cycle.** This is the consent mechanism,
+   not an implementation detail: a gardener sees the table *before* deciding whether to commit, and
+   the steward cannot move it afterward.
+2. **Weights attach to activity types, never to identities.** Preserves the anti-scoring rule by
+   construction.
+3. **The rationale is part of the record.** `metadataCID` carries the steward's stated reason,
+   making a political act legible rather than silent.
+
+### 2.3 Gardener voice
+
+Stewards hold the pen. Two rungs are in scope; two are deferred.
+
+| Rung | Status |
+|---|---|
+| See before commit | **In scope.** Comes free with freeze-at-open. The floor. |
+| Visible two-sided signal — align **or** dissent, recorded against the cycle's valuation policy, non-binding | **In scope.** Not an objection log; a legitimacy reading. |
+| Consultation required before open | Deferred — but see §3.3 |
+| Ratification / gardener block | Deferred |
+
+The signal is the same primitive as `NeedSignal` in the community-interface spec, pointed at a
+different object. Build one mechanism, not two.
+
+The aggregate reading is useful in three directions at once: the steward learns whether a weighting
+landed, gardeners see they are not alone in a view, and a funder sees whether a campaign's
+priorities were shared by the people doing the work.
+
+## 3. Pool taxonomy
+
+`enum PoolType` is currently `{ Garden, Protocol }`. Two members are to be added:
+
+| Type | Membership | Status |
+|---|---|---|
+| `Garden` | one garden's roster | live |
+| `Protocol` | cross-garden, root garden tokenId 1 | live, singular by convention |
+| `GardenToGarden` | stewards from multiple gardens | **to add** |
+| `Community` | surfaced from the community app | **to add** |
+
+Append both now, inert, following the `DisbursementKind.LoanPrincipal` precedent — it costs nothing
+and avoids an upgrade later.
+
+### 3.1 The discriminator: when to spin up a pool
+
+**Does this cohort have a different membership than the garden?**
+
+A climate cohort at a university plausibly includes students who are not garden members — different
+people, different boundary, different consent. That is a pool. A garden doing focused work with the
+same people for a season is a *cycle*. Default to one pool per garden with cycle-scoped valuation;
+reserve the heavier structure for when it is earned.
+
+Two consequences. In CPP terms a pool is exactly the thing that declares its own curation,
+valuation and limits, so pool-per-cohort maps cleanly and makes each cohort independently
+discoverable. And two pools inside one garden make `SwapRouter` earn its place *within* a hub — a
+much shorter path to demonstrating routing than waiting for a second hub.
+
+### 3.2 Federation does not require shared valuation
+
+Cross-garden routing appeared to demand a cross-pool rate that nobody has authority to declare
+— the universal price the guardrails ban. It does not. **Each pool independently decides what it
+accepts and at what rate to itself.** Garden A decides what Garden B's voucher is worth *to A*;
+B decides separately; the two need not agree. Asymmetric, and correct — a curation decision, not
+price discovery. This is how Sarafu and CLC already operate.
+
+**Binding constraint, recorded now while it is cheap: never build a global rate table.** A shared
+cross-pool index would break the no-universal-price guardrail and foreclose federation in the same
+move. Valuation stays pool-local; acceptance is curation.
+
+**Start hub-and-spoke, not mesh.** Peer-to-peer garden pairs need N² acceptance rates and N²
+relationships; routing through the Protocol pool needs N. The Protocol pool already exists and is
+already cross-garden.
+
+### 3.3 Multi-steward pools pull governance forward
+
+`RosterLib` is commitment-scoped — self-join, self-exit, managed removal, contributor requirements —
+not pool membership. Pool membership currently rides on garden membership through Hats. A pool
+stewarded across gardens needs a pool-scoped authority concept that does not exist yet, and Hats
+constrains its shape: no wearer enumeration, and revoke behaves as transfer, so authority must be a
+**predicate** (`isWearerOfHat` against a pool-scoped hat) rather than a set.
+
+Second-order consequence: in a single-garden pool one steward obviously holds the pen. In a
+co-stewarded pool **nobody does**, so the "consultation required" rung deferred in §2.3 becomes the
+minimum viable process. Multi-steward pools and the heavier governance rungs arrive together.
+
+## 4. Voucher model
+
+- **Backing mode**: `FulfilledBacking`. Confirmed contribution authorizes a bounded mint. The
+  labor already happened; the job is to record and count it. `ReservedCapacity` stays disabled.
+- **Class unit**: one voucher class per campaign, wrapping a `commitmentSeriesId` as issuer context.
+  A series — "one pool-scoped Offer used over time" — is the natural class boundary.
+- **Unit label**: a **weighted contribution unit, not an hour.** Weights are applied at mint per
+  §2.1; hours stay unconverted in layer 1 forever.
+- **Expiry**: `expiresAt = 0`. See [`tensions.md`](./tensions.md) §5 — the expiry cliff is a
+  confiscation, and the outstanding-obligation figure it would erase is itself the funder signal.
+- **Per-member limits stay Green Goods-side.** CLC's `Limiter` caps `(token, holder-contract)` and
+  rejects EOAs, so it is pool inventory control, not per-person credit. That granularity is right:
+  the amount a pool will absorb of a garden's voucher **is that community's credit line**, set at
+  community level, never per person.
+
+The three identities from the frozen compatibility contract stay separate and never collapse:
+`commitmentId`/`classId` (one immutable promise instance), `commitmentSeriesId` (one ongoing Offer),
+`voucherClassId` (one issuer-backed transferable settlement instrument).
+
+## 5. CPP crosswalk
+
+| CPP pool function | CLC contract | Green Goods | Note |
+|---|---|---|---|
+| Curation | `TokenUniqueSymbolIndex`, `AccountsIndex` | `CommitmentRegistry`, pool roster | GG curates promises; CLC curates tokens |
+| Valuation | `RelativeQuoter` (PPM, owner-mutable, global) | `ValuationPolicy` (cycle-frozen, weighted) | **Weights at mint; the quoter carries one rate per garden voucher** |
+| Limitation | `Limiter` (per token, per holder-contract) | class quotas, `providerOpenCommitmentCap`, `borrowerCap` | Different units — inventory vs counts. Per-member stays GG-side |
+| Exchange | `SwapPool` + `FeePolicy` + `SwapRouter` | reserved `settlementAdapter` | The gap CLC fills |
+| Receipts | `Swap`, `SwapSettlement` | EAS work → approval → assessment → testimony → confirmation → Hypercert | Different kinds of receipt; neither substitutes |
+| Health endpoints (MCC) | — | Envio indexer, `promiseKeptRate`, `distinctProviderCount` | Exists; not yet published in MCC shape |
+
+**The asymmetry is the contribution.** CLC's voucher metadata carries `proof` as a free-text string
+and its Fulfillment Rate KPI (`FR = Settlements / RedemptionsRequested`) has no defined source of
+truth. Green Goods' Hats-gated attestation graph is that missing source.
+
+## 6. Functional requirements
+
+1. A confirmed commitment on Arbitrum authorizes a bounded voucher mint on Gnosis, with double-spend
+   prevention against the same fulfilment facts.
+2. Weights from the cycle's frozen `ValuationPolicy` determine mint quantity; layer-1 hour records
+   are never rewritten.
+3. A garden voucher is listable, priceable, limitable and exchangeable in a CLC pool.
+4. Every pool publishes a machine-readable MCC-shaped profile — registry roots, receipt standard,
+   health endpoints with freshness bounds, policy constraints, failure codes — plus an `evidence`
+   block CLC has no equivalent for.
+5. Gardeners hold, transfer and redeem vouchers from a Gnosis account at the same address as their
+   Arbitrum account.
+6. Outstanding unredeemed obligation is a first-class published figure.
+7. Marketplace surfaces built by Green Goods obey Green Goods vocabulary and design rules; external
+   surfaces are acknowledged as outside that control.
+
+## 7. Human judgment points
+
+| Decision | Status |
+|---|---|
+| Transact against CLC's live Gnosis deployment vs deploy own instances | **Decided: live deployment.** Accepts the rake and the network-governance dependency |
+| Accept external pricing vs constrain transfer venues | **Decided: constrain the marketplaces Green Goods creates**, enable the market aspects CLC supports |
+| Introduce transferability | **Decided: yes.** This is the core of the change |
+| Weights at mint vs at exchange | **Decided: at mint** |
+| Basis | **Decided: time, for v1** |
+| Who holds the pen | **Decided: stewards**, with see-before-commit + two-sided signal |
+| Does learning count, and at what weight relative to facilitating? | **Open.** Values decision; everything else in the education weights table follows from it |
+| Do concurrent campaigns need a bound? | **Open.** Exit check ("a campaign nobody joins is inert") may be sufficient at hub scale |
+| Whether `GiftableToken.burn` survives expiry | **Open.** Fork verification |
+
+## 8. Non-functional constraints
+
+- **Clean room**: hand-write interfaces from `docs/SPEC.md`. Never import `src/`. Never vendor the
+  `ge-publish` Go package. Interface implementation is not derivation; vendoring is.
+- **Package boundaries**: contracts → indexer → shared → client/admin, per repo dependency order.
+- **Security**: every pooling-tier mainnet deployment, upgrade, activation or unpause remains
+  blocked by external audit with no unresolved critical/high finding, 3-of-5 Safe ownership, a
+  48-hour mainnet timelock, two weeks of testnet operation, tested rollback, and explicit human
+  authorization. CLC's internal review does not satisfy this.
+- **Localization**: every user-facing string is i18n'd with en/es/pt mirrors.
+- **Privacy**: `pilot-evidence-spec.md` §9 governs publication of event-derived pair and holding
+  data. Public surfaces must not enumerate addresses.
+- **Vocabulary**: no leaderboards, no streaks, no ordered participant comparison, no price-framed
+  care work on Green Goods surfaces.
+
+## 9. Package / lane mapping
+
+| Area | Lane | Notes |
+|---|---|---|
+| UI | `ui` | Valuation-policy authoring, two-sided signal, voucher holdings, funder view |
+| State / API | `state_api` | Gnosis chain config, CLC read clients, MCC profile assembly, indexer schema |
+| Contracts | `contracts` | `ValuationPolicy`, enum members, mint-authorization adapter, Gnosis CCIP lane |
+| QA | `qa_pass_1`, `qa_pass_2` | Sequential |
+
+## 10. Risks
+
+See [`tensions.md`](./tensions.md) for the full integration analysis. Headline risks:
+
+- **Cold start.** Small voucher circles usually die. GE's own visualizer shows ~4 transactions per
+  pool per day across five established chamas. A new hub needs a reason to transact in week one.
+- **Motivation crowding.** Quantifying intrinsic contribution can reduce it. A contribution ledger
+  must read differently from a wallet balance.
+- **Measurement capture.** Whoever records best accrues most. Counterparty confirmation prevents
+  self-credit but does not surface the person who never asks to be confirmed.
+- **The fracture moment.** Valuing things against each other means someone's contribution is valued
+  lower — typically care work, typically gendered. Facilitation problem first, software problem
+  second; software's job is to keep the table visible, versioned, revisable and clearly owned by the
+  group.
+- **Exit with a negative balance.** Students graduate. Mutual credit's default problem, unaddressed
+  in Green Goods today beyond "visible and repairable."
+- **Liquidity fragmentation.** Every added pool is a thinner market. Education is the most portable
+  unit across gardens — every hub wants teaching — which is a second argument for the education
+  anchor.

--- a/.plans/backlog/cosmo-local-credit-interop/status.json
+++ b/.plans/backlog/cosmo-local-credit-interop/status.json
@@ -1,0 +1,188 @@
+{
+  "version": 2,
+  "feature": {
+    "slug": "cosmo-local-credit-interop",
+    "title": "Cosmo-Local Credit Voucher Interoperability",
+    "kind": "feature",
+    "stage": "backlog"
+  },
+  "workflow": {
+    "overall_status": "backlog",
+    "priority": "p2",
+    "created_at": "2026-08-25T06:09:38.829Z",
+    "updated_at": "2026-08-25T06:16:46.701Z"
+  },
+  "links": {
+    "brief": "brief.md",
+    "spec": "spec.md",
+    "plan": "plan.todo.md",
+    "eval": "eval.md",
+    "tensions": "tensions.md",
+    "resources": "resources.md"
+  },
+  "linear": {
+    "parentIssue": null,
+    "project": null,
+    "initiative": null,
+    "syncDirection": "plans_to_linear_visibility",
+    "lastSyncedAt": null,
+    "lanes": {}
+  },
+  "taxonomy": {
+    "initiative": "protocol-readiness",
+    "tracks": ["contracts", "indexer", "shared", "client", "client-pwa", "admin", "docs"],
+    "work_types": ["research"],
+    "surfaces": [
+      "packages/contracts",
+      "packages/indexer",
+      "packages/shared",
+      "packages/client",
+      "packages/admin",
+      ".plans/active/commitment-pooling",
+      ".plans/active/celo-garden-account-safe-ownership"
+    ],
+    "depends_on_features": [
+      "commitment-pooling",
+      "celo-garden-account-safe-ownership",
+      "community-interface"
+    ]
+  },
+  "notes": [
+    "Scoping and architecture hub. No implementation, deployment, custody change, venue integration, or partner commitment is authorized here.",
+    "Slices are dependency statements, not a schedule. Each requires its own scope lock and explicit human dispatch.",
+    "PRD-651 gates are unchanged: federation is stage four of four, and every pooling-tier mainnet action still needs external audit, 3-of-5 Safe, 48h timelock, two weeks testnet, tested rollback, and human authorization.",
+    "Clean room: hand-write interfaces from cosmo-local-credit/protocol docs/SPEC.md. Never read, import, or vendor AGPL src/.",
+    "Never build a global cross-pool rate table (decision 17) — it would break the no-universal-price guardrail and foreclose federation.",
+    "External facts in resources.md were verified 2026-08-24/25; re-verify against primary sources before any transaction."
+  ],
+  "lanes": {
+    "ui": {
+      "owner": "claude",
+      "status": "blocked",
+      "branch": null,
+      "depends_on": [],
+      "handoff": "handoffs/claude-ui.md",
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": "No implementation authorized. RED/GREEN is recorded when a slice is dispatched."
+      },
+      "skill_tags": ["ui", "frontend-design", "react"],
+      "manual_blocked": true
+    },
+    "state_api": {
+      "owner": "codex",
+      "status": "blocked",
+      "branch": null,
+      "depends_on": [],
+      "handoff": "handoffs/codex-state-api.md",
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": "No implementation authorized. RED/GREEN is recorded when a slice is dispatched."
+      },
+      "skill_tags": ["react", "tanstack-query", "data-layer"],
+      "manual_blocked": true
+    },
+    "contracts": {
+      "owner": "codex",
+      "status": "blocked",
+      "branch": null,
+      "depends_on": [],
+      "handoff": "handoffs/codex-contracts.md",
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": "No implementation authorized. RED/GREEN is recorded when a slice is dispatched."
+      },
+      "skill_tags": ["contracts"],
+      "manual_blocked": true
+    },
+    "qa_pass_1": {
+      "owner": "claude",
+      "status": "blocked",
+      "ready_when_dependencies_met": true,
+      "manual_blocked": true,
+      "branch": null,
+      "depends_on": ["ui", "state_api", "contracts"],
+      "handoff": "handoffs/claude-qa-pass-1.md",
+      "skill_tags": ["testing", "review"]
+    },
+    "qa_pass_2": {
+      "owner": "codex",
+      "status": "blocked",
+      "ready_when_dependencies_met": true,
+      "manual_blocked": true,
+      "branch": null,
+      "depends_on": ["qa_pass_1"],
+      "handoff": "handoffs/codex-qa-pass-2.md",
+      "skill_tags": ["testing", "review"]
+    }
+  },
+  "history": [
+    {
+      "timestamp": "2026-08-25T06:09:38.832Z",
+      "actor": "human",
+      "lane": "system",
+      "status": "scaffolded",
+      "branch": null,
+      "note": "Scaffolded feature hub in backlog"
+    },
+    {
+      "timestamp": "2026-08-25T06:16:30.077Z",
+      "actor": "human",
+      "lane": "contracts",
+      "status": "blocked",
+      "branch": null,
+      "note": "Scoping only — no implementation authorized. Slice 0 due diligence plus explicit human dispatch required first."
+    },
+    {
+      "timestamp": "2026-08-25T06:16:30.674Z",
+      "actor": "human",
+      "lane": "state_api",
+      "status": "blocked",
+      "branch": null,
+      "note": "Scoping only — no implementation authorized. Slice 0 due diligence plus explicit human dispatch required first."
+    },
+    {
+      "timestamp": "2026-08-25T06:16:31.242Z",
+      "actor": "human",
+      "lane": "ui",
+      "status": "blocked",
+      "branch": null,
+      "note": "Scoping only — no implementation authorized. Slice 0 due diligence plus explicit human dispatch required first."
+    },
+    {
+      "timestamp": "2026-08-25T06:16:46.701Z",
+      "actor": "claude",
+      "lane": "system",
+      "status": "scoped",
+      "branch": null,
+      "note": "Captured architecture, integration tensions, resources, decision log (22), slices 0-6+, and phasing from the 2026-08-25 scoping conversation."
+    }
+  ]
+}

--- a/.plans/backlog/cosmo-local-credit-interop/status.json
+++ b/.plans/backlog/cosmo-local-credit-interop/status.json
@@ -10,7 +10,7 @@
     "overall_status": "backlog",
     "priority": "p2",
     "created_at": "2026-08-25T06:09:38.829Z",
-    "updated_at": "2026-08-25T06:39:35.972Z"
+    "updated_at": "2026-08-25T06:54:00.451Z"
   },
   "links": {
     "brief": "brief.md",
@@ -54,14 +54,15 @@
     "PRD-651 gates are unchanged: federation is stage four of four, and every pooling-tier mainnet action still needs external audit, 3-of-5 Safe, 48h timelock, two weeks testnet, tested rollback, and human authorization.",
     "Clean room: hand-write interfaces from cosmo-local-credit/protocol docs/SPEC.md. Never read, import, or vendor AGPL src/.",
     "Never build a global cross-pool rate table (decision 17) — it would break the no-universal-price guardrail and foreclose federation.",
-    "External facts in resources.md were verified 2026-08-24/25; re-verify against primary sources before any transaction."
+    "External facts in resources.md were verified 2026-08-24/25; re-verify against primary sources before any transaction.",
+    "Lane order is encoded, not implied: contracts -> state_api -> ui. laneDependenciesMet treats an empty depends_on as satisfied, so an empty list would let a manual-blocker clear make UI actionable before its contract and shared-state prerequisites exist."
   ],
   "lanes": {
     "ui": {
       "owner": "claude",
       "status": "blocked",
       "branch": null,
-      "depends_on": [],
+      "depends_on": ["contracts", "state_api"],
       "handoff": "handoffs/claude-ui.md",
       "tdd": {
         "mode": "required",
@@ -83,7 +84,7 @@
       "owner": "codex",
       "status": "blocked",
       "branch": null,
-      "depends_on": [],
+      "depends_on": ["contracts"],
       "handoff": "handoffs/codex-state-api.md",
       "tdd": {
         "mode": "required",
@@ -192,6 +193,14 @@
       "status": "linear_recorded",
       "branch": null,
       "note": "Recorded Linear parent/lane issue identifiers"
+    },
+    {
+      "timestamp": "2026-08-25T06:54:00.451Z",
+      "actor": "claude",
+      "lane": "system",
+      "status": "scoped",
+      "branch": "plan/cosmo-local-credit-interop-hub",
+      "note": "Addressed 13 CodeRabbit findings on PR #769; encoded contracts -> state_api -> ui lane order."
     }
   ]
 }

--- a/.plans/backlog/cosmo-local-credit-interop/status.json
+++ b/.plans/backlog/cosmo-local-credit-interop/status.json
@@ -10,7 +10,7 @@
     "overall_status": "backlog",
     "priority": "p2",
     "created_at": "2026-08-25T06:09:38.829Z",
-    "updated_at": "2026-08-25T06:16:46.701Z"
+    "updated_at": "2026-08-25T06:39:35.972Z"
   },
   "links": {
     "brief": "brief.md",
@@ -21,12 +21,13 @@
     "resources": "resources.md"
   },
   "linear": {
-    "parentIssue": null,
-    "project": null,
+    "parentIssue": "RESR-73",
+    "project": "Commitment Pooling",
     "initiative": null,
     "syncDirection": "plans_to_linear_visibility",
-    "lastSyncedAt": null,
-    "lanes": {}
+    "lastSyncedAt": "2026-08-25T06:39:35.972Z",
+    "lanes": {},
+    "laneSyncMode": "parent_only"
   },
   "taxonomy": {
     "initiative": "protocol-readiness",
@@ -183,6 +184,14 @@
       "status": "scoped",
       "branch": null,
       "note": "Captured architecture, integration tensions, resources, decision log (22), slices 0-6+, and phasing from the 2026-08-25 scoping conversation."
+    },
+    {
+      "timestamp": "2026-08-25T06:39:35.972Z",
+      "actor": "claude",
+      "lane": "system",
+      "status": "linear_recorded",
+      "branch": null,
+      "note": "Recorded Linear parent/lane issue identifiers"
     }
   ]
 }

--- a/.plans/backlog/cosmo-local-credit-interop/tensions.md
+++ b/.plans/backlog/cosmo-local-credit-interop/tensions.md
@@ -1,0 +1,227 @@
+# Integration Tensions — Green Goods × Cosmo-Local Credit
+
+**Date**: 2026-08-25
+**Posture**: analysis only
+**Source basis**: `cosmo-local-credit/protocol` `README.md` / `docs/SPEC.md` / `docs/DEPLOY.md`,
+`cosmolocal.credit/llms-full.txt`, Chainlink CCIP mainnet directory, and the Green Goods contracts
+at the commit this hub was created on. **No AGPL `src/` was read.**
+
+Ordered by how much each hurts if discovered late.
+
+---
+
+## 1. Ownership — what you control and what you do not
+
+Decided: transact against CLC's **live** Gnosis deployment. That makes the ownership split the
+sharpest single item in this document.
+
+**Green Goods owns** its `GiftableToken` voucher class. Owner; grants `writer` to the mint adapter.
+One asymmetry matters: `burn(amount)` is **owner-only and burns from the caller's own balance**.
+Green Goods cannot burn a holder's voucher. Redemption-by-burn requires the holder to send it back,
+or the pool to hold it.
+
+**Cosmo-Local Credit owns everything else that decides your economics:**
+
+| Contract | What their owner controls |
+|---|---|
+| `RelativeQuoter` | `setPriceIndexValue(token, rate)` — **they set what the community's work is worth relative to everything else in the pool** |
+| `TokenUniqueSymbolIndex` | listing. `remove` de-lists, and per `SwapPool` validation both `tokenIn` and `tokenOut` must pass the registry check — so **de-listing stops entry *and exit*, trapping holders** |
+| `Limiter` | how much of the voucher the pool will absorb |
+| `SwapPool` | `withdrawLiquidity` is an owner-only emergency withdrawal of pool liquidity |
+| `FeePolicy` / `ProtocolFeeController` | rates, changeable at any time |
+
+### Seal semantics — two easy misreadings
+
+`SwapPool.seal(state)` is a bitmask permanently locking `feePolicy`, `feeAddress`, `quoter`,
+`tokenRegistry`, `tokenLimiter` (bits 1/2/4/8/16, `maxSealState` 31).
+
+- *"Sealing an address locks the slot, not the callee: a sealed `quoter` or `feePolicy` can still
+  change its own rates."* **"The pool is sealed" does not mean the rate is fixed.**
+- Seal is only a commitment when the ERC1967 proxy admin is a different, more conservative principal
+  than the owner. `ge-publish` requires `--admin` and rejects `admin == owner` — but that is a
+  deploy-time check, not an ongoing guarantee.
+- `fullSealMask` is written at `initialize` and frozen, so adding a seal bit in a later
+  implementation does not silently unseal existing pools. That part is sound.
+
+### Fees
+
+- `FeePolicy`: a zero-fee pool **is** expressible via `defaultFee = 0`. What is not expressible is a
+  zero fee for one pair while others are charged — *"a pair fee of `0` is treated as unset"* and
+  falls back to `defaultFee`. Use `removePairFee` to clear an override.
+- Protocol fee sits on top of the pool fee, computed against a **1% assumed floor**
+  (`DEFAULT_FEE_PPM = 10_000`) explicitly so *"a pool operator can't set a tiny pool fee just to
+  shrink the protocol's cut."* Skipped entirely only if the controller is unset, its ppm is 0, or the
+  recipient is zero.
+- The whitepaper's network layer sits above this: rake `τ_p = f_p · r_p`, a monthly waterfall funding
+  insurance reserve / core ops / liquidity mandates, and CLC / stCLC / sCLC gauge voting deciding
+  which pools receive incentives. **Green Goods has no weight in that governance unless it
+  participates.**
+
+### Mitigation
+
+- The reserved `settlementAdapter` should treat the CLC pool as an **external venue** with explicit
+  handling for de-listing, rate change, limit change and pool insolvency.
+- Green Goods always publishes the garden's own declared valuation **alongside** the pool's rate, so
+  the two are never confused.
+- Due diligence is entirely on-chain and available today — see `plan.todo.md` Slice 0.
+
+---
+
+## 2. External marketplaces mean external pricing
+
+Green Goods guardrails — no leaderboards, mutual-aid vocabulary, `lint:vocab`'s banned list, *"care
+work is not reduced to a tradeable price"* — govern **Green Goods surfaces**. They cannot follow an
+ERC20.
+
+**You cannot simultaneously make care work externally visible and exchangeable and guarantee it will
+not be priced.** Someone will quote an hour of cooking against a stablecoin, and it will not be you.
+
+Decided posture: **constrain the marketplaces Green Goods creates** so they work with Green Goods
+rules, while enabling the market aspects CLC supports. The conceptual `VoucherClass` already reserves
+`transferPolicy` as the mechanism for narrowing where a class may move.
+
+Residual, accepted: outside the constrained set, external pricing happens and Green Goods does not
+control it. Worth stating plainly in external material rather than implying otherwise.
+
+---
+
+## 3. Chain split — proof and instrument on different chains
+
+Commitments, EAS, Hats, Hypercerts and 18 pools are on Arbitrum. Vouchers and pools are on Gnosis.
+`networks.json` has no chain-100 entry.
+
+**Resolved by the existing pattern.** Arbitrum emits a *mint authorization*; Gnosis mints locally.
+Nothing crosses but a message, so "no bridged value ever" is preserved without amendment — the same
+shape as `SettlementMessageCodec`'s frozen v1 command/ack for G$.
+
+CCIP is live: Gnosis chain selector `465200170687744372`, **Arbitrum One lane at OnRamp v1.5.0**, fee
+tokens GHO / LINK / WXDAI / native XDAI.
+
+Remaining work is real but known-shape: a Gnosis executor deployment, a published and verified lane,
+a `ConsiderationRail` enum member, and a reviewed UUPS upgrade — `exchange-architecture-brief.md` §7
+already describes exactly this. The relay pattern in `CeloGardenAccountRelay` (authenticated CCIP
+proposal/finalisation, replay guard, nonce, expiry, action hash, deliberately not an owner or
+module) transfers directly.
+
+---
+
+## 4. Transferability breaks counterparty confirmation
+
+Green Goods confirmation is counterparty-first: the person helped confirms. A `GiftableToken` is a
+bearer instrument. If a voucher changes hands three times, whoever redeems it is **not** the person
+the service was originally for.
+
+Half of this is already guarded — *"holding or transferring a voucher grants no authority over the
+promise, provider, claimant, contributors, confirmation, dispute, recognition, or Story."*
+
+The other half is open: **the redemption event has no confirmed counterparty in the Green Goods
+sense.** Fulfilment confirmation and redemption confirmation become two different events with two
+different confirmers, and only the first fits the machinery that exists. Needs a design answer before
+any redemption path ships.
+
+---
+
+## 5. Expiry is a cliff, and should not be used
+
+`GiftableToken.initialize(..., expiresAt)`; `expiresAt = 0` means never. Once
+`block.timestamp >= expiresAt`, *"every transfer (including mint) reverts with `TokenExpired`."*
+Expiry flips on the first transfer at or after the timestamp, or explicitly via `applyExpiry()`,
+which anyone may call.
+
+The token freezes completely. Value does not decay — it vanishes, and the holder cannot even move it
+somewhere to rescue it. Whoever loses out is whoever was slowest to redeem, which is systematically
+the least-engaged person. That is strictly worse than demurrage and it is
+`pilot-evidence-spec.md`'s "failed redemption remains visible and repairable" gap in its most
+damaging form.
+
+### Options
+
+| # | Approach | Assessment |
+|---|---|---|
+| 1 | **`expiresAt = 0`; scope by issuance.** One class per campaign; cycle close revokes the mint writer rather than killing the token. Holdings stay valid and transferable; redemption is a Green Goods-side obligation with a visible figure | **Recommended** |
+| 2 | Expiry plus grace window and pre-expiry sweep | Depends on holders acting — reintroduces the same equity problem |
+| 3 | Demurrage | No primitive in their contract set, and modifying their token crosses the AGPL line. Could decay a contribution's *salience in reporting* without touching balances |
+| 4 | Two-token split (non-expiring record unit + expiring circulating unit) | Overbuilt for v1 |
+
+Option 1 has a bonus: **the outstanding unredeemed balance becomes a first-class number instead of
+something that silently disappears.** That is CLC's own `D_tot` — total outstanding redeemable
+obligations — and it is a genuine funder signal. Expiry then becomes a policy a garden decides
+explicitly rather than a default that bites.
+
+It also composes with campaign-scoped valuation: one token per campaign means the campaign's weights
+are baked into that token's issuance, and the token *is* the versioned artifact.
+
+**To verify on a fork**: whether `burn` still functions after expiry. The spec says every transfer
+including mint reverts; burn-to-zero is ambiguous from documentation alone, and it determines whether
+a redemption path survives an expired class.
+
+---
+
+## 6. The Limiter caps contracts, not people
+
+`setLimitFor(token, holder, value)` is owner-or-writer and **rejects externally owned accounts**
+(`InvalidHolder`, via an `extcodesize` check — which also means a limit cannot be set in the same
+transaction that deploys the holder contract). `SwapPool` enforces on deposit. A limit of `0` **blocks
+all deposits**, so the default is fail-closed: a voucher cannot enter the pool until a non-zero limit
+exists.
+
+So listing and limit are two separate gates, both CLC-controlled.
+
+**Not a problem — the granularity is correct.** The amount a pool will absorb of a garden's voucher
+**is that community's credit line**, set at community level by track record and relationship, never
+per person. That is precisely the shape the anti-scoring rule wants. Per-member caps stay Green
+Goods-side where the governance is. The only thing to internalise is that the credit line is a number
+someone else sets — the way a credit union sets one.
+
+---
+
+## 7. Identity — resolved, with two caveats
+
+`CeloGardenAccountDeploymentCoordinator` reconstructs the frozen CREATE2 dependency closure and
+deploys all 18 foreign-tuple GardenAccounts at their **exact Arbitrum addresses** on Celo in one
+transaction, refusing any init code failing the frozen length, hash, CREATE2-target and runtime-hash
+checks. `ACCOUNT_SALT` is constant; source chain pinned to 42161. Verified on pinned forks under
+PRD-821, with a target 2-of-3 Safe of GardenAccount + protocol recovery Safe + Dev Guild recovery
+Safe.
+
+Gnosis is a sibling deployment of proven tooling.
+
+**Caveat 1**: the coordinator is one-shot and chain-pinned by constant, so this is a new instance, not
+a reuse.
+**Caveat 2**: same *address* is not same *account*. The gardener's smart account still has to be
+deployed on Gnosis, and Pimlico needs its own Gnosis bundler and paymaster configuration and funding.
+Passkey userOps spend sponsorship per transaction.
+
+---
+
+## 8. Licensing
+
+`cosmo-local-credit/protocol` `src/` is **AGPL-3.0**; unmodified Solady stays MIT; `NOTICE` carries
+attributions.
+
+Safe posture, and it is the pattern the repo already uses for ~30 external protocols
+(`IHats`, `IGardensV2`, `IJuicebox`, `IUnlock`):
+
+- Hand-write `ISwapPool`, `ILimiter`, `IQuoter`, `IGiftableToken`, `ITokenIndex` from
+  `docs/SPEC.md` — documentation, not source.
+- Deploy via their `ge-publish` tool run **externally**, never vendored.
+- Never import `src/`. Never vendor their Go package.
+
+Interface implementation is not derivation; vendoring is. The counsel question pending since July
+only bites past that line, and the repo's stricter clean-room rule (no AGPL source read at all)
+remains satisfiable.
+
+---
+
+## Cross-cutting: what none of this fixes
+
+The gates in Linear [PRD-651](https://linear.app/greenpill-dev-guild/issue/PRD-651) are unchanged.
+Federation is stage four of four: field evidence of real exchange demand → fulfilled-backed issuance
+→ one bounded pool proving authorised issue, bounded seed, exchange in/out, redemption, liquidity,
+failed-redemption visibility and repair → then separately gated federation. Every pooling-tier
+mainnet action still needs external audit, 3-of-5 Safe ownership, a 48-hour timelock, two weeks of
+testnet operation, tested rollback, and explicit human authorization.
+
+Nothing in this document shortens that. What it does is make sure the design decisions taken now —
+pool-local valuation, pool-scoped authority predicates, `expiresAt = 0`, weights at mint, one signal
+primitive — do not foreclose the path.

--- a/.plans/backlog/cosmo-local-credit-interop/tensions.md
+++ b/.plans/backlog/cosmo-local-credit-interop/tensions.md
@@ -175,7 +175,7 @@ someone else sets — the way a credit union sets one.
 
 ---
 
-## 7. Identity — resolved, with two caveats
+## 7. Identity — solved for gardens, open for gardeners
 
 `CeloGardenAccountDeploymentCoordinator` reconstructs the frozen CREATE2 dependency closure and
 deploys all 18 foreign-tuple GardenAccounts at their **exact Arbitrum addresses** on Celo in one
@@ -184,11 +184,26 @@ checks. `ACCOUNT_SALT` is constant; source chain pinned to 42161. Verified on pi
 PRD-821, with a target 2-of-3 Safe of GardenAccount + protocol recovery Safe + Dev Guild recovery
 Safe.
 
-Gnosis is a sibling deployment of proven tooling.
+For **garden organisation accounts**, Gnosis is a sibling deployment of proven tooling.
 
-**Caveat 1**: the coordinator is one-shot and chain-pinned by constant, so this is a new instance, not
-a reuse.
-**Caveat 2**: same *address* is not same *account*. The gardener's smart account still has to be
+**But that coordinator does not solve gardener identity, and vouchers for individuals go to
+gardeners.** It deploys exactly `GARDEN_COUNT = 18` ERC-6551 accounts keyed by `GardenToken` token
+IDs — garden organisation accounts and nothing else. Individual contributors authenticate with
+per-person Pimlico Kernel accounts
+([`auth-passkey-adapters.ts`](../../../packages/shared/src/workflows/auth-passkey-adapters.ts)), an
+entirely different derivation with its own cross-chain determinism question. Pointing the coordinator
+at the gardener path would reproduce garden accounts and mint to the wrong recipients.
+
+So the honest state is:
+
+| | Status |
+|---|---|
+| Garden accounts, same address across chains | **Proven** on pinned forks under PRD-821 |
+| Gardener Kernel accounts, same address across chains | **Unproven.** Plausible for a deterministic factory with a fixed salt, but not verified, and it is the path vouchers actually take |
+
+**Caveat 1**: the coordinator is one-shot and chain-pinned by constant, so Gnosis is a new instance,
+not a reuse.
+**Caveat 2**: same *address* is not same *account* on either path. The account still has to be
 deployed on Gnosis, and Pimlico needs its own Gnosis bundler and paymaster configuration and funding.
 Passkey userOps spend sponsorship per transaction.
 


### PR DESCRIPTION
Adds a scoping and architecture hub for making Green Goods commitment pools interoperable with Grassroots Economics' **Cosmo-Local Credit** network, targeting Problem Statement 2 of the SustainableFinance.Live 2026 hackathon — *"From Underbanked to Understood — Community Credit and Commitment Pools"*, whose named idea starter is the Sarafu Network.

**Posture: design only.** All lanes are `manual_blocked`. No implementation, deployment, custody change, venue integration, or partner commitment is authorized. The [PRD-651](https://linear.app/greenpill-dev-guild/issue/PRD-651) evidence gates are unchanged.

## The shape

Green Goods keeps the promise and the evidence; CLC provides the exchange venue. Confirmed contribution on Arbitrum authorizes the mint of a **Gnosis-native** voucher over CCIP, in the same split-state command/ack shape already used for Celo G$ settlement. Nothing bridges — only authorization crosses, so the "no bridged value ever" posture holds unamended.

## Architecture recorded

- **Three valuation layers that must not collapse** — record in native units, commensuration declared per cycle, exchange. A layer-2 revision produces a new version and **never rewrites a layer-1 record**. This is what lets contribution become comparable without pricing care work.
- **`ValuationPolicy` as a third `Cycle` snapshot** frozen at `CycleOpened` alongside `AllocationBps` and `RecognitionPolicy`, keyed to action UIDs or domains and never to identities. **Weights apply at mint, not at exchange** — CLC's `RelativeQuoter` is global, per-token and owner-mutable, so it cannot hold cycle-scoped activity weights.
- **Two pool types to add** — `GardenToGarden` and `Community`, appended inert per the `DisbursementKind.LoanPrincipal` precedent. Membership boundary is the discriminator between a new pool and a new cycle.
- **Federation needs no shared valuation** — each pool decides what it accepts and at what rate *to itself*. Recorded as a binding constraint: **never build a global cross-pool rate table**, which would break the no-universal-price guardrail and foreclose federation in the same move.

## Integration tensions

`tensions.md` records eight, ranked by how much each hurts if found late. Highlights:

- **Ownership** — transacting against the live deployment means CLC's owner sets our voucher's rate, and `remove` from the token registry stops entry **and exit**, trapping holders. Seal locks the slot, not the callee's rates.
- **The expiry cliff** — `GiftableToken` freezes on expiry; value doesn't decay, it vanishes, and the holder can't move it. Recommendation is `expiresAt = 0` and outstanding obligation as a published figure instead.
- **Bearer instruments break counterparty confirmation** — fulfilment and redemption become two events with two different confirmers. Open.
- **Identity is solved** — `CeloGardenAccountDeploymentCoordinator` already proves exact same-address ERC-6551 accounts on a second chain.

## Closes two stale open items

- The 2026-07-02 *"missing LICENSE file"* observation in `commitment-pooling/exchange-architecture-brief.md` §6 is **stale** — the repo now carries an explicit AGPL-3.0 LICENSE and a NOTICE.
- Their security assessment is an **internal** engineering review, explicitly *"not an independent third-party certification"* — it does not satisfy the external-audit gate.

## Clean room

Interfaces are to be hand-written from the published `docs/SPEC.md`, matching the existing pattern for ~30 external protocols. **No AGPL `src/` was read, imported, or vendored** while producing this hub.

## Validation

- `node scripts/harness/plan-hub.mjs validate` → `Validated 48 feature hubs.`
- `bun run lint:vocab` → clean
- `bun run format` → no fixes applied
- Public-repo scan for partner detail → clean (two references generalised before commit; the repo is world-readable and neither pilot participation nor jurisdiction should be implied)

Docs-only. No package, contract, or runtime surface is touched.

Refs PRD-651, PRD-796

🤖 Generated with [Claude Code](https://claude.com/claude-code)