### PR TITLE
feat(shared,agent): add public garden impact API

### DIFF
--- a/.plans/active/public-garden-impact-api/brief.md
+++ b/.plans/active/public-garden-impact-api/brief.md
@@ -1,0 +1,34 @@
+# Public Garden Impact API
+
+**Slug**: `public-garden-impact-api`
+**Stage**: `active`
+**Priority**: `p2`
+**Created**: `2026-08-29T00:24:32.707Z`
+
+## Problem
+
+Public websites, partner tools, and funder integrations cannot retrieve one garden's impact from a
+stable public API. They would have to understand the Green Goods indexer, multiple EAS schemas,
+historical approval recipient differences, Hypercert status semantics, and the public visibility
+policy themselves.
+
+## Desired Outcome
+
+- A caller can fetch one public garden's submitted work, protocol approvals, assessments, and
+  impact certificates through a versioned JSON response.
+- Individual provider failures remain visible as partial provenance instead of becoming false zero
+  counts.
+- The existing protected public APIs, application UI, contracts, indexer schema, and deployment
+  configuration do not change.
+
+## Scope Notes
+
+- In scope: dependency-light response types, strict chain-aware source readers, pure aggregation,
+  one Agent GET/OPTIONS route, bounded rate limiting and caching, tests, and builder documentation.
+- Out of scope: UI work, writes, authentication, deployment, indexer or EAS schema changes, new
+  dependencies, environment files, Linear records, and production verification.
+
+## Success Signal
+
+A deterministic Agent integration test can request a visible garden and receive a public-safe,
+source-aware impact snapshot while failures produce the documented partial or unavailable result.

--- a/.plans/active/public-garden-impact-api/eval.md
+++ b/.plans/active/public-garden-impact-api/eval.md
@@ -1,0 +1,39 @@
+# Public Garden Impact API Evaluation Plan
+
+## Release Gates
+
+1. Correctness: every count and null state follows the source-availability and deduplication rules.
+2. Usability: the response is versioned, stable, privacy-safe, and usable from any browser origin.
+3. Regression safety: protected route CORS remains allowlisted and invalid chains cannot fall back.
+4. Evidence quality: research evidence and open assumptions are recorded before implementation.
+5. Human judgment: protected surfaces and maintainer-call decisions are called out before merge.
+
+## Acceptance Checks
+
+| ID | Behavior Boundary | Check | Owner | Evidence |
+|---|---|---|---|---|
+| AC-1 | Public contract | Response types and path builder are exported through `public-contracts` | `state_api` | Shared targeted suite passed |
+| AC-2 | Aggregation | Approval, certificate, deduplication, partial/null, privacy, and ordering rules pass | `state_api` | Direct aggregator suite passed |
+| AC-3 | Strict readers | Chain support, pagination, schema gaps, provider failures, and overflow fail closed | `state_api` | Direct reader suite passed |
+| AC-4 | HTTP route | GET/OPTIONS, validation, status mapping, wildcard CORS, rate limit, and cache pass | `state_api` | Agent integration suite passed |
+| AC-5 | Regression review | Protected CORS, source structure, package types, builds, and repo checkpoint pass | `qa_pass_1`, `qa_pass_2` | Validation receipts |
+
+## Test Strategy
+
+- Unit: direct Shared contract, aggregator, and reader tests with injected source results.
+- Integration: in-process Hono requests with injected snapshot loader, clock, and rate limiter.
+- E2E / Playwright: not applicable; no UI surface changes.
+- Manual checks: inspect JSON for identity leakage and confirm docs match the implemented shape.
+- TDD proof: RED/GREEN commands and evidence are recorded in lane handoffs and summarized in `status.json`.
+
+## QA Sequence
+
+### Claude QA Pass 1
+
+- Focus on UX issues, missing requirements, and test gaps
+- If blocked, record the blocker in `handoffs/claude-qa-pass-1.md`
+
+### Codex QA Pass 2
+
+- Start only after `qa_pass_1` is passed
+- Re-run targeted validation and close the loop on remaining defects

--- a/.plans/active/public-garden-impact-api/eval.md
+++ b/.plans/active/public-garden-impact-api/eval.md
@@ -16,7 +16,7 @@
 | AC-2 | Aggregation | Approval, certificate, deduplication, partial/null, privacy, and ordering rules pass | `state_api` | Direct aggregator suite passed |
 | AC-3 | Strict readers | Chain support, pagination, schema gaps, provider failures, and overflow fail closed | `state_api` | Direct reader suite passed |
 | AC-4 | HTTP route | GET/OPTIONS, validation, status mapping, wildcard CORS, rate limit, and cache pass | `state_api` | Agent integration suite passed |
-| AC-5 | Regression review | Protected CORS, source structure, package types, builds, and repo checkpoint pass | `qa_pass_1`, `qa_pass_2` | Validation receipts |
+| AC-5 | Regression review | Protected CORS, source structure, package types, builds, and repo checkpoint pass | `qa_pass_1`, `qa_pass_2` | Pending — validation receipts incomplete |
 
 ## Test Strategy
 

--- a/.plans/active/public-garden-impact-api/handoffs/README.md
+++ b/.plans/active/public-garden-impact-api/handoffs/README.md
@@ -1,0 +1,45 @@
+# Handoffs
+
+Keep lane handoffs short and factual. Use one file per lane:
+
+- `claude-ui.md`
+- `codex-state-api.md`
+- `codex-contracts.md`
+- `claude-qa-pass-1.md`
+- `codex-qa-pass-2.md`
+
+Each handoff should capture:
+
+1. What changed
+2. What remains
+3. TDD proof
+4. Validation run
+5. Known risks or blockers
+6. Repo-truth references from the active hub or reports, not tool-local memory claims
+
+Before a handoff claims `green`, `passed`, `completed`, or `merge-ready`, it must include:
+
+```markdown
+## Validation Receipt
+
+- Tested implementation commit SHA: `<full SHA>`
+- Run at (UTC): `YYYY-MM-DDTHH:MM:SSZ`
+- Exact command(s): `<commands>`
+- Result: `<counts or concise output summary>`
+- Validated paths: `<implementation, dependency, configuration, and validation paths>`
+- Worktree identity command and result: `git status --porcelain=v1 --untracked-files=all -- <validated paths>` → `<empty result>`
+- Evidence-only diff command and result (if applicable): `git diff --exit-code <tested>..HEAD -- <validated paths>` → `<result>`
+- Evidence-only worktree-status command and result (if applicable): `git status --porcelain=v1 --untracked-files=all -- <validated paths>` → `<empty result>`
+```
+
+`status.json` and `record-tdd` do not replace this receipt; they track orchestration and TDD state.
+
+Use this short proof block for implementation lanes:
+
+```markdown
+## TDD Proof
+
+- RED: command + expected failing result
+- GREEN: command + passing result
+- Proof limit: `none`, `not_applicable`, or the exact reason TDD could not honestly apply
+```

--- a/.plans/active/public-garden-impact-api/handoffs/claude-qa-pass-1.md
+++ b/.plans/active/public-garden-impact-api/handoffs/claude-qa-pass-1.md
@@ -1,0 +1,30 @@
+# Public Garden Impact API - QA Pass 1 Handoff
+
+## Lane
+
+- Owner: Claude
+- Branch: set when work begins using `<type>/<work-description>`
+- Status: blocked until dependencies pass
+
+## Scope
+
+- Review user flow, acceptance criteria, and missing test coverage after implementation lanes complete.
+
+## Validation
+
+- Pending QA pass.
+
+## Validation Receipt
+
+- Tested implementation commit SHA: pending
+- Run at (UTC): pending
+- Exact command(s): pending
+- Result: pending
+- Validated paths: pending
+- Worktree identity command and result: pending
+- Evidence-only diff command and result (if applicable): not applicable
+- Evidence-only worktree-status command and result (if applicable): not applicable
+
+## Risks / Blockers
+
+- Record blockers here before changing `status.json`.

--- a/.plans/active/public-garden-impact-api/handoffs/claude-ui.md
+++ b/.plans/active/public-garden-impact-api/handoffs/claude-ui.md
@@ -1,0 +1,36 @@
+# Public Garden Impact API - UI Handoff
+
+## Lane
+
+- Owner: Claude
+- Branch: set when work begins using `<type>/<work-description>`
+- Status: not applicable
+
+## Scope
+
+- No rendered UI, component, i18n, or browser-visible behavior changes.
+
+## TDD Proof
+
+- RED: not applicable
+- GREEN: not applicable
+- Proof limit: `not_applicable` — no behavior in this lane changes.
+
+## Validation
+
+- Pending lane implementation.
+
+## Validation Receipt
+
+- Tested implementation commit SHA: pending
+- Run at (UTC): pending
+- Exact command(s): pending
+- Result: pending
+- Validated paths: pending
+- Worktree identity command and result: pending
+- Evidence-only diff command and result (if applicable): not applicable
+- Evidence-only worktree-status command and result (if applicable): not applicable
+
+## Risks / Blockers
+
+- Record blockers here before changing `status.json`.

--- a/.plans/active/public-garden-impact-api/handoffs/claude-ui.md
+++ b/.plans/active/public-garden-impact-api/handoffs/claude-ui.md
@@ -18,16 +18,16 @@
 
 ## Validation
 
-- Pending lane implementation.
+- Not applicable.
 
 ## Validation Receipt
 
-- Tested implementation commit SHA: pending
-- Run at (UTC): pending
-- Exact command(s): pending
-- Result: pending
-- Validated paths: pending
-- Worktree identity command and result: pending
+- Tested implementation commit SHA: not applicable
+- Run at (UTC): not applicable
+- Exact command(s): not applicable
+- Result: not applicable
+- Validated paths: not applicable
+- Worktree identity command and result: not applicable
 - Evidence-only diff command and result (if applicable): not applicable
 - Evidence-only worktree-status command and result (if applicable): not applicable
 

--- a/.plans/active/public-garden-impact-api/handoffs/codex-contracts.md
+++ b/.plans/active/public-garden-impact-api/handoffs/codex-contracts.md
@@ -1,0 +1,36 @@
+# Public Garden Impact API - Contracts Handoff
+
+## Lane
+
+- Owner: Codex
+- Branch: set when work begins using `<type>/<work-description>`
+- Status: not applicable
+
+## Scope
+
+- No Solidity, ABI, deployment, broadcast, or release surface changes.
+
+## TDD Proof
+
+- RED: not applicable
+- GREEN: not applicable
+- Proof limit: `not_applicable` — no behavior in this lane changes.
+
+## Validation
+
+- Pending lane implementation.
+
+## Validation Receipt
+
+- Tested implementation commit SHA: pending
+- Run at (UTC): pending
+- Exact command(s): pending
+- Result: pending
+- Validated paths: pending
+- Worktree identity command and result: pending
+- Evidence-only diff command and result (if applicable): not applicable
+- Evidence-only worktree-status command and result (if applicable): not applicable
+
+## Risks / Blockers
+
+- Record blockers here before changing `status.json`.

--- a/.plans/active/public-garden-impact-api/handoffs/codex-contracts.md
+++ b/.plans/active/public-garden-impact-api/handoffs/codex-contracts.md
@@ -18,16 +18,16 @@
 
 ## Validation
 
-- Pending lane implementation.
+- Not applicable.
 
 ## Validation Receipt
 
-- Tested implementation commit SHA: pending
-- Run at (UTC): pending
-- Exact command(s): pending
-- Result: pending
-- Validated paths: pending
-- Worktree identity command and result: pending
+- Tested implementation commit SHA: not applicable
+- Run at (UTC): not applicable
+- Exact command(s): not applicable
+- Result: not applicable
+- Validated paths: not applicable
+- Worktree identity command and result: not applicable
 - Evidence-only diff command and result (if applicable): not applicable
 - Evidence-only worktree-status command and result (if applicable): not applicable
 

--- a/.plans/active/public-garden-impact-api/handoffs/codex-qa-pass-2.md
+++ b/.plans/active/public-garden-impact-api/handoffs/codex-qa-pass-2.md
@@ -1,0 +1,30 @@
+# Public Garden Impact API - QA Pass 2 Handoff
+
+## Lane
+
+- Owner: Codex
+- Branch: set when work begins using `<type>/<work-description>`
+- Status: blocked until QA Pass 1 completes
+
+## Scope
+
+- Review regressions, implementation edges, and validation evidence after QA Pass 1.
+
+## Validation
+
+- Pending QA pass.
+
+## Validation Receipt
+
+- Tested implementation commit SHA: pending
+- Run at (UTC): pending
+- Exact command(s): pending
+- Result: pending
+- Validated paths: pending
+- Worktree identity command and result: pending
+- Evidence-only diff command and result (if applicable): not applicable
+- Evidence-only worktree-status command and result (if applicable): not applicable
+
+## Risks / Blockers
+
+- Record blockers here before changing `status.json`.

--- a/.plans/active/public-garden-impact-api/handoffs/codex-state-api.md
+++ b/.plans/active/public-garden-impact-api/handoffs/codex-state-api.md
@@ -1,0 +1,63 @@
+# Public Garden Impact API - State/API Handoff
+
+## Lane
+
+- Owner: Codex
+- Branch: detached HEAD preserved as requested
+- Status: implementation and lane proof complete; terminal lane receipt pending commit authority
+
+## Scope
+
+- Added the versioned public contract, strict Shared readers and pure aggregator, Agent route,
+  route-local CORS, rate limiting, cache behavior, tests, and builder documentation.
+- No UI, deployment, dependency, lockfile, or environment-file changes were made.
+- Added the default reader to the existing Shared modules barrel and load it lazily from the Agent.
+  A direct Bun-runtime import proves the production composition path without changing the Shared
+  package export map. The governed seam registry remains unchanged and passes its integrity check.
+
+## TDD Proof
+
+- RED: the initial focused commands failed before the new modules existed. Deep-review regression
+  tests later failed on the name-derived Garden URL, minted-only certificate activity, and missing
+  `updatedAt` selection before the review fixes were applied.
+- GREEN: Shared public-contract/reader/aggregator proof passed 40 tests across 3 files; the Agent
+  impact-route proof passed 14 tests. A direct Bun-runtime import resolved the default reader through
+  the existing Shared modules export.
+- Proof limit: none recorded
+
+## Validation
+
+- Shared source and test typechecks: passed.
+- Agent source/test typechecks and the Agent build are blocked by an existing address-type mismatch
+  in the untouched Garden join-request source and tests. The impact-route type errors are resolved.
+- Full client suite: 110 files and 935 tests passed in both independent and pinned-checkpoint runs.
+- Full admin suite: 104 files and 774 tests passed in both independent and pinned-checkpoint runs.
+- Docs tests/build, source structure, format, lint, design guards, ontology, test quality, supply
+  chain, and Plan Hub validation passed.
+- The final pinned-toolchain quick checkpoint passed every independent check and exited only for the
+  same Garden join-request Agent typecheck failures.
+- Review-closure tests first reproduced dropped by-action partial data, per-schema Assessment
+  overfetch, and filtered unknown-certificate activity. The focused Shared suite then passed all 34
+  tests after the fixes.
+- Deep-review closure tests reproduced the name-derived Garden URL and minted-only Hypercert
+  activity timestamp before the fixes. They also added direct coverage for missing Assessment
+  schemas, equal-time Work ordering, cache expiration, and LRU eviction.
+
+## Validation Receipt
+
+- Tested implementation commit SHA: pending
+- Run at (UTC): pending
+- Exact command(s): pending
+- Result: pending
+- Validated paths: pending
+- Worktree identity command and result: pending
+- Evidence-only diff command and result (if applicable): not applicable
+- Evidence-only worktree-status command and result (if applicable): not applicable
+
+## Risks / Blockers
+
+- The lane remains `in_progress` and the Plan Hub remains active because the working tree is
+  intentionally uncommitted. A commit-attributed terminal receipt needs separate commit authority.
+- Repository-wide Agent typecheck/build proof requires the unrelated Garden join-request address
+  mismatch to be fixed in its owning scope.
+- Deployment and production curl verification remain later release work.

--- a/.plans/active/public-garden-impact-api/plan.todo.md
+++ b/.plans/active/public-garden-impact-api/plan.todo.md
@@ -1,0 +1,101 @@
+# Public Garden Impact API Plan
+
+**Feature Slug**: `public-garden-impact-api`
+**Stage**: `active`
+**Status**: `ACTIVE`
+**Created**: `2026-08-29T00:24:32.707Z`
+**Last Updated**: `2026-08-29T03:15:16Z`
+
+## Decision Log
+
+| # | Decision | Rationale |
+|---|---|---|
+| 1 | Use a separate `garden-impact` public contract | The existing `public-impact` type is a frontend evidence slice, not an HTTP response |
+| 2 | Keep aggregation pure and inject all source readers | Source failure and privacy behavior stay directly testable |
+| 3 | Add strict, bounded readers instead of reusing tolerant UI helpers | Empty results must remain distinguishable from provider failure and truncation |
+| 4 | Derive supported chains from direct deployment plus EAS endpoint data | Invalid chains must never fall back to another network |
+| 5 | Count every positive nonrevoked approval once per Work | This is the accepted protocol-approval meaning for this endpoint |
+| 6 | Represent missing schemas and failed sources as partial/null | Zero must mean a successful empty source |
+| 7 | Keep wildcard CORS inside the new route | Existing authenticated/protected public routes retain their allowlist |
+| 8 | Cache canonical 12-item snapshots after rate limiting | Limits remain effective and all request sizes share one bounded result |
+| 9 | Keep this hub repository-only | No Linear mirror was requested |
+
+## Implementation Notes
+
+- The default reader is exposed through the existing Shared `./modules` package export. The Agent
+  loads that barrel only when the route needs the default composition. A Bun-runtime import proof
+  covers the deployed runtime path without adding a package-map entry.
+- Review closure keeps by-action counts available when Action metadata fails, applies one shared
+  Assessment source ceiling across schema versions, uses Hypercert lifecycle updates for activity,
+  and returns a chain/address-stable impact resource URL.
+
+## Research / Plan Gate
+
+- [x] Record research evidence in `spec.md`
+- [x] Identify the existing repo pattern to mirror
+- [x] List human judgment points before implementation
+- [x] Define what is out of scope
+- [x] Choose targeted Shared/Agent tests, typechecks, source-structure proof, Plan Hub validation,
+  the repository quick gate, and Agent/docs builds
+
+## Requirements Coverage
+
+| Requirement | Lane | Planned Step | Status |
+|---|---|---|---|
+| Versioned public response and route contract | `state_api` | Add contract types, route builder, and exports | ✅ |
+| Strict source semantics and aggregation | `state_api` | Add readers, pure snapshot builder, and tests | ✅ |
+| Public Agent endpoint | `state_api` | Add validation, CORS, rate limiting, LRU cache, and integration tests | ✅ |
+| Builder documentation | `state_api` | Document the endpoint, source semantics, and operations | ✅ |
+| UI behavior | `ui` | Not applicable | ✅ |
+| Solidity/deployment behavior | `contracts` | Not applicable | ✅ |
+
+## TDD / Proof Order
+
+- [x] Identify the behavior boundary for the State/API lane before editing code
+- [x] Write or select the minimal failing test/proof first
+- [x] Run the RED command and record evidence in the lane handoff
+- [x] Implement the smallest change that can satisfy the proof
+- [x] Run the GREEN command and record evidence in the lane handoff
+- [x] Record machine-readable proof with `node scripts/harness/plan-hub.mjs record-tdd`
+- [ ] If TDD cannot honestly apply, record `not_applicable` or `proof_limit` with a concrete note in `status.json`
+
+## Lane Checklists
+
+### UI
+
+- [x] Marked not applicable; no UI, i18n, component, or browser-visible behavior changes.
+
+### State / API
+
+- [x] Add the dependency-light response contract and no-fallback support predicate.
+- [x] Add strict source readers and pure source-aware aggregation.
+- [x] Add the route-local CORS, rate limit, LRU cache, and HTTP status mapping.
+- [x] Add Shared and Agent direct tests before implementation and record RED/GREEN proof.
+- [x] Update API and Agent documentation.
+- [x] Record RED/GREEN proof or a proof-limit note before marking the lane complete
+- [x] Write `handoffs/codex-state-api.md`
+
+### Contracts
+
+- [x] Marked not applicable; no contract, ABI, deployment, broadcast, or release changes.
+
+### QA Pass 1
+
+- [ ] Verify `eval.md` behavior and regression criteria after State/API GREEN proof.
+
+### QA Pass 2
+
+- [ ] Review failure, recovery, privacy, caching, CORS, and source-cap edges.
+- [ ] Run every selector-chosen check and reconcile the hub.
+
+## Validation
+
+- [x] Targeted Shared and Agent tests pass.
+- [x] Shared source and test typechecks pass.
+- [ ] Agent source and test typechecks are blocked by pre-existing address-type errors in the
+  untouched Garden join-request source and tests.
+- [x] `bun run check:source-structure` passes.
+- [x] `node scripts/harness/plan-hub.mjs validate` passes.
+- [ ] `node scripts/dev/ci-local.js --quick` passes every independent check but exits at the same
+  Agent join-request type errors.
+- [ ] `bun run build:agent` is blocked by the same untouched error; `bun run build:docs` passes.

--- a/.plans/active/public-garden-impact-api/spec.md
+++ b/.plans/active/public-garden-impact-api/spec.md
@@ -18,7 +18,8 @@ validation, wildcard route CORS, rate limiting, caching, and safe error mapping.
 2. Treat any positive nonrevoked Work Approval as protocol approval; deduplicate Work and Approval
    UIDs and use the newest positive approval timestamp.
 3. Count deduplicated Hypercerts only in active, claimed, or sold states.
-4. Support only Arbitrum, Celo, and Sepolia through a no-fallback chain predicate.
+4. Support only Arbitrum and Sepolia through a no-fallback chain predicate. Keep Celo rejected until
+   the public indexer covers its Garden, Action, and Hypercert sources.
 5. Keep missing schemas and individual source failures explicit through nullable dependent fields
    and partial provenance; return 503 only when Garden resolution is unsafe or all primary impact
    sources are unusable.
@@ -35,9 +36,11 @@ validation, wildcard route CORS, rate limiting, caching, and safe error mapping.
 - Confirmed against the official EAS GraphQL documentation and checked-in schema types: supported
   chains expose chain-specific endpoints, and Attestation queries support bounded ordering and
   pagination without a client-side fallback.
-- Confirmed: Garden IDs are bare normalized addresses plus `chainId`; Action IDs are
+- Confirmed: indexer Garden IDs are bare normalized addresses and can collide across chains, so
+  Garden identity resolves from the chain-qualified token-bound account instead. Action IDs are
   `${chainId}-${actionUID}`; current Approval records cannot be joined reliably by recipient or
-  `refUID`; Celo lacks Approval and Assessment schema UIDs.
+  `refUID`; Celo lacks Approval and Assessment schema UIDs plus public Garden, Action, and Hypercert
+  indexer coverage.
 - Assumption: page each source in stable order with 100-record pages and fail the source closed when
   more than 1,000 records are detected.
 
@@ -74,7 +77,7 @@ validation, wildcard route CORS, rate limiting, caching, and safe error mapping.
 - Silent source truncation could undercount impact. Mitigation: detect the 1,001st row and mark the
   source unavailable.
 - Historical Approval recipients vary. Mitigation: page the schema, then join by exact Work UID.
-- Celo schema gaps could look like zero impact. Mitigation: nullable fields and unavailable-source
-  provenance.
+- Celo's absent indexer sources could look like zero impact. Mitigation: reject Celo until those
+  sources exist instead of advertising an incomplete chain.
 - Cache or CORS changes could weaken protected routes. Mitigation: route-local wildcard headers and
   regression coverage proving protected CORS is unchanged.

--- a/.plans/active/public-garden-impact-api/spec.md
+++ b/.plans/active/public-garden-impact-api/spec.md
@@ -1,0 +1,80 @@
+# Public Garden Impact API Spec
+
+## Summary
+
+Add `GET /public/gardens/:chainId/:gardenAddress/impact` as a read-only public aggregation boundary.
+The shared package owns the versioned response contract and source semantics. The Agent owns HTTP
+validation, wildcard route CORS, rate limiting, caching, and safe error mapping.
+
+## Users
+
+- Primary: public Green Goods web surfaces and partner integrations.
+- Secondary: maintainers and funders who need a stable, privacy-preserving garden impact summary.
+
+## Functional Requirements
+
+1. Return garden identity, nullable source-aware counts, domain/action breakdowns, approved recent
+   work, latest known activity, and provenance in `PublicGardenImpactResponseV1`.
+2. Treat any positive nonrevoked Work Approval as protocol approval; deduplicate Work and Approval
+   UIDs and use the newest positive approval timestamp.
+3. Count deduplicated Hypercerts only in active, claimed, or sold states.
+4. Support only Arbitrum, Celo, and Sepolia through a no-fallback chain predicate.
+5. Keep missing schemas and individual source failures explicit through nullable dependent fields
+   and partial provenance; return 503 only when Garden resolution is unsafe or all primary impact
+   sources are unusable.
+6. Expose GET/OPTIONS with route-only wildcard CORS, 120 requests per 10 minutes, and a bounded
+   five-minute per-server LRU cache.
+7. Never return gardener, steward, evaluator, assessor, or other wallet-role identities.
+
+## Research Evidence
+
+- Existing patterns: dependency-light contracts under `public-contracts`, injected Hono route
+  dependencies, `checkRateLimit`, `jsonNoStore`, `GQLClient`, and Plan Hub RED/GREEN receipts.
+- Reviewed: blockchain deployments/config, EAS parsing/readers, Envio Garden/Action/Hypercert
+  schemas and handlers, public garden visibility, current public API routes, and builder docs.
+- Confirmed against the official EAS GraphQL documentation and checked-in schema types: supported
+  chains expose chain-specific endpoints, and Attestation queries support bounded ordering and
+  pagination without a client-side fallback.
+- Confirmed: Garden IDs are bare normalized addresses plus `chainId`; Action IDs are
+  `${chainId}-${actionUID}`; current Approval records cannot be joined reliably by recipient or
+  `refUID`; Celo lacks Approval and Assessment schema UIDs.
+- Assumption: page each source in stable order with 100-record pages and fail the source closed when
+  more than 1,000 records are detected.
+
+## Human Judgment Points
+
+- Locked decisions: approval is the protocol flag only; missing schemas are partial/null; unknown
+  Hypercert states do not count.
+- Sensitive surfaces: Agent route behavior, public response types, provider failure handling,
+  source caps, rate limiting, and cache isolation.
+- Review tradeoff: approval counts describe protocol state; they do not assess submission quality
+  or independently validate supporting material.
+
+## Non-Functional Constraints
+
+- Package boundaries: aggregation and readers in Shared; HTTP behavior in Agent; no deep imports.
+- Performance: maximum 1,000 rows per source, five-minute cache, 100-garden LRU, in-flight load
+  coalescing, and a cached canonical 12-item recent-work list.
+- Security/privacy: validate chain/address/query inputs, apply rate limits to cache hits, return
+  generic provider errors, and omit actor identities.
+- Offline/sync: not applicable; this is a public network API.
+- Localization: not applicable; no UI copy or localized response content.
+
+## Package / Lane Mapping
+
+| Area | Lane | Notes |
+|---|---|---|
+| UI | `ui` | Not applicable; no rendered behavior |
+| State / API | `state_api` | Shared contract/readers/aggregation and Agent endpoint |
+| Contracts | `contracts` | Not applicable; no Solidity, ABI, or deployment work |
+| QA | `qa_pass_1`, `qa_pass_2` | Targeted Shared/Agent proof, then repository checkpoint |
+
+## Risks
+
+- Silent source truncation could undercount impact. Mitigation: detect the 1,001st row and mark the
+  source unavailable.
+- Historical Approval recipients vary. Mitigation: page the schema, then join by exact Work UID.
+- Celo schema gaps could look like zero impact. Mitigation: nullable fields and unavailable-source
+  provenance.
+- Cache or CORS changes could weaken protected routes. Mitigation: route-local wildcard headers and
+  regression coverage proving protected CORS is unchanged.

--- a/.plans/active/public-garden-impact-api/status.json
+++ b/.plans/active/public-garden-impact-api/status.json
@@ -1,0 +1,194 @@
+{
+  "version": 2,
+  "feature": {
+    "slug": "public-garden-impact-api",
+    "title": "Public Garden Impact API",
+    "kind": "feature",
+    "stage": "active"
+  },
+  "workflow": {
+    "overall_status": "active",
+    "priority": "p2",
+    "created_at": "2026-08-29T00:24:32.707Z",
+    "updated_at": "2026-08-29T03:15:48.344Z"
+  },
+  "links": {
+    "brief": "brief.md",
+    "spec": "spec.md",
+    "plan": "plan.todo.md",
+    "eval": "eval.md"
+  },
+  "linear": {
+    "parentIssue": null,
+    "project": null,
+    "initiative": null,
+    "syncDirection": "plans_to_linear_visibility",
+    "lastSyncedAt": null,
+    "lanes": {}
+  },
+  "taxonomy": {
+    "initiative": "engineering-quality",
+    "tracks": ["shared", "agent", "docs"],
+    "work_types": ["implementation"],
+    "surfaces": [
+      "packages/shared/src/public-contracts",
+      "packages/shared/src/modules/data",
+      "packages/agent/src/api",
+      "docs/docs/builders/packages",
+      ".plans/active/public-garden-impact-api"
+    ],
+    "depends_on_features": []
+  },
+  "notes": [
+    "Repository-only implementation: no Linear mirror or tracker write was requested.",
+    "The clean detached checkout is preserved; branch, commit, PR, deployment, and production proof are outside scope.",
+    "UI and contracts lanes are not applicable; behavior lives in the State/API lane.",
+    "The hub stays active because terminal status requires a clean commit-attributed validation receipt.",
+    "The Agent default loader dynamically uses the existing Shared modules export; the production Bun runtime import is covered directly and no package-map entry was added.",
+    "Review closure makes garden.url a chain/address-stable impact self-link and uses Hypercert updatedAt for lifecycle activity."
+  ],
+  "lanes": {
+    "ui": {
+      "owner": "claude",
+      "status": "n/a",
+      "branch": null,
+      "depends_on": [],
+      "handoff": "handoffs/claude-ui.md",
+      "tdd": {
+        "mode": "not_applicable",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": "No rendered UI, component, i18n, or browser-visible behavior changes."
+      },
+      "skill_tags": ["not-applicable"]
+    },
+    "state_api": {
+      "owner": "codex",
+      "status": "in_progress",
+      "branch": null,
+      "depends_on": [],
+      "handoff": "handoffs/codex-state-api.md",
+      "tdd": {
+        "mode": "required",
+        "status": "green_recorded",
+        "red": {
+          "command": "bun run --filter @green-goods/shared test -- src/__tests__/public-garden-impact.test.ts src/__tests__/public-garden-impact-readers.test.ts",
+          "evidence": "Deep-review regression tests failed in three expected places before source edits: name-derived Garden URL, minted-only certificate activity, and missing updatedAt in the Hypercert query."
+        },
+        "green": {
+          "command": "bun run test src/__tests__/public-contracts.test.ts src/__tests__/public-garden-impact-readers.test.ts src/__tests__/public-garden-impact.test.ts (Shared); bun run test src/__tests__/public-garden-impact-api.test.ts (Agent)",
+          "evidence": "Shared passed 3 files and 40 tests; Agent passed 1 file and 14 tests. A direct Bun import also resolved readPublicGardenImpactSnapshot through the existing @green-goods/shared/modules export."
+        },
+        "note": ""
+      },
+      "skill_tags": ["public-api", "data-layer", "agent"],
+      "manual_blocked": false
+    },
+    "contracts": {
+      "owner": "codex",
+      "status": "n/a",
+      "branch": null,
+      "depends_on": [],
+      "handoff": "handoffs/codex-contracts.md",
+      "tdd": {
+        "mode": "not_applicable",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": "No Solidity, ABI, deployment, broadcast, or release surface changes."
+      },
+      "skill_tags": ["not-applicable"]
+    },
+    "qa_pass_1": {
+      "owner": "claude",
+      "status": "blocked",
+      "ready_when_dependencies_met": true,
+      "manual_blocked": false,
+      "branch": null,
+      "depends_on": ["ui", "state_api", "contracts"],
+      "handoff": "handoffs/claude-qa-pass-1.md",
+      "skill_tags": ["testing", "review"]
+    },
+    "qa_pass_2": {
+      "owner": "codex",
+      "status": "blocked",
+      "ready_when_dependencies_met": true,
+      "manual_blocked": false,
+      "branch": null,
+      "depends_on": ["qa_pass_1"],
+      "handoff": "handoffs/codex-qa-pass-2.md",
+      "skill_tags": ["testing", "review"]
+    }
+  },
+  "history": [
+    {
+      "timestamp": "2026-08-29T00:24:32.744Z",
+      "actor": "human",
+      "lane": "system",
+      "status": "scaffolded",
+      "branch": null,
+      "note": "Scaffolded feature hub in active"
+    },
+    {
+      "timestamp": "2026-08-29T00:24:43.000Z",
+      "actor": "codex",
+      "lane": "state_api",
+      "status": "in_progress",
+      "branch": null,
+      "note": "Locked the public impact API contract, source semantics, cache and rate-limit behavior, and repository-only scope before implementation."
+    },
+    {
+      "timestamp": "2026-08-29T00:58:38.785Z",
+      "actor": "codex",
+      "lane": "state_api",
+      "status": "tdd_recorded",
+      "branch": null,
+      "note": "Recorded RED/GREEN TDD proof"
+    },
+    {
+      "timestamp": "2026-08-29T01:09:30.615Z",
+      "actor": "codex",
+      "lane": "state_api",
+      "status": "in_progress",
+      "branch": null,
+      "note": "Implementation, RED/GREEN proof, and selected validation are complete. Lane stays in progress because the detached working tree is intentionally uncommitted and terminal receipt evidence requires separate commit authority."
+    },
+    {
+      "timestamp": "2026-08-29T02:06:53.101Z",
+      "actor": "codex",
+      "lane": "state_api",
+      "status": "tdd_recorded",
+      "branch": null,
+      "note": "Recorded RED/GREEN TDD proof"
+    },
+    {
+      "timestamp": "2026-08-29T03:06:30.362Z",
+      "actor": "codex",
+      "lane": "state_api",
+      "status": "tdd_recorded",
+      "branch": null,
+      "note": "Recorded RED/GREEN TDD proof"
+    },
+    {
+      "timestamp": "2026-08-29T03:15:48.344Z",
+      "actor": "codex",
+      "lane": "state_api",
+      "status": "in_progress",
+      "branch": null,
+      "note": "Deep-review fixes and direct behavior proof are complete. The pinned quick gate passes every independent check; Agent source/test typechecks and build remain blocked only by pre-existing Garden join-request address-type errors outside this lane."
+    }
+  ]
+}

--- a/.plans/active/public-garden-impact-api/status.json
+++ b/.plans/active/public-garden-impact-api/status.json
@@ -41,7 +41,7 @@
   },
   "notes": [
     "Repository-only implementation: no Linear mirror or tracker write was requested.",
-    "The clean detached checkout is preserved; branch, commit, PR, deployment, and production proof are outside scope.",
+    "Implementation is tracked by PR 782 on feature/review-garden-impact-api-plan; deployment and production proof remain outside scope.",
     "UI and contracts lanes are not applicable; behavior lives in the State/API lane.",
     "The hub stays active because terminal status requires a clean commit-attributed validation receipt.",
     "The Agent default loader dynamically uses the existing Shared modules export; the production Bun runtime import is covered directly and no package-map entry was added.",
@@ -83,8 +83,8 @@
           "evidence": "Deep-review regression tests failed in three expected places before source edits: name-derived Garden URL, minted-only certificate activity, and missing updatedAt in the Hypercert query."
         },
         "green": {
-          "command": "bun run test src/__tests__/public-contracts.test.ts src/__tests__/public-garden-impact-readers.test.ts src/__tests__/public-garden-impact.test.ts (Shared); bun run test src/__tests__/public-garden-impact-api.test.ts (Agent)",
-          "evidence": "Shared passed 3 files and 40 tests; Agent passed 1 file and 14 tests. A direct Bun import also resolved readPublicGardenImpactSnapshot through the existing @green-goods/shared/modules export."
+          "command": "bun run --filter @green-goods/shared test -- src/__tests__/public-contracts.test.ts src/__tests__/public-garden-impact-readers.test.ts src/__tests__/public-garden-impact.test.ts && bun run --filter @green-goods/agent test -- src/__tests__/public-garden-impact-api.test.ts src/__tests__/garden-join-requests.api.test.ts",
+          "evidence": "Shared passed 3 files and 40 tests; Agent passed 2 files and 35 tests. Each invocation records its package filter and contains no non-shell labels. A direct Bun import also resolved readPublicGardenImpactSnapshot through the existing @green-goods/shared/modules export."
         },
         "note": ""
       },

--- a/docs/docs/builders/packages/agent.mdx
+++ b/docs/docs/builders/packages/agent.mdx
@@ -4,12 +4,13 @@ sidebar_label: Agent
 slug: /builders/packages/agent
 audience: developer
 owner: docs
-last_verified: 2026-04-19
+last_verified: 2026-08-28
 feature_status: Live
 source_of_truth:
   - packages/agent/AGENTS.md
   - packages/agent/package.json
   - packages/agent/src/index.ts
+  - packages/agent/src/api/routes/public-garden-impact.ts
   - packages/agent/README.md
 ---
 
@@ -48,6 +49,39 @@ Bot, webhook, and limited public API service for Green Goods. The current packag
 - AI-assisted transcription/photo/text processing paths.
 - Rate limiting, database integration, analytics, and structured logging.
 - Blockchain service initialization for Green Goods transaction flows.
+- A versioned, read-only public garden impact aggregation route.
+
+## Public garden impact route
+
+```http
+GET /public/gardens/11155111/0x1111111111111111111111111111111111111111/impact?recentLimit=3
+```
+
+The response contains the public garden identity, nullable source-aware totals, domain and action
+breakdowns, recent protocol-approved Work, and provenance. It excludes gardener, steward,
+evaluator, assessor, and other role addresses.
+
+`garden.url` is the canonical impact-resource URL for the resolved chain and checksummed Garden
+address. It is not derived from the Garden name, so duplicate names and cross-chain Gardens remain
+distinct.
+
+The route behaves as follows:
+
+- `GET` and `OPTIONS` allow any origin without credentials. This wildcard policy is local to the
+  impact route; other public APIs keep their configured origin allowlist.
+- Requests are limited to 120 per 10 minutes using the existing public IP, origin, and garden
+  material buckets. Cache hits count toward the limit; preflight requests do not.
+- Successful snapshots use a five-minute, 100-garden in-process LRU cache. The Agent loads up to 12
+  recent items once and slices the cached result for each request.
+- A 200 response uses
+  `public, max-age=60, s-maxage=300, stale-while-revalidate=86400`. Errors use `no-store`.
+- Invalid or unsupported targets return 400, hidden and missing gardens share a generic 404,
+  exhausted rate limits return 429, and an unsafe provider result returns 503.
+
+`provenance.status: "partial"` means at least one source is unavailable. Fields that depend on that
+source are `null`; successful empty sources remain zero. Celo therefore reports missing Approval or
+Assessment schema data as partial until those schemas are configured. The implementation does not
+deploy the Agent or provide production URL proof.
 
 ## What to expect
 

--- a/docs/docs/builders/packages/agent.mdx
+++ b/docs/docs/builders/packages/agent.mdx
@@ -69,8 +69,8 @@ The route behaves as follows:
 
 - `GET` and `OPTIONS` allow any origin without credentials. This wildcard policy is local to the
   impact route; other public APIs keep their configured origin allowlist.
-- Requests are limited to 120 per 10 minutes using the existing public IP, origin, and garden
-  material buckets. Cache hits count toward the limit; preflight requests do not.
+- Requests are limited to 120 per 10 minutes using origin-independent IP and garden material
+  buckets. Cache hits count toward the limit; preflight requests do not.
 - Successful snapshots use a five-minute, 100-garden in-process LRU cache. The Agent loads up to 12
   recent items once and slices the cached result for each request.
 - A 200 response uses
@@ -79,8 +79,8 @@ The route behaves as follows:
   exhausted rate limits return 429, and an unsafe provider result returns 503.
 
 `provenance.status: "partial"` means at least one source is unavailable. Fields that depend on that
-source are `null`; successful empty sources remain zero. Celo therefore reports missing Approval or
-Assessment schema data as partial until those schemas are configured. The implementation does not
+source are `null`; successful empty sources remain zero. Arbitrum and Sepolia are supported. Celo is
+rejected until its Garden, Action, and Hypercert sources are indexed. The implementation does not
 deploy the Agent or provide production URL proof.
 
 ## What to expect

--- a/docs/docs/builders/packages/api-index.mdx
+++ b/docs/docs/builders/packages/api-index.mdx
@@ -3,7 +3,7 @@ title: API Index
 slug: /builders/packages/api-index
 audience: developer
 owner: docs
-last_verified: 2026-02-18
+last_verified: 2026-08-28
 feature_status: Live
 goal: "Locate canonical endpoints and schema sources without ambiguity."
 difficulty: "advanced"
@@ -14,6 +14,8 @@ persona_context: "Developers and maintainers building, operating, and validating
 source_of_truth:
   - docs/src/data/endpoints.ts
   - packages/indexer/config.yaml
+  - packages/shared/src/public-contracts/garden-impact.ts
+  - packages/agent/src/api/routes/public-garden-impact.ts
   - packages/contracts/deployments/42161-latest.json
 ---
 
@@ -38,15 +40,37 @@ import {INDEXER_ENDPOINT, EAS_GRAPHQL_ENDPOINTS} from "@site/src/data/endpoints"
 - `packages/contracts/deployments/11155111-latest.json`
 - `packages/contracts/config/schemas.json` (read-only source)
 
+## Public garden impact
+
+`GET /public/gardens/:chainId/:gardenAddress/impact?recentLimit=3`
+
+The Agent aggregates one publicly visible garden's Work, Work Approval, Action, Assessment, and
+Hypercert records. The response contract is versioned independently from the frontend impact
+archive. Supported chains are Arbitrum (`42161`), Celo (`42220`), and Sepolia (`11155111`). Values
+above 12 for `recentLimit` are clamped to 12.
+
+The response's `garden.url` is a canonical self-link keyed by chain ID and checksummed Garden
+address. Consumers should use it instead of deriving an identity URL from the nullable Garden name.
+
+An approved Work count means **protocol-approved**: at least one positive, nonrevoked Work Approval
+exists. It does not assess submission quality or independently validate the supporting material.
+
+Counts are `null` when their required source or schema is unavailable. Check `provenance.status`,
+`partialData`, and `unavailableSources` before interpreting a partial response. A successful empty
+source returns zero instead. The endpoint is implemented in the Agent source; deploying it is a
+separate release step.
+
 ## Shared package integration entry points
 
 - `packages/shared/src/modules/data/eas.ts`
+- `packages/shared/src/modules/data/public-garden-impact-readers.ts`
 - `packages/shared/src/hooks/index.ts`
 
 ## Notes
 
 1. Always select chain context before querying schema-scoped data.
 2. Work and approval schema IDs must come from deployment artifacts for the same chain.
+3. Do not substitute an unsupported chain with a default chain when resolving public impact.
 
 <NextBestAction
   title="Next best action"

--- a/docs/docs/builders/packages/api-index.mdx
+++ b/docs/docs/builders/packages/api-index.mdx
@@ -46,11 +46,14 @@ import {INDEXER_ENDPOINT, EAS_GRAPHQL_ENDPOINTS} from "@site/src/data/endpoints"
 
 The Agent aggregates one publicly visible garden's Work, Work Approval, Action, Assessment, and
 Hypercert records. The response contract is versioned independently from the frontend impact
-archive. Supported chains are Arbitrum (`42161`), Celo (`42220`), and Sepolia (`11155111`). Values
+archive. Supported chains are Arbitrum (`42161`) and Sepolia (`11155111`). Celo (`42220`) remains
+unsupported until its public Garden, Action, and Hypercert indexer sources are available. Values
 above 12 for `recentLimit` are clamped to 12.
 
 The response's `garden.url` is a canonical self-link keyed by chain ID and checksummed Garden
-address. Consumers should use it instead of deriving an identity URL from the nullable Garden name.
+address. Garden identity is verified against the chain's token-bound account registry, so the same
+address on another chain cannot resolve through an indexer collision. Consumers should use the URL
+instead of deriving an identity from the nullable Garden name.
 
 An approved Work count means **protocol-approved**: at least one positive, nonrevoked Work Approval
 exists. It does not assess submission quality or independently validate the supporting material.

--- a/packages/agent/src/__tests__/garden-join-requests.api.test.ts
+++ b/packages/agent/src/__tests__/garden-join-requests.api.test.ts
@@ -3,8 +3,8 @@ import {
   type GardenJoinProofAction,
   type GardenJoinProofEnvelope,
 } from "@green-goods/shared/public-contracts/join-requests";
+import type { Address } from "@green-goods/shared/public-contracts";
 import { describe, expect, it, vi } from "vitest";
-import type { Address } from "viem";
 import { InMemoryPublicRateLimiter } from "../api/public-protection";
 import { createServer } from "../api/server";
 import { MemoryGardenJoinRequestStore } from "../services/garden-join-request-memory-store";
@@ -563,7 +563,7 @@ describe("garden join request public API", () => {
     const accepted = await submitForGarden(
       app,
       GARDEN,
-      `0x${"99".padStart(40, "0")}`,
+      `0x${"99".padStart(40, "0")}` as Address,
       ORIGIN,
       "198.51.100.99"
     );
@@ -590,7 +590,7 @@ describe("garden join request public API", () => {
     const accepted = await submitForGarden(
       app,
       GARDEN,
-      `0x${"fe".padStart(40, "0")}`,
+      `0x${"fe".padStart(40, "0")}` as Address,
       ORIGIN,
       "203.0.113.99"
     );

--- a/packages/agent/src/__tests__/public-garden-impact-api.test.ts
+++ b/packages/agent/src/__tests__/public-garden-impact-api.test.ts
@@ -1,0 +1,226 @@
+import {
+  buildPublicGardenImpactPath,
+  PUBLIC_AGENT_ROUTES,
+  type Address,
+  type PublicGardenImpactResponseV1,
+} from "@green-goods/shared/public-contracts";
+import { Hono } from "hono";
+import { getAddress } from "viem";
+import { describe, expect, it, vi } from "vitest";
+import { createServer } from "../api/server";
+import { InMemoryPublicRateLimiter } from "../api/public-protection";
+import {
+  PublicGardenImpactCache,
+  registerPublicGardenImpactRoutes,
+} from "../api/routes/public-garden-impact";
+
+const gardenAddress = getAddress("0x1111111111111111111111111111111111111111") as Address;
+const route = buildPublicGardenImpactPath(11155111, gardenAddress);
+const fetchedAt = "2026-08-28T12:00:00.000Z";
+
+function snapshot(recentCount = 12): PublicGardenImpactResponseV1 {
+  return {
+    version: 1,
+    ok: true,
+    garden: {
+      chainId: 11155111,
+      address: gardenAddress,
+      name: "Sun Garden",
+      location: "Lisbon",
+      url: `https://agent.greengoods.app${route}`,
+    },
+    summary: {
+      submittedWorkCount: recentCount,
+      approvedWorkCount: recentCount,
+      assessmentCount: 1,
+      impactCertificateCount: 1,
+      latestKnownActivityAt: fetchedAt,
+    },
+    breakdown: { byDomain: [], byAction: [] },
+    recentWork: Array.from({ length: recentCount }, (_, index) => ({
+      id: `0xwork-${index}`,
+      title: `Work ${index}`,
+      description: null,
+      media: [],
+      actionUid: index,
+      action: null,
+      createdAt: fetchedAt,
+      approvedAt: fetchedAt,
+    })),
+    provenance: {
+      status: "ready",
+      partialData: false,
+      unavailableSources: [],
+      fetchedAt,
+    },
+  };
+}
+
+function deps(loader = vi.fn(async () => snapshot())) {
+  return {
+    isAIReady: () => true,
+    publicRateLimiter: new InMemoryPublicRateLimiter(),
+    publicGardenImpactChainSupported: (chainId: number) => chainId === 11155111,
+    publicGardenImpactLoader: loader,
+    fundingSweepIntervalMs: 0,
+    chatMessageSweepIntervalMs: 0,
+    gardenJoinRequestSweepIntervalMs: 0,
+  };
+}
+
+describe("public garden impact API", () => {
+  it("registers the concrete route and slices one canonical cached snapshot", async () => {
+    const loader = vi.fn(async () => snapshot());
+    const app = createServer(deps(loader));
+
+    const first = await app.request(`${route}?recentLimit=1`, {
+      headers: { origin: "https://partner.example" },
+    });
+    const second = await app.request(`${route}?recentLimit=2`, {
+      headers: { origin: "https://another.example" },
+    });
+
+    expect(first.status).toBe(200);
+    expect((await first.json()).recentWork).toHaveLength(1);
+    expect((await second.json()).recentWork).toHaveLength(2);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(loader).toHaveBeenCalledWith({
+      chainId: 11155111,
+      gardenAddress,
+      recentLimit: 12,
+    });
+    expect(first.headers.get("access-control-allow-origin")).toBe("*");
+    expect(first.headers.get("cache-control")).toBe(
+      "public, max-age=60, s-maxage=300, stale-while-revalidate=86400"
+    );
+  });
+
+  it("handles arbitrary-origin preflight without opening protected routes", async () => {
+    const app = createServer({ ...deps(), allowedOrigins: new Set(["https://greengoods.app"]) });
+    const preflight = await app.request(PUBLIC_AGENT_ROUTES.gardenImpact, {
+      method: "OPTIONS",
+      headers: { origin: "https://partner.example" },
+    });
+    const protectedPreflight = await app.request(PUBLIC_AGENT_ROUTES.subscribe, {
+      method: "OPTIONS",
+      headers: { origin: "https://partner.example" },
+    });
+
+    expect(preflight.status).toBe(204);
+    expect(preflight.headers.get("access-control-allow-origin")).toBe("*");
+    expect(preflight.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+    expect(preflight.headers.get("vary")).toBeNull();
+    expect(protectedPreflight.status).toBe(403);
+  });
+
+  it.each([
+    ["/public/gardens/not-a-chain/0x1111111111111111111111111111111111111111/impact", 400],
+    ["/public/gardens/1/0x1111111111111111111111111111111111111111/impact", 400],
+    ["/public/gardens/11155111/not-an-address/impact", 400],
+    [`${route}?recentLimit=0`, 400],
+    [`${route}?recentLimit=1&recentLimit=2`, 400],
+  ])("rejects invalid input at %s", async (path, status) => {
+    const response = await createServer(deps()).request(path, {
+      headers: { origin: "https://partner.example" },
+    });
+    expect(response.status).toBe(status);
+    expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect((await response.json()).errorCode).toBe("invalid_request");
+  });
+
+  it("clamps oversized positive integer limits to twelve", async () => {
+    const response = await createServer(deps()).request(`${route}?recentLimit=999999999999999999`);
+    expect(response.status).toBe(200);
+    expect((await response.json()).recentWork).toHaveLength(12);
+  });
+
+  it("maps missing and provider failures to safe public errors", async () => {
+    const missingError = new Error("missing");
+    missingError.name = "PublicGardenImpactNotFoundError";
+    const providerError = new Error("unavailable");
+    providerError.name = "PublicGardenImpactProviderError";
+    const missing = createServer(deps(vi.fn(async () => Promise.reject(missingError))));
+    const failed = createServer(deps(vi.fn(async () => Promise.reject(providerError))));
+
+    const missingResponse = await missing.request(route);
+    const failedResponse = await failed.request(route);
+    expect(missingResponse.status).toBe(404);
+    expect((await missingResponse.json()).errorCode).toBe("not_found");
+    expect(failedResponse.status).toBe(503);
+    expect((await failedResponse.json()).errorCode).toBe("provider_unavailable");
+  });
+
+  it("rate-limits cached reads after 120 requests and skips OPTIONS", async () => {
+    const app = createServer(deps());
+    for (let index = 0; index < 120; index++) {
+      expect((await app.request(route)).status).toBe(200);
+    }
+    const limited = await app.request(route);
+    const preflight = await app.request(PUBLIC_AGENT_ROUTES.gardenImpact, { method: "OPTIONS" });
+    expect(limited.status).toBe(429);
+    expect((await limited.json()).errorCode).toBe("rate_limited");
+    expect(preflight.status).toBe(204);
+  });
+
+  it("coalesces concurrent loads and removes a failed pending entry", async () => {
+    let resolveLoad: ((value: PublicGardenImpactResponseV1) => void) | undefined;
+    const loader = vi
+      .fn<() => Promise<PublicGardenImpactResponseV1>>()
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveLoad = resolve;
+          })
+      );
+    const app = createServer(deps(loader));
+
+    expect((await app.request(route)).status).toBe(503);
+    const first = app.request(route);
+    const second = app.request(route);
+    await vi.waitFor(() => expect(loader).toHaveBeenCalledTimes(2));
+    resolveLoad?.(snapshot());
+    expect((await first).status).toBe(200);
+    expect((await second).status).toBe(200);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it("expires completed entries after the configured TTL", async () => {
+    let now = 0;
+    const cache = new PublicGardenImpactCache({ now: () => now, ttlMs: 10, maxEntries: 3 });
+    const loadA = vi.fn(async () => snapshot(1));
+
+    await cache.get("a", loadA);
+    now = 9;
+    await cache.get("a", loadA);
+    expect(loadA).toHaveBeenCalledTimes(1);
+
+    now = 10;
+    await cache.get("a", loadA);
+    expect(loadA).toHaveBeenCalledTimes(2);
+  });
+
+  it("evicts the least recently used completed value", async () => {
+    let now = 0;
+    const cache = new PublicGardenImpactCache({ now: () => now, ttlMs: 100, maxEntries: 2 });
+    const loadA = vi.fn(async () => snapshot(1));
+    const loadB = vi.fn(async () => snapshot(2));
+    const loadC = vi.fn(async () => snapshot(3));
+
+    await cache.get("a", loadA);
+    await cache.get("b", loadB);
+    await cache.get("a", loadA);
+    await cache.get("c", loadC);
+    await cache.get("b", loadB);
+    expect(loadA).toHaveBeenCalledTimes(1);
+    expect(loadB).toHaveBeenCalledTimes(2);
+    expect(loadC).toHaveBeenCalledTimes(1);
+  });
+
+  it("can be registered directly as a bounded route module", async () => {
+    const app = new Hono();
+    registerPublicGardenImpactRoutes(app, { deps: deps() });
+    expect((await app.request(route)).status).toBe(200);
+  });
+});

--- a/packages/agent/src/__tests__/public-garden-impact-api.test.ts
+++ b/packages/agent/src/__tests__/public-garden-impact-api.test.ts
@@ -163,6 +163,31 @@ describe("public garden impact API", () => {
     expect(preflight.status).toBe(204);
   });
 
+  it("rate-limits one client IP across caller-controlled origins", async () => {
+    const app = createServer({
+      ...deps(),
+      trustedProxy: { allowTestSocketIp: true },
+    });
+    for (let index = 0; index < 120; index++) {
+      const response = await app.request(route, {
+        headers: {
+          origin: `https://partner-${index}.example`,
+          "x-gg-test-socket-ip": "198.51.100.10",
+        },
+      });
+      expect(response.status).toBe(200);
+    }
+    const limited = await app.request(route, {
+      headers: {
+        origin: "https://partner-120.example",
+        "x-gg-test-socket-ip": "198.51.100.10",
+      },
+    });
+
+    expect(limited.status).toBe(429);
+    expect((await limited.json()).errorCode).toBe("rate_limited");
+  });
+
   it("coalesces concurrent loads and removes a failed pending entry", async () => {
     let resolveLoad: ((value: PublicGardenImpactResponseV1) => void) | undefined;
     const loader = vi

--- a/packages/agent/src/api/http/public.ts
+++ b/packages/agent/src/api/http/public.ts
@@ -60,7 +60,8 @@ export function checkRateLimitWithPolicy(
     route === "join_request_create" ||
     route === "join_request_read" ||
     route === "join_request_resolve";
-  if (isJoinRequestRoute) {
+  const usesOriginIndependentKeys = isJoinRequestRoute || route === "garden_impact_read";
+  if (usesOriginIndependentKeys) {
     const aggregateRoute = route === "join_request_create" ? "join_request_create_ip" : route;
     const aggregateIpResult = limiter.check(
       publicIpMaterialRateLimitKey({
@@ -93,7 +94,7 @@ export function checkRateLimitWithPolicy(
       });
     }
   }
-  const key = isJoinRequestRoute
+  const key = usesOriginIndependentKeys
     ? publicIpMaterialRateLimitKey({
         route,
         request: c.req.raw,

--- a/packages/agent/src/api/http/server.types.ts
+++ b/packages/agent/src/api/http/server.types.ts
@@ -1,5 +1,7 @@
 import type {
   createProviderProofRegistry,
+  Address,
+  PublicGardenImpactResponseV1,
   PublicUploadSignRequest,
 } from "@green-goods/shared/public-contracts";
 import type { Hono } from "hono";
@@ -60,6 +62,12 @@ export interface ServerDeps {
   /** Defaults to 30 days. */
   chatMessageRetentionMs?: number;
   publicRateLimiter?: InMemoryPublicRateLimiter;
+  publicGardenImpactChainSupported?: (chainId: number) => boolean;
+  publicGardenImpactLoader?: (input: {
+    chainId: number;
+    gardenAddress: Address;
+    recentLimit: number;
+  }) => Promise<PublicGardenImpactResponseV1>;
   providerProofRegistry?: ReturnType<typeof createProviderProofRegistry>;
   allowedOrigins?: Set<string>;
   trustedProxy?: TrustedProxyConfig;

--- a/packages/agent/src/api/public-protection.ts
+++ b/packages/agent/src/api/public-protection.ts
@@ -6,6 +6,7 @@ export type PublicRouteClass =
   | "funding_create"
   | "funding_proof"
   | "receipt_read"
+  | "garden_impact_read"
   | "upload_sign"
   | "profile_avatar_read"
   | "profile_avatar_mutation"
@@ -51,6 +52,7 @@ export const PUBLIC_RATE_LIMIT_POLICIES = {
   funding_create: { limit: 10, windowMs: 10 * 60 * 1000 },
   funding_proof: { limit: 10, windowMs: 10 * 60 * 1000 },
   receipt_read: { limit: 60, windowMs: 10 * 60 * 1000 },
+  garden_impact_read: { limit: 120, windowMs: 10 * 60 * 1000 },
   upload_sign: { limit: 20, windowMs: 60 * 1000 },
   profile_avatar_read: { limit: 120, windowMs: 10 * 60 * 1000 },
   profile_avatar_mutation: { limit: 10, windowMs: 10 * 60 * 1000 },

--- a/packages/agent/src/api/routes/garden-join-request-auth.ts
+++ b/packages/agent/src/api/routes/garden-join-request-auth.ts
@@ -7,7 +7,7 @@ import {
   type GardenJoinProofEnvelope,
   type GardenJoinRequestApiErrorCode,
 } from "@green-goods/shared/public-contracts/join-requests";
-import type { Address } from "@green-goods/shared/types";
+import type { Address } from "@green-goods/shared/public-contracts";
 import type { Context } from "hono";
 import type { GardenJoinRequestStore } from "../../services/garden-join-requests";
 import { checkOrigin, publicBrowserCorsResponse } from "../http/public";

--- a/packages/agent/src/api/routes/public-garden-impact.ts
+++ b/packages/agent/src/api/routes/public-garden-impact.ts
@@ -1,0 +1,213 @@
+import { isPublicGardenImpactChainSupported } from "@green-goods/shared/config/blockchain";
+import {
+  PUBLIC_AGENT_ROUTES,
+  PUBLIC_GARDEN_IMPACT_DEFAULT_RECENT_LIMIT,
+  PUBLIC_GARDEN_IMPACT_MAX_RECENT_LIMIT,
+  type Address,
+  type PublicGardenImpactResponseV1,
+} from "@green-goods/shared/public-contracts";
+import type { Context, Hono } from "hono";
+import { getAddress } from "viem";
+import { checkRateLimit } from "../http/public";
+import { jsonNoStore, safeError } from "../http/responses";
+import type { ServerDeps } from "../http/server.types";
+
+const SUCCESS_CACHE_CONTROL = "public, max-age=60, s-maxage=300, stale-while-revalidate=86400";
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const CACHE_MAX_GARDENS = 100;
+
+interface CacheEntry {
+  expiresAt: number;
+  value?: PublicGardenImpactResponseV1;
+  pending?: Promise<PublicGardenImpactResponseV1>;
+}
+
+export class PublicGardenImpactCache {
+  private readonly entries = new Map<string, CacheEntry>();
+  private readonly now: () => number;
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+
+  constructor(options: { now?: () => number; ttlMs?: number; maxEntries?: number } = {}) {
+    this.now = options.now ?? Date.now;
+    this.ttlMs = options.ttlMs ?? CACHE_TTL_MS;
+    this.maxEntries = options.maxEntries ?? CACHE_MAX_GARDENS;
+  }
+
+  async get(
+    key: string,
+    load: () => Promise<PublicGardenImpactResponseV1>
+  ): Promise<PublicGardenImpactResponseV1> {
+    const existing = this.entries.get(key);
+    if (existing?.pending) {
+      this.touch(key, existing);
+      return existing.pending;
+    }
+    if (existing?.value && existing.expiresAt > this.now()) {
+      this.touch(key, existing);
+      return existing.value;
+    }
+    if (existing) this.entries.delete(key);
+
+    const pending = load();
+    this.entries.set(key, { expiresAt: Number.POSITIVE_INFINITY, pending });
+    this.trim();
+    try {
+      const value = await pending;
+      const current = this.entries.get(key);
+      if (current?.pending === pending) {
+        this.touch(key, { value, expiresAt: this.now() + this.ttlMs });
+      }
+      return value;
+    } catch (error) {
+      if (this.entries.get(key)?.pending === pending) this.entries.delete(key);
+      throw error;
+    }
+  }
+
+  private touch(key: string, entry: CacheEntry): void {
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+  }
+
+  private trim(): void {
+    while (this.entries.size > this.maxEntries) {
+      const oldestKey = this.entries.keys().next().value;
+      if (typeof oldestKey !== "string") return;
+      this.entries.delete(oldestKey);
+    }
+  }
+}
+
+interface PublicGardenImpactRouteContext {
+  deps: ServerDeps;
+}
+
+function setCors(c: Context): void {
+  c.header("Access-Control-Allow-Origin", "*");
+  c.header("Access-Control-Allow-Methods", "GET, OPTIONS");
+  c.header("Access-Control-Allow-Headers", "Content-Type");
+  c.header("Access-Control-Max-Age", "600");
+}
+
+function publicError(
+  c: Context,
+  errorCode: "invalid_request" | "not_found" | "rate_limited" | "provider_unavailable",
+  message: string,
+  status: 400 | 404 | 429 | 503,
+  body = safeError(errorCode, message)
+) {
+  setCors(c);
+  return jsonNoStore(c, body, status);
+}
+
+function parsePositiveInteger(value: string): number | null {
+  if (!/^[1-9]\d*$/.test(value)) return null;
+  const parsed = BigInt(value);
+  return parsed <= BigInt(Number.MAX_SAFE_INTEGER) ? Number(parsed) : null;
+}
+
+function parseRecentLimit(c: Context): number | null {
+  const values = new URL(c.req.url).searchParams.getAll("recentLimit");
+  if (values.length === 0) return PUBLIC_GARDEN_IMPACT_DEFAULT_RECENT_LIMIT;
+  if (values.length !== 1 || !/^[1-9]\d*$/.test(values[0] ?? "")) return null;
+  const parsed = BigInt(values[0] ?? "0");
+  return parsed > BigInt(PUBLIC_GARDEN_IMPACT_MAX_RECENT_LIMIT)
+    ? PUBLIC_GARDEN_IMPACT_MAX_RECENT_LIMIT
+    : Number(parsed);
+}
+
+function parseTarget(
+  c: Context,
+  deps: ServerDeps
+): {
+  chainId: number;
+  gardenAddress: Address;
+  recentLimit: number;
+} | null {
+  const chainId = parsePositiveInteger(c.req.param("chainId") ?? "");
+  const recentLimit = parseRecentLimit(c);
+  if (chainId === null || recentLimit === null) return null;
+  const supportsChain = deps.publicGardenImpactChainSupported ?? isPublicGardenImpactChainSupported;
+  if (!supportsChain(chainId)) return null;
+  try {
+    return {
+      chainId,
+      gardenAddress: getAddress(c.req.param("gardenAddress") ?? "") as Address,
+      recentLimit,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function defaultLoader(input: {
+  chainId: number;
+  gardenAddress: Address;
+  recentLimit: number;
+}): Promise<PublicGardenImpactResponseV1> {
+  return import("@green-goods/shared/modules").then(({ readPublicGardenImpactSnapshot }) =>
+    readPublicGardenImpactSnapshot(input)
+  );
+}
+
+function hasErrorName(error: unknown, name: string): boolean {
+  return error instanceof Error && error.name === name;
+}
+
+function sliceRecentWork(
+  snapshot: PublicGardenImpactResponseV1,
+  limit: number
+): PublicGardenImpactResponseV1 {
+  return {
+    ...snapshot,
+    recentWork: snapshot.recentWork ? snapshot.recentWork.slice(0, limit) : null,
+  };
+}
+
+export function registerPublicGardenImpactRoutes(
+  app: Hono,
+  ctx: PublicGardenImpactRouteContext
+): void {
+  const cache = new PublicGardenImpactCache({ now: ctx.deps.now });
+  app.options(PUBLIC_AGENT_ROUTES.gardenImpact, (c) => {
+    setCors(c);
+    return c.body(null, 204);
+  });
+  app.get(PUBLIC_AGENT_ROUTES.gardenImpact, async (c) => {
+    const target = parseTarget(c, ctx.deps);
+    if (!target) return publicError(c, "invalid_request", "Invalid garden impact request.", 400);
+
+    const material = `${target.chainId}:${target.gardenAddress.toLowerCase()}`;
+    const rateError = checkRateLimit(c, ctx.deps, "garden_impact_read", material);
+    if (rateError) {
+      return publicError(
+        c,
+        "rate_limited",
+        "Too many requests. Please try again later.",
+        429,
+        rateError
+      );
+    }
+
+    const loader = ctx.deps.publicGardenImpactLoader ?? defaultLoader;
+    try {
+      const snapshot = await cache.get(material, () =>
+        loader({
+          chainId: target.chainId,
+          gardenAddress: target.gardenAddress,
+          recentLimit: PUBLIC_GARDEN_IMPACT_MAX_RECENT_LIMIT,
+        })
+      );
+      setCors(c);
+      return c.json(sliceRecentWork(snapshot, target.recentLimit), 200, {
+        "Cache-Control": SUCCESS_CACHE_CONTROL,
+      });
+    } catch (error) {
+      if (hasErrorName(error, "PublicGardenImpactNotFoundError")) {
+        return publicError(c, "not_found", "Public garden not found.", 404);
+      }
+      return publicError(c, "provider_unavailable", "Garden impact is unavailable right now.", 503);
+    }
+  });
+}

--- a/packages/agent/src/api/server.ts
+++ b/packages/agent/src/api/server.ts
@@ -33,6 +33,7 @@ import { registerGardenJoinRequestRoutes } from "./routes/garden-join-requests";
 import { publicBrowserCorsPreflight, publicBrowserCorsResponse } from "./http/public";
 import { trackGardenJoinRequestEvent } from "../services/analytics";
 import { GardenJoinRequestRateLimitPressure } from "../services/garden-join-requests";
+import { registerPublicGardenImpactRoutes } from "./routes/public-garden-impact";
 
 const log = loggers.api;
 
@@ -170,6 +171,7 @@ export function createServer(deps: ServerDeps, _config?: Partial<ServerConfig>):
   registerUploadSignRoutes(app, routeContext);
   registerMessageRoutes(app, routeContext);
   registerSubscribeRoutes(app, routeContext);
+  registerPublicGardenImpactRoutes(app, routeContext);
   registerProfileAvatarRoutes(app, {
     ...routeContext,
     profileAvatarStore: deps.profileAvatarStore ?? createSqliteProfileAvatarStore(),

--- a/packages/agent/src/services/db/core.ts
+++ b/packages/agent/src/services/db/core.ts
@@ -31,6 +31,7 @@ import * as sessions from "./sessions";
 import * as users from "./users";
 import type { FundingIntentRecord } from "../funding-intents";
 import type { ProfileAvatarRecord } from "@green-goods/shared/profile-avatar/protocol";
+import type { Address as PublicAddress } from "@green-goods/shared/public-contracts";
 import type { Address } from "@green-goods/shared/types";
 import type { SavedOfferCipher } from "../saved-offers";
 import type { GardenJoinRequestCipher } from "../garden-join-requests";
@@ -261,8 +262,8 @@ class DB {
 
   async getGardenJoinRequestMine(
     cipher: GardenJoinRequestCipher,
-    gardenAddress: Address,
-    accountAddress: Address,
+    gardenAddress: PublicAddress,
+    accountAddress: PublicAddress,
     nowIso?: string
   ) {
     return gardenJoinRequests.getGardenJoinRequestMine(
@@ -276,7 +277,7 @@ class DB {
 
   async getGardenJoinRequestById(
     cipher: GardenJoinRequestCipher,
-    gardenAddress: Address,
+    gardenAddress: PublicAddress,
     requestId: string
   ) {
     return gardenJoinRequests.getGardenJoinRequestById(this.db, cipher, gardenAddress, requestId);
@@ -284,7 +285,7 @@ class DB {
 
   async listPendingGardenJoinRequests(
     cipher: GardenJoinRequestCipher,
-    gardenAddress: Address,
+    gardenAddress: PublicAddress,
     options?: { cursor?: string; limit?: number; nowIso?: string }
   ) {
     return gardenJoinRequests.listPendingGardenJoinRequests(
@@ -304,7 +305,7 @@ class DB {
 
   async reconcileWelcomedGardenJoinRequest(
     cipher: GardenJoinRequestCipher,
-    gardenAddress: Address,
+    gardenAddress: PublicAddress,
     requestId: string,
     resolvedAt: string
   ) {
@@ -456,18 +457,18 @@ export const createGardenJoinRequest = (
 ) => getDB().createGardenJoinRequest(cipher, id, input);
 export const getGardenJoinRequestMine = (
   cipher: GardenJoinRequestCipher,
-  gardenAddress: Address,
-  accountAddress: Address,
+  gardenAddress: PublicAddress,
+  accountAddress: PublicAddress,
   nowIso?: string
 ) => getDB().getGardenJoinRequestMine(cipher, gardenAddress, accountAddress, nowIso);
 export const getGardenJoinRequestById = (
   cipher: GardenJoinRequestCipher,
-  gardenAddress: Address,
+  gardenAddress: PublicAddress,
   requestId: string
 ) => getDB().getGardenJoinRequestById(cipher, gardenAddress, requestId);
 export const listPendingGardenJoinRequests = (
   cipher: GardenJoinRequestCipher,
-  gardenAddress: Address,
+  gardenAddress: PublicAddress,
   options?: { cursor?: string; limit?: number; nowIso?: string }
 ) => getDB().listPendingGardenJoinRequests(cipher, gardenAddress, options);
 export const resolveGardenJoinRequest = (
@@ -476,7 +477,7 @@ export const resolveGardenJoinRequest = (
 ) => getDB().resolveGardenJoinRequest(cipher, input);
 export const reconcileWelcomedGardenJoinRequest = (
   cipher: GardenJoinRequestCipher,
-  gardenAddress: Address,
+  gardenAddress: PublicAddress,
   requestId: string,
   resolvedAt: string
 ) => getDB().reconcileWelcomedGardenJoinRequest(cipher, gardenAddress, requestId, resolvedAt);

--- a/packages/agent/src/services/db/garden-join-requests.ts
+++ b/packages/agent/src/services/db/garden-join-requests.ts
@@ -1,5 +1,5 @@
 import type { Database } from "bun:sqlite";
-import type { Address } from "@green-goods/shared/types";
+import type { Address } from "@green-goods/shared/public-contracts";
 import {
   decryptGardenJoinRequestRecord,
   GARDEN_JOIN_REQUEST_MAX_PENDING_PER_GARDEN,

--- a/packages/agent/src/services/garden-join-request-memory-store.ts
+++ b/packages/agent/src/services/garden-join-request-memory-store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import type { Address } from "@green-goods/shared/types";
+import type { Address } from "@green-goods/shared/public-contracts";
 import {
   decryptGardenJoinRequestRecord,
   GARDEN_JOIN_REQUEST_MAX_PENDING_PER_GARDEN,

--- a/packages/agent/src/services/garden-join-requests.ts
+++ b/packages/agent/src/services/garden-join-requests.ts
@@ -1,4 +1,5 @@
 import { createCipheriv, createDecipheriv, createHmac, randomBytes, randomUUID } from "node:crypto";
+import type { Address } from "@green-goods/shared/public-contracts";
 import type {
   GardenJoinRequestedVia,
   GardenJoinRequestKind,
@@ -6,7 +7,6 @@ import type {
   GardenJoinRequestSelfRecord,
   GardenJoinRequestState,
 } from "@green-goods/shared/public-contracts/join-requests";
-import type { Address } from "@green-goods/shared/types";
 
 export const GARDEN_JOIN_REQUEST_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 export const GARDEN_JOIN_REQUEST_MAX_PENDING_PER_GARDEN = 100;

--- a/packages/shared/src/__tests__/public-contracts.test.ts
+++ b/packages/shared/src/__tests__/public-contracts.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildPublicGardenImpactPath,
   createProviderProofRegistry,
   createPublicImpactSlice,
   derivePublicGardenSlug,
@@ -51,6 +52,13 @@ describe("@green-goods/shared/public-contracts", () => {
     expect(PUBLIC_AGENT_ROUTES.fundingIntentProof).toBe("/public/funding-intents/proof");
     expect(PUBLIC_AGENT_ROUTES.fundingIntentProof).not.toBe(
       PUBLIC_AGENT_ROUTES.fundingIntentReceipt
+    );
+  });
+
+  it("publishes and builds the versioned public garden impact route", () => {
+    expect(PUBLIC_AGENT_ROUTES.gardenImpact).toBe("/public/gardens/:chainId/:gardenAddress/impact");
+    expect(buildPublicGardenImpactPath(11155111, gardenA)).toBe(
+      `/public/gardens/11155111/${gardenA}/impact`
     );
   });
 

--- a/packages/shared/src/__tests__/public-garden-impact-readers.test.ts
+++ b/packages/shared/src/__tests__/public-garden-impact-readers.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
-import { isPublicGardenImpactChainSupported } from "../config/blockchain";
+import type { Address } from "../public-contracts";
+import {
+  getPublicGardenImpactChainConfig,
+  isPublicGardenImpactChainSupported,
+} from "../config/blockchain";
 import {
   PUBLIC_GARDEN_IMPACT_SOURCE_LIMIT,
   PublicGardenImpactSourceError,
@@ -7,20 +11,17 @@ import {
 } from "../modules/data/public-garden-impact-readers";
 import type { GraphQLReader } from "../modules/data/graphql-client";
 
-const gardenAddress = "0x1111111111111111111111111111111111111111";
+const gardenAddress: Address = "0x1111111111111111111111111111111111111111";
 
 function reader(query: GraphQLReader["query"]): GraphQLReader {
   return { query };
 }
 
 describe("public garden impact source readers", () => {
-  it("supports only direct deployment chains with EAS endpoints", () => {
-    expect([42161, 42220, 11155111].map(isPublicGardenImpactChainSupported)).toEqual([
-      true,
-      true,
-      true,
-    ]);
-    expect([1, 31337, 10, Number.NaN].map(isPublicGardenImpactChainSupported)).toEqual([
+  it("supports only chains covered by the Garden, EAS, and indexer sources", () => {
+    expect([42161, 11155111].map(isPublicGardenImpactChainSupported)).toEqual([true, true]);
+    expect([1, 42220, 31337, 10, Number.NaN].map(isPublicGardenImpactChainSupported)).toEqual([
+      false,
       false,
       false,
       false,
@@ -28,47 +29,18 @@ describe("public garden impact source readers", () => {
     ]);
   });
 
-  it("rejects unsupported chains before constructing a fallback EAS reader", async () => {
+  it("rejects Celo before constructing a fallback EAS reader", async () => {
     const createEasReader = vi.fn(() => reader(vi.fn()));
     const impactReaders = createPublicGardenImpactReaders({
       indexerReader: reader(vi.fn()),
       createEasReader,
     });
 
-    await expect(impactReaders.readWorks(1, gardenAddress)).rejects.toMatchObject({
+    await expect(impactReaders.readWorks(42220, gardenAddress)).rejects.toMatchObject({
       source: "works",
       reason: "unsupported_chain",
     });
     expect(createEasReader).not.toHaveBeenCalled();
-  });
-
-  it("keeps a missing approval schema distinct from an empty result", async () => {
-    const indexer = reader(vi.fn());
-    const eas = reader(vi.fn());
-    const impactReaders = createPublicGardenImpactReaders({
-      indexerReader: indexer,
-      createEasReader: () => eas,
-    });
-
-    await expect(impactReaders.readApprovals(42220)).rejects.toMatchObject({
-      source: "approvals",
-      reason: "missing_schema",
-    });
-    expect(eas.query).not.toHaveBeenCalled();
-  });
-
-  it("keeps a missing Assessment schema distinct from an empty result", async () => {
-    const eas = reader(vi.fn());
-    const impactReaders = createPublicGardenImpactReaders({
-      indexerReader: reader(vi.fn()),
-      createEasReader: () => eas,
-    });
-
-    await expect(impactReaders.readAssessments(42220, gardenAddress)).rejects.toMatchObject({
-      source: "assessments",
-      reason: "missing_schema",
-    });
-    expect(eas.query).not.toHaveBeenCalled();
   });
 
   it("treats a structurally missing provider result as unavailable, not empty", async () => {
@@ -84,27 +56,66 @@ describe("public garden impact source readers", () => {
     });
   });
 
-  it("reads the exact chain/address garden without replacing nullable fields", async () => {
-    const indexerQuery = vi.fn(async (_document, variables, operationName) => {
-      expect(operationName).toBe("readPublicGardenImpactGarden");
-      expect(variables).toMatchObject({ chainId: 11155111, gardenAddress });
-      return {
-        data: {
-          Garden: [
-            { id: gardenAddress, chainId: 11155111, name: "", location: "", initialized: true },
-          ],
-        },
-      };
+  it("resolves the exact chain-qualified Garden account without replacing nullable fields", async () => {
+    const config = getPublicGardenImpactChainConfig(11155111);
+    expect(config).not.toBeNull();
+    const readContract = vi.fn(async (input: { functionName: string }) => {
+      if (input.functionName === "token") {
+        return [11155111n, config?.gardenToken, 7n];
+      }
+      if (input.functionName === "account") return gardenAddress;
+      if (input.functionName === "name" || input.functionName === "location") return "";
+      throw new Error(`Unexpected function ${input.functionName}`);
     });
     const impactReaders = createPublicGardenImpactReaders({
-      indexerReader: reader(indexerQuery as GraphQLReader["query"]),
+      indexerReader: reader(vi.fn()),
       createEasReader: () => reader(vi.fn()),
+      createChainReader: (chainId) => {
+        expect(chainId).toBe(11155111);
+        return { readContract };
+      },
     });
 
     await expect(impactReaders.readGarden(11155111, gardenAddress)).resolves.toEqual({
       id: gardenAddress,
       name: null,
       location: null,
+    });
+    expect(readContract.mock.calls.map(([input]) => input.functionName)).toEqual([
+      "token",
+      "account",
+      "name",
+      "location",
+    ]);
+  });
+
+  it("rejects an account whose token binding belongs to another chain", async () => {
+    const arbitrum = getPublicGardenImpactChainConfig(42161);
+    const readContract = vi.fn(async () => [42161n, arbitrum?.gardenToken, 7n]);
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(vi.fn()),
+      createEasReader: () => reader(vi.fn()),
+      createChainReader: () => ({ readContract }),
+    });
+
+    await expect(impactReaders.readGarden(11155111, gardenAddress)).resolves.toBeNull();
+    expect(readContract).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a Garden provider failure distinct from a missing Garden", async () => {
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(vi.fn()),
+      createEasReader: () => reader(vi.fn()),
+      createChainReader: () => ({
+        readContract: vi.fn(async () => {
+          throw new Error("RPC unavailable");
+        }),
+      }),
+    });
+
+    await expect(impactReaders.readGarden(11155111, gardenAddress)).rejects.toMatchObject({
+      source: "works",
+      reason: "provider_failed",
     });
   });
 

--- a/packages/shared/src/__tests__/public-garden-impact-readers.test.ts
+++ b/packages/shared/src/__tests__/public-garden-impact-readers.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it, vi } from "vitest";
+import { isPublicGardenImpactChainSupported } from "../config/blockchain";
+import {
+  PUBLIC_GARDEN_IMPACT_SOURCE_LIMIT,
+  PublicGardenImpactSourceError,
+  createPublicGardenImpactReaders,
+} from "../modules/data/public-garden-impact-readers";
+import type { GraphQLReader } from "../modules/data/graphql-client";
+
+const gardenAddress = "0x1111111111111111111111111111111111111111";
+
+function reader(query: GraphQLReader["query"]): GraphQLReader {
+  return { query };
+}
+
+describe("public garden impact source readers", () => {
+  it("supports only direct deployment chains with EAS endpoints", () => {
+    expect([42161, 42220, 11155111].map(isPublicGardenImpactChainSupported)).toEqual([
+      true,
+      true,
+      true,
+    ]);
+    expect([1, 31337, 10, Number.NaN].map(isPublicGardenImpactChainSupported)).toEqual([
+      false,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it("rejects unsupported chains before constructing a fallback EAS reader", async () => {
+    const createEasReader = vi.fn(() => reader(vi.fn()));
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(vi.fn()),
+      createEasReader,
+    });
+
+    await expect(impactReaders.readWorks(1, gardenAddress)).rejects.toMatchObject({
+      source: "works",
+      reason: "unsupported_chain",
+    });
+    expect(createEasReader).not.toHaveBeenCalled();
+  });
+
+  it("keeps a missing approval schema distinct from an empty result", async () => {
+    const indexer = reader(vi.fn());
+    const eas = reader(vi.fn());
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: indexer,
+      createEasReader: () => eas,
+    });
+
+    await expect(impactReaders.readApprovals(42220)).rejects.toMatchObject({
+      source: "approvals",
+      reason: "missing_schema",
+    });
+    expect(eas.query).not.toHaveBeenCalled();
+  });
+
+  it("keeps a missing Assessment schema distinct from an empty result", async () => {
+    const eas = reader(vi.fn());
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(vi.fn()),
+      createEasReader: () => eas,
+    });
+
+    await expect(impactReaders.readAssessments(42220, gardenAddress)).rejects.toMatchObject({
+      source: "assessments",
+      reason: "missing_schema",
+    });
+    expect(eas.query).not.toHaveBeenCalled();
+  });
+
+  it("treats a structurally missing provider result as unavailable, not empty", async () => {
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(vi.fn()),
+      createEasReader: () =>
+        reader(vi.fn(async () => ({ data: {} })) as unknown as GraphQLReader["query"]),
+    });
+
+    await expect(impactReaders.readWorks(11155111, gardenAddress)).rejects.toMatchObject({
+      source: "works",
+      reason: "provider_failed",
+    });
+  });
+
+  it("reads the exact chain/address garden without replacing nullable fields", async () => {
+    const indexerQuery = vi.fn(async (_document, variables, operationName) => {
+      expect(operationName).toBe("readPublicGardenImpactGarden");
+      expect(variables).toMatchObject({ chainId: 11155111, gardenAddress });
+      return {
+        data: {
+          Garden: [
+            { id: gardenAddress, chainId: 11155111, name: "", location: "", initialized: true },
+          ],
+        },
+      };
+    });
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(indexerQuery as GraphQLReader["query"]),
+      createEasReader: () => reader(vi.fn()),
+    });
+
+    await expect(impactReaders.readGarden(11155111, gardenAddress)).resolves.toEqual({
+      id: gardenAddress,
+      name: null,
+      location: null,
+    });
+  });
+
+  it("decodes the nested numeric envelope returned by EAS", async () => {
+    const easQuery = vi.fn(async (document, _variables, operationName) => {
+      expect(String(document)).not.toMatch(/\n\s+(attester|recipient)\s*\n/);
+      if (operationName === "readPublicGardenImpactWorks") {
+        return {
+          data: {
+            attestations: [
+              {
+                id: "0xwork",
+                timeCreated: 1_700_000_000,
+                decodedDataJson: JSON.stringify([
+                  { name: "actionUID", value: { value: { hex: "0x2a" } } },
+                  { name: "title", value: { value: "Compost collection" } },
+                  { name: "feedback", value: { value: "Collected safely" } },
+                  { name: "media", value: { value: [] } },
+                ]),
+              },
+            ],
+          },
+        };
+      }
+      return {
+        data: {
+          attestations: [
+            {
+              id: "0xapproval",
+              timeCreated: 1_700_000_100,
+              decodedDataJson: JSON.stringify([
+                { name: "workUID", value: { value: "0xwork" } },
+                { name: "approved", value: { value: true } },
+              ]),
+            },
+          ],
+        },
+      };
+    });
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(vi.fn()),
+      createEasReader: () => reader(easQuery as GraphQLReader["query"]),
+    });
+
+    await expect(impactReaders.readWorks(11155111, gardenAddress)).resolves.toEqual([
+      expect.objectContaining({ id: "0xwork", actionUID: 42, title: "Compost collection" }),
+    ]);
+    await expect(impactReaders.readApprovals(11155111)).resolves.toEqual([
+      expect.objectContaining({ id: "0xapproval", workUID: "0xwork", approved: true }),
+    ]);
+  });
+
+  it("queries every configured Assessment schema in one bounded source stream", async () => {
+    const easQuery = vi.fn(async (_document, variables, operationName) => {
+      expect(operationName).toBe("readPublicGardenImpactAssessments");
+      expect(variables).toMatchObject({
+        where: {
+          schemaId: {
+            in: expect.arrayContaining([
+              "0x97b3a7378bc97e8e455dbf9bd7958e4c149bef5e1f388540852b6d53eb6dbf93",
+              "0x9358f3371f9fcf6b3467c524da3ba5f8d43f8f0b9cc3ba12c925e77ecbcf06a0",
+            ]),
+          },
+        },
+      });
+      return {
+        data: {
+          attestations: [
+            { id: "0xassessment-v2", timeCreated: 100, decodedDataJson: "[]" },
+            { id: "0xassessment-v3", timeCreated: 200, decodedDataJson: "[]" },
+          ],
+        },
+      };
+    });
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(vi.fn()),
+      createEasReader: () => reader(easQuery as GraphQLReader["query"]),
+    });
+
+    await expect(impactReaders.readAssessments(42161, gardenAddress)).resolves.toEqual([
+      { id: "0xassessment-v2", createdAt: 100 },
+      { id: "0xassessment-v3", createdAt: 200 },
+    ]);
+    expect(easQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads Hypercert lifecycle update timestamps", async () => {
+    const indexerQuery = vi.fn(async (document) => {
+      expect(String(document)).toContain("updatedAt");
+      return {
+        data: {
+          Hypercert: [
+            {
+              id: "11155111-7",
+              status: "CLAIMED",
+              mintedAt: 400,
+              updatedAt: 650,
+            },
+          ],
+        },
+      };
+    });
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(indexerQuery as GraphQLReader["query"]),
+      createEasReader: () => reader(vi.fn()),
+    });
+
+    await expect(impactReaders.readCertificates(11155111, gardenAddress)).resolves.toEqual([
+      {
+        id: "11155111-7",
+        status: "claimed",
+        mintedAt: 400,
+        updatedAt: 650,
+      },
+    ]);
+  });
+
+  it("fails a source closed when the 1,001st record exists", async () => {
+    const indexerQuery = vi.fn(async (_document, variables) => {
+      const offset = Number((variables as { offset?: number }).offset ?? 0);
+      const length = offset < PUBLIC_GARDEN_IMPACT_SOURCE_LIMIT ? 100 : 1;
+      return {
+        data: {
+          Hypercert: Array.from({ length }, (_, index) => ({
+            id: `11155111-${offset + index}`,
+            status: "ACTIVE",
+            mintedAt: offset + index,
+            updatedAt: offset + index,
+          })),
+        },
+      };
+    });
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(indexerQuery as GraphQLReader["query"]),
+      createEasReader: () => reader(vi.fn()),
+    });
+
+    await expect(impactReaders.readCertificates(11155111, gardenAddress)).rejects.toEqual(
+      expect.objectContaining<Partial<PublicGardenImpactSourceError>>({
+        source: "certificates",
+        reason: "limit_exceeded",
+      })
+    );
+    expect(indexerQuery).toHaveBeenCalledTimes(11);
+  });
+
+  it("applies the source ceiling across all Assessment schema versions", async () => {
+    const easQuery = vi.fn(async (_document, variables) => {
+      const skip = Number((variables as { skip?: number }).skip ?? 0);
+      return {
+        data: {
+          attestations: Array.from(
+            { length: skip < PUBLIC_GARDEN_IMPACT_SOURCE_LIMIT ? 100 : 1 },
+            (_, index) => ({
+              id: `0x${skip + index}`,
+              timeCreated: skip + index,
+              decodedDataJson: "[]",
+            })
+          ),
+        },
+      };
+    });
+    const impactReaders = createPublicGardenImpactReaders({
+      indexerReader: reader(vi.fn()),
+      createEasReader: () => reader(easQuery as GraphQLReader["query"]),
+    });
+
+    await expect(impactReaders.readAssessments(42161, gardenAddress)).rejects.toEqual(
+      expect.objectContaining<Partial<PublicGardenImpactSourceError>>({
+        source: "assessments",
+        reason: "limit_exceeded",
+      })
+    );
+    expect(easQuery).toHaveBeenCalledTimes(11);
+  });
+});

--- a/packages/shared/src/__tests__/public-garden-impact.test.ts
+++ b/packages/shared/src/__tests__/public-garden-impact.test.ts
@@ -124,18 +124,18 @@ describe("public garden impact aggregation", () => {
       { chainId: 42161, gardenAddress, recentLimit: 3 },
       { readers: readers(), now: () => now }
     );
-    const celo = await loadPublicGardenImpactSnapshot(
-      { chainId: 42220, gardenAddress, recentLimit: 3 },
+    const sepolia = await loadPublicGardenImpactSnapshot(
+      { chainId: 11155111, gardenAddress, recentLimit: 3 },
       { readers: readers(), now: () => now }
     );
 
     expect(arbitrum.garden.url).toBe(
       `https://agent.greengoods.app/public/gardens/42161/${gardenAddress}/impact`
     );
-    expect(celo.garden.url).toBe(
-      `https://agent.greengoods.app/public/gardens/42220/${gardenAddress}/impact`
+    expect(sepolia.garden.url).toBe(
+      `https://agent.greengoods.app/public/gardens/11155111/${gardenAddress}/impact`
     );
-    expect(arbitrum.garden.url).not.toBe(celo.garden.url);
+    expect(arbitrum.garden.url).not.toBe(sepolia.garden.url);
   });
 
   it("keeps known-domain and action breakdowns deterministic", async () => {

--- a/packages/shared/src/__tests__/public-garden-impact.test.ts
+++ b/packages/shared/src/__tests__/public-garden-impact.test.ts
@@ -1,0 +1,390 @@
+import { describe, expect, it } from "vitest";
+import {
+  PUBLIC_GARDEN_IMPACT_DOMAINS,
+  type PublicGardenImpactResponseV1,
+} from "../public-contracts/garden-impact";
+import {
+  PublicGardenImpactNotFoundError,
+  PublicGardenImpactProviderError,
+  type PublicGardenImpactReaders,
+  loadPublicGardenImpactSnapshot,
+} from "../modules/data/public-garden-impact";
+
+const gardenAddress = "0x1111111111111111111111111111111111111111";
+const otherAddress = "0x2222222222222222222222222222222222222222";
+const now = Date.UTC(2026, 7, 28, 12);
+
+function readers(overrides: Partial<PublicGardenImpactReaders> = {}): PublicGardenImpactReaders {
+  return {
+    readGarden: async () => ({
+      id: gardenAddress,
+      name: "Sun Garden",
+      location: "Lisbon",
+    }),
+    readWorks: async () => [
+      {
+        id: "0xwork-b",
+        actionUID: 2,
+        title: "Installed panels",
+        feedback: "Six panels are producing power.",
+        media: ["ipfs://panel"],
+        createdAt: 300,
+      },
+      {
+        id: "0xwork-a",
+        actionUID: 1,
+        title: "Planted trees",
+        feedback: "",
+        media: [],
+        createdAt: 200,
+      },
+    ],
+    readApprovals: async () => [
+      { id: "0xapproval-1", workUID: "0xwork-b", approved: true, createdAt: 320 },
+      { id: "0xapproval-2", workUID: "0xwork-b", approved: false, createdAt: 340 },
+      { id: "0xapproval-3", workUID: "0xwork-b", approved: true, createdAt: 330 },
+      { id: "0xapproval-4", workUID: "0xwork-a", approved: false, createdAt: 210 },
+    ],
+    readActions: async () => [
+      { id: "11155111-1", title: "Tree planting", domain: "agroforestry" },
+      { id: "11155111-2", title: "Solar installation", domain: "solar" },
+    ],
+    readAssessments: async () => [
+      { id: "0xassessment", createdAt: 250 },
+      { id: "0xASSESSMENT", createdAt: 250 },
+    ],
+    readCertificates: async () => [
+      { id: "11155111-1", status: "active", mintedAt: 400, updatedAt: 400 },
+      { id: "11155111-1", status: "claimed", mintedAt: 400, updatedAt: 450 },
+      { id: "11155111-2", status: "unknown", mintedAt: 500, updatedAt: 500 },
+    ],
+    ...overrides,
+  };
+}
+
+async function load(overrides: Partial<PublicGardenImpactReaders> = {}) {
+  return loadPublicGardenImpactSnapshot(
+    { chainId: 11155111, gardenAddress, recentLimit: 12 },
+    { readers: readers(overrides), now: () => now }
+  );
+}
+
+describe("public garden impact aggregation", () => {
+  it("publishes a fixed domain contract", () => {
+    expect(PUBLIC_GARDEN_IMPACT_DOMAINS).toEqual(["solar", "agroforestry", "education", "waste"]);
+  });
+
+  it("aggregates protocol approvals without treating a later rejection as erasure", async () => {
+    const snapshot = await load();
+
+    expect(snapshot).toMatchObject<Partial<PublicGardenImpactResponseV1>>({
+      version: 1,
+      ok: true,
+      garden: {
+        chainId: 11155111,
+        address: gardenAddress,
+        name: "Sun Garden",
+        location: "Lisbon",
+        url: `https://agent.greengoods.app/public/gardens/11155111/${gardenAddress}/impact`,
+      },
+      summary: {
+        submittedWorkCount: 2,
+        approvedWorkCount: 1,
+        assessmentCount: 1,
+        impactCertificateCount: 1,
+        latestKnownActivityAt: new Date(500_000).toISOString(),
+      },
+      provenance: {
+        status: "ready",
+        partialData: false,
+        unavailableSources: [],
+        fetchedAt: new Date(now).toISOString(),
+      },
+    });
+    expect(snapshot.recentWork).toEqual([
+      {
+        id: "0xwork-b",
+        title: "Installed panels",
+        description: "Six panels are producing power.",
+        media: ["ipfs://panel"],
+        actionUid: 2,
+        action: {
+          id: "11155111-2",
+          title: "Solar installation",
+          domain: "solar",
+        },
+        createdAt: new Date(300_000).toISOString(),
+        approvedAt: new Date(330_000).toISOString(),
+      },
+    ]);
+  });
+
+  it("keeps same-address public resource URLs distinct across chains", async () => {
+    const arbitrum = await loadPublicGardenImpactSnapshot(
+      { chainId: 42161, gardenAddress, recentLimit: 3 },
+      { readers: readers(), now: () => now }
+    );
+    const celo = await loadPublicGardenImpactSnapshot(
+      { chainId: 42220, gardenAddress, recentLimit: 3 },
+      { readers: readers(), now: () => now }
+    );
+
+    expect(arbitrum.garden.url).toBe(
+      `https://agent.greengoods.app/public/gardens/42161/${gardenAddress}/impact`
+    );
+    expect(celo.garden.url).toBe(
+      `https://agent.greengoods.app/public/gardens/42220/${gardenAddress}/impact`
+    );
+    expect(arbitrum.garden.url).not.toBe(celo.garden.url);
+  });
+
+  it("keeps known-domain and action breakdowns deterministic", async () => {
+    const snapshot = await load();
+
+    expect(snapshot.breakdown.byDomain).toEqual([
+      { domain: "solar", submittedWorkCount: 1, approvedWorkCount: 1 },
+      { domain: "agroforestry", submittedWorkCount: 1, approvedWorkCount: 0 },
+      { domain: "education", submittedWorkCount: 0, approvedWorkCount: 0 },
+      { domain: "waste", submittedWorkCount: 0, approvedWorkCount: 0 },
+    ]);
+    expect(snapshot.breakdown.byAction?.map((item) => item.actionUid)).toEqual([1, 2]);
+  });
+
+  it("returns nullable dependent fields and partial provenance for unavailable sources", async () => {
+    const snapshot = await load({
+      readApprovals: async () => {
+        throw new Error("missing schema");
+      },
+      readActions: async () => {
+        throw new Error("indexer unavailable");
+      },
+    });
+
+    expect(snapshot.summary.approvedWorkCount).toBeNull();
+    expect(snapshot.recentWork).toBeNull();
+    expect(snapshot.breakdown).toEqual({
+      byDomain: null,
+      byAction: [
+        {
+          actionUid: 1,
+          actionId: "11155111-1",
+          title: null,
+          domain: null,
+          submittedWorkCount: 1,
+          approvedWorkCount: null,
+        },
+        {
+          actionUid: 2,
+          actionId: "11155111-2",
+          title: null,
+          domain: null,
+          submittedWorkCount: 1,
+          approvedWorkCount: null,
+        },
+      ],
+    });
+    expect(snapshot.provenance).toMatchObject({
+      status: "partial",
+      partialData: true,
+      unavailableSources: ["approvals", "actions"],
+    });
+  });
+
+  it("marks a missing Assessment schema as partial without hiding other counts", async () => {
+    const snapshot = await load({
+      readAssessments: async () => {
+        throw new Error("missing schema");
+      },
+    });
+
+    expect(snapshot.summary).toMatchObject({
+      submittedWorkCount: 2,
+      approvedWorkCount: 1,
+      assessmentCount: null,
+      impactCertificateCount: 1,
+    });
+    expect(snapshot.provenance).toMatchObject({
+      status: "partial",
+      partialData: true,
+      unavailableSources: ["assessments"],
+    });
+  });
+
+  it("preserves by-action counts when only Action metadata is unavailable", async () => {
+    const snapshot = await load({
+      readActions: async () => {
+        throw new Error("indexer unavailable");
+      },
+    });
+
+    expect(snapshot.breakdown.byDomain).toBeNull();
+    expect(snapshot.breakdown.byAction).toEqual([
+      {
+        actionUid: 1,
+        actionId: "11155111-1",
+        title: null,
+        domain: null,
+        submittedWorkCount: 1,
+        approvedWorkCount: 0,
+      },
+      {
+        actionUid: 2,
+        actionId: "11155111-2",
+        title: null,
+        domain: null,
+        submittedWorkCount: 1,
+        approvedWorkCount: 1,
+      },
+    ]);
+  });
+
+  it("retains unresolved work in totals and by-action while excluding it from domains", async () => {
+    const snapshot = await load({
+      readWorks: async () => [
+        {
+          id: "0xwork-unresolved",
+          actionUID: 99,
+          title: "Other work",
+          feedback: "",
+          media: [],
+          createdAt: 600,
+        },
+      ],
+      readApprovals: async () => [
+        {
+          id: "0xapproval-unresolved",
+          workUID: "0xwork-unresolved",
+          approved: true,
+          createdAt: 610,
+        },
+      ],
+    });
+
+    expect(snapshot.summary.submittedWorkCount).toBe(1);
+    expect(snapshot.breakdown.byDomain?.every((item) => item.submittedWorkCount === 0)).toBe(true);
+    expect(snapshot.breakdown.byAction).toEqual([
+      {
+        actionUid: 99,
+        actionId: "11155111-99",
+        title: null,
+        domain: null,
+        submittedWorkCount: 1,
+        approvedWorkCount: 1,
+      },
+    ]);
+  });
+
+  it("returns empty only when every source is available and empty", async () => {
+    const snapshot = await load({
+      readWorks: async () => [],
+      readApprovals: async () => [],
+      readActions: async () => [],
+      readAssessments: async () => [],
+      readCertificates: async () => [],
+    });
+
+    expect(snapshot.provenance.status).toBe("empty");
+    expect(snapshot.summary.latestKnownActivityAt).toBeNull();
+  });
+
+  it("orders equal-time recent Work by UID ascending", async () => {
+    const snapshot = await load({
+      readWorks: async () => [
+        {
+          id: "0xwork-b",
+          actionUID: 2,
+          title: "Second UID",
+          feedback: "",
+          media: [],
+          createdAt: 600,
+        },
+        {
+          id: "0xwork-a",
+          actionUID: 1,
+          title: "First UID",
+          feedback: "",
+          media: [],
+          createdAt: 600,
+        },
+      ],
+      readApprovals: async () => [
+        { id: "0xapproval-b", workUID: "0xwork-b", approved: true, createdAt: 610 },
+        { id: "0xapproval-a", workUID: "0xwork-a", approved: true, createdAt: 610 },
+      ],
+    });
+
+    expect(snapshot.recentWork?.map((work) => work.id)).toEqual(["0xwork-a", "0xwork-b"]);
+  });
+
+  it("uses the latest certificate lifecycle update for status and activity", async () => {
+    const snapshot = await load({
+      readWorks: async () => [],
+      readApprovals: async () => [],
+      readActions: async () => [],
+      readAssessments: async () => [],
+      readCertificates: async () => [
+        { id: "11155111-7", status: "active", mintedAt: 400, updatedAt: 400 },
+        { id: "11155111-7", status: "claimed", mintedAt: 400, updatedAt: 650 },
+      ],
+    });
+
+    expect(snapshot.summary.impactCertificateCount).toBe(1);
+    expect(snapshot.summary.latestKnownActivityAt).toBe(new Date(650_000).toISOString());
+  });
+
+  it("fails when every primary impact source is unavailable", async () => {
+    const unavailable = async () => Promise.reject(new Error("offline"));
+    await expect(
+      load({
+        readWorks: unavailable,
+        readAssessments: unavailable,
+        readCertificates: unavailable,
+      })
+    ).rejects.toBeInstanceOf(PublicGardenImpactProviderError);
+  });
+
+  it("uses the same not-found error for missing and non-public gardens", async () => {
+    await expect(load({ readGarden: async () => null })).rejects.toBeInstanceOf(
+      PublicGardenImpactNotFoundError
+    );
+    await expect(
+      load({
+        readGarden: async () => ({ id: otherAddress, name: "", location: "" }),
+      })
+    ).rejects.toBeInstanceOf(PublicGardenImpactNotFoundError);
+  });
+
+  it("hides curated gardens and fails closed when Garden resolution throws", async () => {
+    const hiddenAddress = "0xf401f34378384713222d1d21f63359cc4E8a858a";
+    await expect(
+      loadPublicGardenImpactSnapshot(
+        { chainId: 11155111, gardenAddress: hiddenAddress, recentLimit: 3 },
+        {
+          readers: readers({
+            readGarden: async () => ({
+              id: hiddenAddress,
+              name: "Green Goods Community Garden",
+              location: "Online",
+            }),
+          }),
+          now: () => now,
+        }
+      )
+    ).rejects.toBeInstanceOf(PublicGardenImpactNotFoundError);
+
+    await expect(
+      load({
+        readGarden: async () => {
+          throw new Error("indexer unavailable");
+        },
+      })
+    ).rejects.toBeInstanceOf(PublicGardenImpactProviderError);
+  });
+
+  it("does not expose actor identities from source records", async () => {
+    const serialized = JSON.stringify(await load());
+    expect(serialized).not.toContain("gardenerAddress");
+    expect(serialized).not.toContain("stewardAddress");
+    expect(serialized).not.toContain("authorAddress");
+  });
+});

--- a/packages/shared/src/config/blockchain.ts
+++ b/packages/shared/src/config/blockchain.ts
@@ -53,6 +53,7 @@ interface DeploymentConfig {
     schemaRegistry?: string;
   };
   gardenToken?: string;
+  gardenAccountImpl?: string;
   actionRegistry?: string;
   workResolver?: string;
   workApprovalResolver?: string;
@@ -97,6 +98,13 @@ const EAS_GRAPHQL_URLS: Record<string, string> = {
 
 const DEFAULT_EAS_GRAPHQL_URL = "https://sepolia.easscan.org/graphql";
 const FALLBACK_CHAIN_ID = 42161;
+const PUBLIC_GARDEN_IMPACT_INDEXER_CHAINS = new Set([42161, 11155111]);
+
+export interface PublicGardenImpactChainConfig {
+  gardenToken: string;
+  gardenAccountImpl: string;
+  tokenboundRegistry: string;
+}
 
 function hasNetworkConfig(chainId: number): boolean {
   return Object.values(networksConfig.networks).some(
@@ -104,11 +112,43 @@ function hasNetworkConfig(chainId: number): boolean {
   );
 }
 
-/** True only for a directly configured Green Goods deployment with its own EAS endpoint. */
+function isConfiguredAddress(value: unknown): value is string {
+  return (
+    typeof value === "string" && /^0x[0-9a-fA-F]{40}$/.test(value) && !/^0x0{40}$/i.test(value)
+  );
+}
+
+export function getPublicGardenImpactChainConfig(
+  chainId: number
+): PublicGardenImpactChainConfig | null {
+  const deployment = DEPLOYMENT_CONFIGS[String(chainId)];
+  const tokenboundRegistry = (
+    networksConfig as { deploymentDefaults?: { tokenboundRegistry?: string } }
+  ).deploymentDefaults?.tokenboundRegistry;
+  if (
+    !isConfiguredAddress(deployment?.gardenToken) ||
+    !isConfiguredAddress(deployment.gardenAccountImpl) ||
+    !isConfiguredAddress(tokenboundRegistry)
+  ) {
+    return null;
+  }
+  return {
+    gardenToken: deployment.gardenToken,
+    gardenAccountImpl: deployment.gardenAccountImpl,
+    tokenboundRegistry,
+  };
+}
+
+/** True only when every source required by the public impact adapter covers the chain. */
 export function isPublicGardenImpactChainSupported(chainId: number): boolean {
   if (!Number.isSafeInteger(chainId) || chainId <= 0) return false;
   const key = String(chainId);
-  return Boolean(DEPLOYMENT_CONFIGS[key] && EAS_GRAPHQL_URLS[key] && hasNetworkConfig(chainId));
+  return Boolean(
+    PUBLIC_GARDEN_IMPACT_INDEXER_CHAINS.has(chainId) &&
+      getPublicGardenImpactChainConfig(chainId) &&
+      EAS_GRAPHQL_URLS[key] &&
+      hasNetworkConfig(chainId)
+  );
 }
 
 function resolveChainId(chainId?: number | string): number {

--- a/packages/shared/src/config/blockchain.ts
+++ b/packages/shared/src/config/blockchain.ts
@@ -104,6 +104,13 @@ function hasNetworkConfig(chainId: number): boolean {
   );
 }
 
+/** True only for a directly configured Green Goods deployment with its own EAS endpoint. */
+export function isPublicGardenImpactChainSupported(chainId: number): boolean {
+  if (!Number.isSafeInteger(chainId) || chainId <= 0) return false;
+  const key = String(chainId);
+  return Boolean(DEPLOYMENT_CONFIGS[key] && EAS_GRAPHQL_URLS[key] && hasNetworkConfig(chainId));
+}
+
 function resolveChainId(chainId?: number | string): number {
   if (chainId === undefined || chainId === null || chainId === "") {
     return FALLBACK_CHAIN_ID;

--- a/packages/shared/src/modules/data/public-garden-impact-eas-readers.ts
+++ b/packages/shared/src/modules/data/public-garden-impact-eas-readers.ts
@@ -1,0 +1,200 @@
+import { getEASConfig } from "../../config/blockchain";
+import type { PublicGardenImpactSource } from "../../public-contracts/garden-impact";
+import { isZeroBytes32 } from "../../utils/blockchain/vaults";
+import type { GraphQLReader } from "./graphql-client";
+import { resolveIPFSUrl } from "./ipfs/resolve";
+import {
+  assertPublicGardenImpactChain,
+  PublicGardenImpactSourceError,
+  queryPublicGardenImpactRows,
+  readPublicGardenImpactPages,
+  requirePublicGardenImpactSchema,
+  wrapPublicGardenImpactSourceError,
+} from "./public-garden-impact-reader-core";
+import type {
+  PublicGardenImpactApprovalRecord,
+  PublicGardenImpactAssessmentRecord,
+  PublicGardenImpactReaders,
+  PublicGardenImpactWorkRecord,
+} from "./public-garden-impact";
+
+const EAS_ATTESTATIONS_QUERY = /* GraphQL */ `
+  query PublicGardenImpactAttestations(
+    $where: AttestationWhereInput!
+    $take: Int!
+    $skip: Int!
+  ) {
+    attestations(
+      where: $where
+      orderBy: [{ timeCreated: desc }, { id: asc }]
+      take: $take
+      skip: $skip
+    ) {
+      id
+      timeCreated
+      decodedDataJson
+    }
+  }
+`;
+
+interface PublicAttestationRow {
+  id: string;
+  timeCreated: number | string;
+  decodedDataJson: string;
+}
+
+interface DecodedField {
+  name: string;
+  value?: { value?: unknown; hex?: string };
+}
+
+function decodedFields(value: string): DecodedField[] {
+  const parsed = JSON.parse(value) as unknown;
+  return Array.isArray(parsed) ? (parsed as DecodedField[]) : [];
+}
+
+function fieldValue(fields: readonly DecodedField[], name: string): unknown {
+  const field = fields.find((candidate) => candidate.name === name);
+  return field?.value?.value ?? field?.value?.hex;
+}
+
+function numberValue(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string") {
+    try {
+      return value.startsWith("0x") ? Number(BigInt(value)) : Number(value);
+    } catch {
+      return 0;
+    }
+  }
+  if (value && typeof value === "object") {
+    if ("hex" in value && typeof value.hex === "string") {
+      return numberValue(value.hex);
+    }
+    if ("value" in value) return numberValue((value as { value: unknown }).value);
+  }
+  return 0;
+}
+
+function booleanValue(value: unknown): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  return typeof value === "string" && (value.toLowerCase() === "true" || value === "1");
+}
+
+async function readAttestations(input: {
+  reader: GraphQLReader;
+  source: PublicGardenImpactSource;
+  where: Record<string, unknown>;
+  operationName: string;
+}): Promise<PublicAttestationRow[]> {
+  return readPublicGardenImpactPages(input.source, (take, skip) =>
+    queryPublicGardenImpactRows<PublicAttestationRow>({
+      ...input,
+      document: EAS_ATTESTATIONS_QUERY,
+      variables: { where: input.where, take, skip },
+      field: "attestations",
+    })
+  );
+}
+
+function addressFilter(address: string): { in: string[] } {
+  return { in: [...new Set([address, address.toLowerCase()])] };
+}
+
+export function createPublicGardenImpactEasReaders(
+  createReader: (chainId: number) => GraphQLReader
+): Pick<PublicGardenImpactReaders, "readWorks" | "readApprovals" | "readAssessments"> {
+  return {
+    async readWorks(chainId, gardenAddress): Promise<PublicGardenImpactWorkRecord[]> {
+      assertPublicGardenImpactChain(chainId, "works");
+      const schema = requirePublicGardenImpactSchema("works", getEASConfig(chainId).WORK.uid);
+      try {
+        const rows = await readAttestations({
+          reader: createReader(chainId),
+          source: "works",
+          where: {
+            schemaId: { equals: schema },
+            recipient: addressFilter(gardenAddress),
+            revoked: { equals: false },
+          },
+          operationName: "readPublicGardenImpactWorks",
+        });
+        return rows.map((row) => {
+          const fields = decodedFields(row.decodedDataJson);
+          const mediaValue = fieldValue(fields, "media");
+          return {
+            id: row.id,
+            actionUID: numberValue(fieldValue(fields, "actionUID")),
+            title: String(fieldValue(fields, "title") ?? "Untitled Work"),
+            feedback: String(fieldValue(fields, "feedback") ?? ""),
+            media: Array.isArray(mediaValue)
+              ? mediaValue
+                  .filter((item): item is string => typeof item === "string")
+                  .map((item) => resolveIPFSUrl(item))
+              : [],
+            createdAt: Number(row.timeCreated),
+          };
+        });
+      } catch (error) {
+        throw wrapPublicGardenImpactSourceError("works", error);
+      }
+    },
+
+    async readApprovals(chainId): Promise<PublicGardenImpactApprovalRecord[]> {
+      assertPublicGardenImpactChain(chainId, "approvals");
+      const schema = requirePublicGardenImpactSchema(
+        "approvals",
+        getEASConfig(chainId).WORK_APPROVAL.uid
+      );
+      try {
+        const rows = await readAttestations({
+          reader: createReader(chainId),
+          source: "approvals",
+          where: { schemaId: { equals: schema }, revoked: { equals: false } },
+          operationName: "readPublicGardenImpactApprovals",
+        });
+        return rows.map((row) => {
+          const fields = decodedFields(row.decodedDataJson);
+          return {
+            id: row.id,
+            workUID: String(fieldValue(fields, "workUID") ?? ""),
+            approved: booleanValue(fieldValue(fields, "approved")),
+            createdAt: Number(row.timeCreated),
+          };
+        });
+      } catch (error) {
+        throw wrapPublicGardenImpactSourceError("approvals", error);
+      }
+    },
+
+    async readAssessments(chainId, gardenAddress): Promise<PublicGardenImpactAssessmentRecord[]> {
+      assertPublicGardenImpactChain(chainId, "assessments");
+      const config = getEASConfig(chainId);
+      const schemas = [
+        ...new Set(
+          [config.ASSESSMENT.uid, config.ASSESSMENT_V3.uid].filter((uid) => !isZeroBytes32(uid))
+        ),
+      ];
+      if (schemas.length === 0) {
+        throw new PublicGardenImpactSourceError("assessments", "missing_schema");
+      }
+      try {
+        const rows = await readAttestations({
+          reader: createReader(chainId),
+          source: "assessments",
+          where: {
+            schemaId: { in: schemas },
+            recipient: addressFilter(gardenAddress),
+            revoked: { equals: false },
+          },
+          operationName: "readPublicGardenImpactAssessments",
+        });
+        return rows.map((row) => ({ id: row.id, createdAt: Number(row.timeCreated) }));
+      } catch (error) {
+        throw wrapPublicGardenImpactSourceError("assessments", error);
+      }
+    },
+  };
+}

--- a/packages/shared/src/modules/data/public-garden-impact-reader-core.ts
+++ b/packages/shared/src/modules/data/public-garden-impact-reader-core.ts
@@ -1,0 +1,96 @@
+import { isPublicGardenImpactChainSupported } from "../../config/blockchain";
+import type { PublicGardenImpactSource } from "../../public-contracts/garden-impact";
+import { isZeroBytes32 } from "../../utils/blockchain/vaults";
+import type { GraphQLReader } from "./graphql-client";
+
+export const PUBLIC_GARDEN_IMPACT_SOURCE_PAGE_SIZE = 100;
+export const PUBLIC_GARDEN_IMPACT_SOURCE_LIMIT = 1_000;
+
+export type PublicGardenImpactSourceFailureReason =
+  | "missing_schema"
+  | "provider_failed"
+  | "limit_exceeded"
+  | "unsupported_chain";
+
+export class PublicGardenImpactSourceError extends Error {
+  constructor(
+    public readonly source: PublicGardenImpactSource,
+    public readonly reason: PublicGardenImpactSourceFailureReason,
+    public readonly cause?: unknown
+  ) {
+    super(`Public garden impact ${source} source is unavailable`);
+    this.name = "PublicGardenImpactSourceError";
+  }
+}
+
+export async function readPublicGardenImpactPages<T>(
+  source: PublicGardenImpactSource,
+  readPage: (limit: number, offset: number) => Promise<T[]>
+): Promise<T[]> {
+  const records: T[] = [];
+  for (
+    let offset = 0;
+    offset <= PUBLIC_GARDEN_IMPACT_SOURCE_LIMIT;
+    offset += PUBLIC_GARDEN_IMPACT_SOURCE_PAGE_SIZE
+  ) {
+    const limit =
+      offset === PUBLIC_GARDEN_IMPACT_SOURCE_LIMIT ? 1 : PUBLIC_GARDEN_IMPACT_SOURCE_PAGE_SIZE;
+    const page = await readPage(limit, offset);
+    if (offset === PUBLIC_GARDEN_IMPACT_SOURCE_LIMIT) {
+      if (page.length > 0) throw new PublicGardenImpactSourceError(source, "limit_exceeded");
+      break;
+    }
+    records.push(...page);
+    if (page.length < limit) break;
+  }
+  return records;
+}
+
+export function assertPublicGardenImpactChain(
+  chainId: number,
+  source: PublicGardenImpactSource
+): void {
+  if (!isPublicGardenImpactChainSupported(chainId)) {
+    throw new PublicGardenImpactSourceError(source, "unsupported_chain");
+  }
+}
+
+export function requirePublicGardenImpactSchema(
+  source: PublicGardenImpactSource,
+  uid: string
+): string {
+  if (isZeroBytes32(uid)) throw new PublicGardenImpactSourceError(source, "missing_schema");
+  return uid;
+}
+
+export function wrapPublicGardenImpactSourceError(
+  source: PublicGardenImpactSource,
+  error: unknown
+): PublicGardenImpactSourceError {
+  return error instanceof PublicGardenImpactSourceError
+    ? error
+    : new PublicGardenImpactSourceError(source, "provider_failed", error);
+}
+
+export async function queryPublicGardenImpactRows<T>(input: {
+  reader: GraphQLReader;
+  document: string;
+  variables: Record<string, unknown>;
+  operationName: string;
+  field: string;
+  source: PublicGardenImpactSource;
+}): Promise<T[]> {
+  const result = await input.reader.query<Record<string, unknown>>(
+    input.document,
+    input.variables,
+    input.operationName
+  );
+  if (result.error) {
+    throw new PublicGardenImpactSourceError(input.source, "provider_failed", result.error);
+  }
+  const rows = result.data[input.field];
+  if (!Array.isArray(rows)) {
+    throw new PublicGardenImpactSourceError(input.source, "provider_failed");
+  }
+  return rows as T[];
+}

--- a/packages/shared/src/modules/data/public-garden-impact-readers.ts
+++ b/packages/shared/src/modules/data/public-garden-impact-readers.ts
@@ -1,0 +1,199 @@
+import type { PublicGardenImpactDomain } from "../../public-contracts/garden-impact";
+import { createEasClient, greenGoodsIndexer, type GraphQLReader } from "./graphql-client";
+import { createPublicGardenImpactEasReaders } from "./public-garden-impact-eas-readers";
+import {
+  assertPublicGardenImpactChain,
+  queryPublicGardenImpactRows,
+  readPublicGardenImpactPages,
+  wrapPublicGardenImpactSourceError,
+} from "./public-garden-impact-reader-core";
+import {
+  loadPublicGardenImpactSnapshot,
+  type PublicGardenImpactActionRecord,
+  type PublicGardenImpactCertificateRecord,
+  type PublicGardenImpactGardenRecord,
+  type PublicGardenImpactLoadInput,
+  type PublicGardenImpactReaders,
+} from "./public-garden-impact";
+
+export {
+  PUBLIC_GARDEN_IMPACT_SOURCE_LIMIT,
+  PUBLIC_GARDEN_IMPACT_SOURCE_PAGE_SIZE,
+  PublicGardenImpactSourceError,
+  type PublicGardenImpactSourceFailureReason,
+} from "./public-garden-impact-reader-core";
+export {
+  PublicGardenImpactNotFoundError,
+  PublicGardenImpactProviderError,
+} from "./public-garden-impact";
+
+interface ReaderDependencies {
+  indexerReader?: GraphQLReader;
+  createEasReader?: (chainId: number) => GraphQLReader;
+}
+
+function toDomain(domain: unknown): PublicGardenImpactDomain | null {
+  switch (domain) {
+    case "SOLAR":
+      return "solar";
+    case "AGRO":
+      return "agroforestry";
+    case "EDU":
+      return "education";
+    case "WASTE":
+      return "waste";
+    default:
+      return null;
+  }
+}
+
+export function createPublicGardenImpactReaders(
+  deps: ReaderDependencies = {}
+): PublicGardenImpactReaders {
+  const indexer = deps.indexerReader ?? greenGoodsIndexer;
+  const easReaders = createPublicGardenImpactEasReaders(deps.createEasReader ?? createEasClient);
+
+  return {
+    ...easReaders,
+
+    async readGarden(chainId, gardenAddress): Promise<PublicGardenImpactGardenRecord | null> {
+      assertPublicGardenImpactChain(chainId, "works");
+      const query = /* GraphQL */ `
+        query PublicGardenImpactGarden($chainId: Int!, $gardenAddress: String!) {
+          Garden(
+            where: { chainId: { _eq: $chainId }, id: { _ilike: $gardenAddress } }
+            limit: 2
+          ) {
+            id
+            chainId
+            name
+            location
+            initialized
+          }
+        }
+      `;
+      try {
+        const rows = await queryPublicGardenImpactRows<Record<string, unknown>>({
+          reader: indexer,
+          document: query,
+          variables: { chainId, gardenAddress },
+          operationName: "readPublicGardenImpactGarden",
+          field: "Garden",
+          source: "works",
+        });
+        const garden = rows.find((row) => Number(row.chainId) === chainId);
+        if (!garden || garden.initialized === false) return null;
+        return {
+          id: String(garden.id ?? ""),
+          name: typeof garden.name === "string" && garden.name.trim() ? garden.name : null,
+          location:
+            typeof garden.location === "string" && garden.location.trim() ? garden.location : null,
+        };
+      } catch (error) {
+        throw wrapPublicGardenImpactSourceError("works", error);
+      }
+    },
+
+    async readActions(chainId): Promise<PublicGardenImpactActionRecord[]> {
+      assertPublicGardenImpactChain(chainId, "actions");
+      const query = /* GraphQL */ `
+        query PublicGardenImpactActions($chainId: Int!, $limit: Int!, $offset: Int!) {
+          Action(
+            where: { chainId: { _eq: $chainId } }
+            order_by: { id: asc }
+            limit: $limit
+            offset: $offset
+          ) {
+            id
+            title
+            domain
+          }
+        }
+      `;
+      try {
+        const rows = await readPublicGardenImpactPages<Record<string, unknown>>(
+          "actions",
+          (limit, offset) =>
+            queryPublicGardenImpactRows({
+              reader: indexer,
+              document: query,
+              variables: { chainId, limit, offset },
+              operationName: "readPublicGardenImpactActions",
+              field: "Action",
+              source: "actions",
+            })
+        );
+        return rows.map((row) => ({
+          id: String(row.id ?? ""),
+          title: typeof row.title === "string" && row.title.trim() ? row.title : null,
+          domain: toDomain(row.domain),
+        }));
+      } catch (error) {
+        throw wrapPublicGardenImpactSourceError("actions", error);
+      }
+    },
+
+    async readCertificates(chainId, gardenAddress): Promise<PublicGardenImpactCertificateRecord[]> {
+      assertPublicGardenImpactChain(chainId, "certificates");
+      const query = /* GraphQL */ `
+        query PublicGardenImpactCertificates(
+          $chainId: Int!
+          $gardenAddress: String!
+          $limit: Int!
+          $offset: Int!
+        ) {
+          Hypercert(
+            where: {
+              chainId: { _eq: $chainId }
+              garden: { _ilike: $gardenAddress }
+            }
+            order_by: { id: asc }
+            limit: $limit
+            offset: $offset
+          ) {
+            id
+            status
+            mintedAt
+            updatedAt
+          }
+        }
+      `;
+      try {
+        const rows = await readPublicGardenImpactPages<Record<string, unknown>>(
+          "certificates",
+          (limit, offset) =>
+            queryPublicGardenImpactRows({
+              reader: indexer,
+              document: query,
+              variables: { chainId, gardenAddress, limit, offset },
+              operationName: "readPublicGardenImpactCertificates",
+              field: "Hypercert",
+              source: "certificates",
+            })
+        );
+        return rows.map((row) => {
+          const mintedAt = Number(row.mintedAt ?? 0);
+          const updatedAt = Number(row.updatedAt ?? 0);
+          return {
+            id: String(row.id ?? ""),
+            status:
+              typeof row.status === "string" &&
+              ["active", "claimed", "sold"].includes(row.status.toLowerCase())
+                ? (row.status.toLowerCase() as "active" | "claimed" | "sold")
+                : "unknown",
+            mintedAt,
+            updatedAt: Number.isFinite(updatedAt) && updatedAt > 0 ? updatedAt : mintedAt,
+          };
+        });
+      } catch (error) {
+        throw wrapPublicGardenImpactSourceError("certificates", error);
+      }
+    },
+  };
+}
+
+const defaultPublicGardenImpactReaders = createPublicGardenImpactReaders();
+
+export function readPublicGardenImpactSnapshot(input: PublicGardenImpactLoadInput) {
+  return loadPublicGardenImpactSnapshot(input, { readers: defaultPublicGardenImpactReaders });
+}

--- a/packages/shared/src/modules/data/public-garden-impact-readers.ts
+++ b/packages/shared/src/modules/data/public-garden-impact-readers.ts
@@ -1,8 +1,24 @@
+import {
+  getPublicGardenImpactChainConfig,
+  isPublicGardenImpactChainSupported,
+} from "../../config/blockchain";
+import { getChain } from "../../config/chains";
+import type { Address } from "../../public-contracts/core";
 import type { PublicGardenImpactDomain } from "../../public-contracts/garden-impact";
+import { getRpcUrl } from "../../utils/blockchain/chain-registry";
+import {
+  ContractFunctionExecutionError,
+  ContractFunctionRevertedError,
+  ContractFunctionZeroDataError,
+  createPublicClient,
+  getAddress,
+  http,
+} from "viem";
 import { createEasClient, greenGoodsIndexer, type GraphQLReader } from "./graphql-client";
 import { createPublicGardenImpactEasReaders } from "./public-garden-impact-eas-readers";
 import {
   assertPublicGardenImpactChain,
+  PublicGardenImpactSourceError,
   queryPublicGardenImpactRows,
   readPublicGardenImpactPages,
   wrapPublicGardenImpactSourceError,
@@ -30,6 +46,78 @@ export {
 interface ReaderDependencies {
   indexerReader?: GraphQLReader;
   createEasReader?: (chainId: number) => GraphQLReader;
+  createChainReader?: (chainId: number) => PublicGardenImpactChainReader;
+}
+
+interface PublicGardenImpactChainReader {
+  readContract(input: {
+    address: Address;
+    abi: readonly unknown[];
+    functionName: string;
+    args?: readonly unknown[];
+  }): Promise<unknown>;
+}
+
+const GARDEN_ACCOUNT_IDENTITY_ABI = [
+  {
+    type: "function",
+    name: "token",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [
+      { name: "chainId", type: "uint256" },
+      { name: "tokenContract", type: "address" },
+      { name: "tokenId", type: "uint256" },
+    ],
+  },
+  {
+    type: "function",
+    name: "name",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "string" }],
+  },
+  {
+    type: "function",
+    name: "location",
+    stateMutability: "view",
+    inputs: [],
+    outputs: [{ name: "", type: "string" }],
+  },
+] as const;
+
+const TOKENBOUND_REGISTRY_ABI = [
+  {
+    type: "function",
+    name: "account",
+    stateMutability: "view",
+    inputs: [
+      { name: "implementation", type: "address" },
+      { name: "salt", type: "bytes32" },
+      { name: "chainId", type: "uint256" },
+      { name: "tokenContract", type: "address" },
+      { name: "tokenId", type: "uint256" },
+    ],
+    outputs: [{ name: "account", type: "address" }],
+  },
+] as const;
+
+const GARDEN_ACCOUNT_SALT =
+  "0x6551655165516551655165516551655165516551655165516551655165516551" as const;
+
+function defaultChainReader(chainId: number): PublicGardenImpactChainReader {
+  return createPublicClient({
+    chain: getChain(chainId),
+    transport: http(getRpcUrl(chainId)),
+  }) as unknown as PublicGardenImpactChainReader;
+}
+
+function isMissingGardenContract(error: unknown): boolean {
+  return (
+    error instanceof ContractFunctionExecutionError &&
+    (error.cause instanceof ContractFunctionZeroDataError ||
+      error.cause instanceof ContractFunctionRevertedError)
+  );
 }
 
 function toDomain(domain: unknown): PublicGardenImpactDomain | null {
@@ -58,36 +146,65 @@ export function createPublicGardenImpactReaders(
 
     async readGarden(chainId, gardenAddress): Promise<PublicGardenImpactGardenRecord | null> {
       assertPublicGardenImpactChain(chainId, "works");
-      const query = /* GraphQL */ `
-        query PublicGardenImpactGarden($chainId: Int!, $gardenAddress: String!) {
-          Garden(
-            where: { chainId: { _eq: $chainId }, id: { _ilike: $gardenAddress } }
-            limit: 2
-          ) {
-            id
-            chainId
-            name
-            location
-            initialized
-          }
-        }
-      `;
+      const config = getPublicGardenImpactChainConfig(chainId);
+      if (!config || !isPublicGardenImpactChainSupported(chainId)) {
+        throw new PublicGardenImpactSourceError("works", "unsupported_chain");
+      }
       try {
-        const rows = await queryPublicGardenImpactRows<Record<string, unknown>>({
-          reader: indexer,
-          document: query,
-          variables: { chainId, gardenAddress },
-          operationName: "readPublicGardenImpactGarden",
-          field: "Garden",
-          source: "works",
+        const chainReader = deps.createChainReader?.(chainId) ?? defaultChainReader(chainId);
+        let token: unknown;
+        try {
+          token = await chainReader.readContract({
+            address: gardenAddress,
+            abi: GARDEN_ACCOUNT_IDENTITY_ABI,
+            functionName: "token",
+          });
+        } catch (error) {
+          if (isMissingGardenContract(error)) return null;
+          throw error;
+        }
+        if (!Array.isArray(token) || token.length !== 3)
+          throw new Error("Invalid Garden token tuple");
+        const tokenChainId = BigInt(token[0] as bigint | number | string);
+        const tokenContract = getAddress(String(token[1]));
+        const tokenId = BigInt(token[2] as bigint | number | string);
+        if (
+          tokenChainId !== BigInt(chainId) ||
+          tokenContract.toLowerCase() !== config.gardenToken.toLowerCase()
+        ) {
+          return null;
+        }
+        const expectedAccount = await chainReader.readContract({
+          address: getAddress(config.tokenboundRegistry) as Address,
+          abi: TOKENBOUND_REGISTRY_ABI,
+          functionName: "account",
+          args: [
+            getAddress(config.gardenAccountImpl),
+            GARDEN_ACCOUNT_SALT,
+            tokenChainId,
+            tokenContract,
+            tokenId,
+          ],
         });
-        const garden = rows.find((row) => Number(row.chainId) === chainId);
-        if (!garden || garden.initialized === false) return null;
+        if (getAddress(String(expectedAccount)).toLowerCase() !== gardenAddress.toLowerCase()) {
+          return null;
+        }
+        const [name, location] = await Promise.all([
+          chainReader.readContract({
+            address: gardenAddress,
+            abi: GARDEN_ACCOUNT_IDENTITY_ABI,
+            functionName: "name",
+          }),
+          chainReader.readContract({
+            address: gardenAddress,
+            abi: GARDEN_ACCOUNT_IDENTITY_ABI,
+            functionName: "location",
+          }),
+        ]);
         return {
-          id: String(garden.id ?? ""),
-          name: typeof garden.name === "string" && garden.name.trim() ? garden.name : null,
-          location:
-            typeof garden.location === "string" && garden.location.trim() ? garden.location : null,
+          id: gardenAddress,
+          name: typeof name === "string" && name.trim() ? name : null,
+          location: typeof location === "string" && location.trim() ? location : null,
         };
       } catch (error) {
         throw wrapPublicGardenImpactSourceError("works", error);

--- a/packages/shared/src/modules/data/public-garden-impact.ts
+++ b/packages/shared/src/modules/data/public-garden-impact.ts
@@ -76,7 +76,7 @@ export interface PublicGardenImpactReaders {
 
 export interface PublicGardenImpactLoadInput {
   chainId: number;
-  gardenAddress: string;
+  gardenAddress: Address;
   recentLimit: number;
 }
 

--- a/packages/shared/src/modules/data/public-garden-impact.ts
+++ b/packages/shared/src/modules/data/public-garden-impact.ts
@@ -1,0 +1,344 @@
+import { isGardenPubliclyVisible } from "../../config/garden-visibility";
+import {
+  PUBLIC_GARDEN_IMPACT_DOMAINS,
+  PUBLIC_GARDEN_IMPACT_MAX_RECENT_LIMIT,
+  PUBLIC_GARDEN_IMPACT_VERSION,
+  type PublicGardenImpactActionBreakdown,
+  type PublicGardenImpactDomain,
+  type PublicGardenImpactDomainBreakdown,
+  type PublicGardenImpactRecentWork,
+  type PublicGardenImpactResponseV1,
+  type PublicGardenImpactSource,
+} from "../../public-contracts/garden-impact";
+import type { Address } from "../../public-contracts/core";
+import { buildPublicGardenImpactPath } from "../../public-contracts/routes";
+import { getAddress } from "viem";
+
+const PUBLIC_GARDEN_IMPACT_API_URL = "https://agent.greengoods.app";
+
+export interface PublicGardenImpactGardenRecord {
+  id: string;
+  name: string | null;
+  location: string | null;
+}
+
+export interface PublicGardenImpactWorkRecord {
+  id: string;
+  actionUID: number;
+  title: string;
+  feedback: string;
+  media: string[];
+  createdAt: number;
+}
+
+export interface PublicGardenImpactApprovalRecord {
+  id: string;
+  workUID: string;
+  approved: boolean;
+  createdAt: number;
+}
+
+export interface PublicGardenImpactActionRecord {
+  id: string;
+  title: string | null;
+  domain: PublicGardenImpactDomain | null;
+}
+
+export interface PublicGardenImpactAssessmentRecord {
+  id: string;
+  createdAt: number;
+}
+
+export interface PublicGardenImpactCertificateRecord {
+  id: string;
+  status: "active" | "claimed" | "sold" | "unknown";
+  mintedAt: number;
+  updatedAt: number;
+}
+
+export interface PublicGardenImpactReaders {
+  readGarden(
+    chainId: number,
+    gardenAddress: Address
+  ): Promise<PublicGardenImpactGardenRecord | null>;
+  readWorks(chainId: number, gardenAddress: Address): Promise<PublicGardenImpactWorkRecord[]>;
+  readApprovals(chainId: number): Promise<PublicGardenImpactApprovalRecord[]>;
+  readActions(chainId: number): Promise<PublicGardenImpactActionRecord[]>;
+  readAssessments(
+    chainId: number,
+    gardenAddress: Address
+  ): Promise<PublicGardenImpactAssessmentRecord[]>;
+  readCertificates(
+    chainId: number,
+    gardenAddress: Address
+  ): Promise<PublicGardenImpactCertificateRecord[]>;
+}
+
+export interface PublicGardenImpactLoadInput {
+  chainId: number;
+  gardenAddress: string;
+  recentLimit: number;
+}
+
+export class PublicGardenImpactNotFoundError extends Error {
+  constructor() {
+    super("Public garden not found");
+    this.name = "PublicGardenImpactNotFoundError";
+  }
+}
+
+export class PublicGardenImpactProviderError extends Error {
+  constructor() {
+    super("Public garden impact providers are unavailable");
+    this.name = "PublicGardenImpactProviderError";
+  }
+}
+
+interface SourceState<T> {
+  available: boolean;
+  data: T;
+}
+
+const unavailable = <T>(fallback: T): SourceState<T> => ({ available: false, data: fallback });
+
+async function settle<T>(read: () => Promise<T>, fallback: T): Promise<SourceState<T>> {
+  try {
+    return { available: true, data: await read() };
+  } catch {
+    return unavailable(fallback);
+  }
+}
+
+function dedupeNewest<T extends { id: string }>(
+  records: readonly T[],
+  timestamp: (record: T) => number
+): T[] {
+  const byId = new Map<string, T>();
+  for (const record of records) {
+    const key = record.id.toLowerCase();
+    const existing = byId.get(key);
+    if (!existing || timestamp(record) > timestamp(existing)) byId.set(key, record);
+  }
+  return [...byId.values()];
+}
+
+function toIso(seconds: number): string | null {
+  if (!Number.isFinite(seconds) || seconds <= 0) return null;
+  return new Date(seconds * 1000).toISOString();
+}
+
+function latestIso(values: readonly number[]): string | null {
+  return toIso(values.reduce((latest, value) => Math.max(latest, value), 0));
+}
+
+function buildApprovedAt(
+  approvals: readonly PublicGardenImpactApprovalRecord[],
+  workIds: ReadonlySet<string>
+): Map<string, number> {
+  const approvedAt = new Map<string, number>();
+  for (const approval of approvals) {
+    const workId = approval.workUID.toLowerCase();
+    if (!approval.approved || !workIds.has(workId)) continue;
+    approvedAt.set(workId, Math.max(approvedAt.get(workId) ?? 0, approval.createdAt));
+  }
+  return approvedAt;
+}
+
+function buildBreakdown(input: {
+  chainId: number;
+  works: readonly PublicGardenImpactWorkRecord[];
+  approvalsAvailable: boolean;
+  approvedAt: ReadonlyMap<string, number>;
+  actions: readonly PublicGardenImpactActionRecord[];
+}): {
+  byDomain: PublicGardenImpactDomainBreakdown[];
+  byAction: PublicGardenImpactActionBreakdown[];
+} {
+  const actions = new Map(input.actions.map((action) => [action.id.toLowerCase(), action]));
+  const byAction = new Map<number, PublicGardenImpactWorkRecord[]>();
+  for (const work of input.works) {
+    const records = byAction.get(work.actionUID) ?? [];
+    records.push(work);
+    byAction.set(work.actionUID, records);
+  }
+
+  const actionRows = [...byAction.entries()]
+    .sort(([left], [right]) => left - right)
+    .map(([actionUid, works]) => {
+      const actionId = `${input.chainId}-${actionUid}`;
+      const action = actions.get(actionId.toLowerCase());
+      return {
+        actionUid,
+        actionId,
+        title: action?.title ?? null,
+        domain: action?.domain ?? null,
+        submittedWorkCount: works.length,
+        approvedWorkCount: input.approvalsAvailable
+          ? works.filter((work) => input.approvedAt.has(work.id.toLowerCase())).length
+          : null,
+      } satisfies PublicGardenImpactActionBreakdown;
+    });
+
+  const domainRows = PUBLIC_GARDEN_IMPACT_DOMAINS.map((domain) => {
+    const matchingWorks = input.works.filter((work) => {
+      const action = actions.get(`${input.chainId}-${work.actionUID}`.toLowerCase());
+      return action?.domain === domain;
+    });
+    return {
+      domain,
+      submittedWorkCount: matchingWorks.length,
+      approvedWorkCount: input.approvalsAvailable
+        ? matchingWorks.filter((work) => input.approvedAt.has(work.id.toLowerCase())).length
+        : null,
+    } satisfies PublicGardenImpactDomainBreakdown;
+  });
+  return { byDomain: domainRows, byAction: actionRows };
+}
+
+function buildRecentWork(input: {
+  chainId: number;
+  works: readonly PublicGardenImpactWorkRecord[];
+  approvedAt: ReadonlyMap<string, number>;
+  actions: readonly PublicGardenImpactActionRecord[];
+  limit: number;
+}): PublicGardenImpactRecentWork[] {
+  const actions = new Map(input.actions.map((action) => [action.id.toLowerCase(), action]));
+  return input.works
+    .filter((work) => input.approvedAt.has(work.id.toLowerCase()))
+    .sort((left, right) => right.createdAt - left.createdAt || left.id.localeCompare(right.id))
+    .slice(0, input.limit)
+    .map((work) => {
+      const action = actions.get(`${input.chainId}-${work.actionUID}`.toLowerCase());
+      return {
+        id: work.id,
+        title: work.title,
+        description: work.feedback.trim() || null,
+        media: [...work.media],
+        actionUid: work.actionUID,
+        action: action ? { id: action.id, title: action.title, domain: action.domain } : null,
+        createdAt: toIso(work.createdAt) ?? new Date(0).toISOString(),
+        approvedAt:
+          toIso(input.approvedAt.get(work.id.toLowerCase()) ?? 0) ?? new Date(0).toISOString(),
+      };
+    });
+}
+
+export async function loadPublicGardenImpactSnapshot(
+  input: PublicGardenImpactLoadInput,
+  deps: { readers: PublicGardenImpactReaders; now?: () => number; apiUrl?: string }
+): Promise<PublicGardenImpactResponseV1> {
+  const address = getAddress(input.gardenAddress) as Address;
+  let garden: PublicGardenImpactGardenRecord | null;
+  try {
+    garden = await deps.readers.readGarden(input.chainId, address);
+  } catch {
+    throw new PublicGardenImpactProviderError();
+  }
+  if (
+    !garden ||
+    garden.id.toLowerCase() !== address.toLowerCase() ||
+    !isGardenPubliclyVisible(garden)
+  ) {
+    throw new PublicGardenImpactNotFoundError();
+  }
+
+  const [works, approvals, actions, assessments, certificates] = await Promise.all([
+    settle(() => deps.readers.readWorks(input.chainId, address), []),
+    settle(() => deps.readers.readApprovals(input.chainId), []),
+    settle(() => deps.readers.readActions(input.chainId), []),
+    settle(() => deps.readers.readAssessments(input.chainId, address), []),
+    settle(() => deps.readers.readCertificates(input.chainId, address), []),
+  ]);
+  if (!works.available && !assessments.available && !certificates.available) {
+    throw new PublicGardenImpactProviderError();
+  }
+
+  const workRecords = dedupeNewest(works.data, (record) => record.createdAt);
+  const workIds = new Set(workRecords.map((record) => record.id.toLowerCase()));
+  const approvalRecords = dedupeNewest(approvals.data, (record) => record.createdAt);
+  const approvedAt = buildApprovedAt(approvalRecords, workIds);
+  const assessmentRecords = dedupeNewest(assessments.data, (record) => record.createdAt);
+  const allCertificateRecords = dedupeNewest(certificates.data, (record) => record.updatedAt);
+  const certificateRecords = allCertificateRecords.filter((record) => record.status !== "unknown");
+  const actionRecords = dedupeNewest(actions.data, () => 0);
+  const unavailableSources = (
+    [
+      ["works", works],
+      ["approvals", approvals],
+      ["actions", actions],
+      ["assessments", assessments],
+      ["certificates", certificates],
+    ] as const
+  )
+    .filter(([, state]) => !state.available)
+    .map(([source]) => source satisfies PublicGardenImpactSource);
+  const impactTimes = [
+    ...workRecords.map((record) => record.createdAt),
+    ...approvalRecords
+      .filter((record) => workIds.has(record.workUID.toLowerCase()))
+      .map((record) => record.createdAt),
+    ...assessmentRecords.map((record) => record.createdAt),
+    ...allCertificateRecords.map((record) => record.updatedAt),
+  ];
+  const availableBreakdown = works.available
+    ? buildBreakdown({
+        chainId: input.chainId,
+        works: workRecords,
+        approvalsAvailable: approvals.available,
+        approvedAt,
+        actions: actions.available ? actionRecords : [],
+      })
+    : null;
+  const breakdown = {
+    byDomain: works.available && actions.available ? (availableBreakdown?.byDomain ?? null) : null,
+    byAction: availableBreakdown?.byAction ?? null,
+  };
+  const recentLimit = Math.max(
+    0,
+    Math.min(PUBLIC_GARDEN_IMPACT_MAX_RECENT_LIMIT, Math.floor(input.recentLimit))
+  );
+  const isEmpty =
+    unavailableSources.length === 0 &&
+    workRecords.length === 0 &&
+    assessmentRecords.length === 0 &&
+    certificateRecords.length === 0;
+
+  return {
+    version: PUBLIC_GARDEN_IMPACT_VERSION,
+    ok: true,
+    garden: {
+      chainId: input.chainId,
+      address,
+      name: garden.name,
+      location: garden.location,
+      url: new URL(
+        buildPublicGardenImpactPath(input.chainId, address),
+        deps.apiUrl ?? PUBLIC_GARDEN_IMPACT_API_URL
+      ).toString(),
+    },
+    summary: {
+      submittedWorkCount: works.available ? workRecords.length : null,
+      approvedWorkCount: works.available && approvals.available ? approvedAt.size : null,
+      assessmentCount: assessments.available ? assessmentRecords.length : null,
+      impactCertificateCount: certificates.available ? certificateRecords.length : null,
+      latestKnownActivityAt: latestIso(impactTimes),
+    },
+    breakdown,
+    recentWork:
+      works.available && approvals.available
+        ? buildRecentWork({
+            chainId: input.chainId,
+            works: workRecords,
+            approvedAt,
+            actions: actions.available ? actionRecords : [],
+            limit: recentLimit,
+          })
+        : null,
+    provenance: {
+      status: unavailableSources.length > 0 ? "partial" : isEmpty ? "empty" : "ready",
+      partialData: unavailableSources.length > 0,
+      unavailableSources,
+      fetchedAt: new Date(deps.now?.() ?? Date.now()).toISOString(),
+    },
+  };
+}

--- a/packages/shared/src/modules/index.ts
+++ b/packages/shared/src/modules/index.ts
@@ -1,5 +1,4 @@
 // Modules — EXPLICIT EXPORTS for tree-shaking
-
 export * from "./commitment-pooling";
 
 export {
@@ -181,6 +180,7 @@ export {
   greenGoodsIndexer,
   withTimeout,
 } from "./data/graphql-client";
+export * from "./data/public-garden-impact-readers";
 // ============================================================================
 // DATA / GREENGOODS
 // ============================================================================

--- a/packages/shared/src/public-contracts/garden-impact.ts
+++ b/packages/shared/src/public-contracts/garden-impact.ts
@@ -1,0 +1,81 @@
+import type { Address } from "./funding-types";
+
+export const PUBLIC_GARDEN_IMPACT_VERSION = 1 as const;
+export const PUBLIC_GARDEN_IMPACT_DEFAULT_RECENT_LIMIT = 3;
+export const PUBLIC_GARDEN_IMPACT_MAX_RECENT_LIMIT = 12;
+export const PUBLIC_GARDEN_IMPACT_DOMAINS = [
+  "solar",
+  "agroforestry",
+  "education",
+  "waste",
+] as const;
+
+export type PublicGardenImpactDomain = (typeof PUBLIC_GARDEN_IMPACT_DOMAINS)[number];
+export type PublicGardenImpactSource =
+  | "works"
+  | "approvals"
+  | "actions"
+  | "assessments"
+  | "certificates";
+
+export type PublicGardenImpactCount = number | null;
+
+export interface PublicGardenImpactDomainBreakdown {
+  domain: PublicGardenImpactDomain;
+  submittedWorkCount: number;
+  approvedWorkCount: PublicGardenImpactCount;
+}
+
+export interface PublicGardenImpactActionBreakdown {
+  actionUid: number;
+  actionId: string;
+  title: string | null;
+  domain: PublicGardenImpactDomain | null;
+  submittedWorkCount: number;
+  approvedWorkCount: PublicGardenImpactCount;
+}
+
+export interface PublicGardenImpactRecentWork {
+  id: string;
+  title: string;
+  description: string | null;
+  media: string[];
+  actionUid: number;
+  action: {
+    id: string;
+    title: string | null;
+    domain: PublicGardenImpactDomain | null;
+  } | null;
+  createdAt: string;
+  approvedAt: string;
+}
+
+export interface PublicGardenImpactResponseV1 {
+  version: typeof PUBLIC_GARDEN_IMPACT_VERSION;
+  ok: true;
+  garden: {
+    chainId: number;
+    address: Address;
+    name: string | null;
+    location: string | null;
+    url: string;
+  };
+  summary: {
+    submittedWorkCount: PublicGardenImpactCount;
+    approvedWorkCount: PublicGardenImpactCount;
+    assessmentCount: PublicGardenImpactCount;
+    impactCertificateCount: PublicGardenImpactCount;
+    latestKnownActivityAt: string | null;
+  };
+  breakdown: {
+    byDomain: PublicGardenImpactDomainBreakdown[] | null;
+    byAction: PublicGardenImpactActionBreakdown[] | null;
+  };
+  recentWork: PublicGardenImpactRecentWork[] | null;
+  provenance: {
+    status: "ready" | "empty" | "partial";
+    partialData: boolean;
+    unavailableSources: PublicGardenImpactSource[];
+    fetchedAt: string;
+  };
+}

--- a/packages/shared/src/public-contracts/index.ts
+++ b/packages/shared/src/public-contracts/index.ts
@@ -10,6 +10,19 @@ import {
 
 export { derivePublicGardenSlug } from "./garden-slug";
 export {
+  PUBLIC_GARDEN_IMPACT_DEFAULT_RECENT_LIMIT,
+  PUBLIC_GARDEN_IMPACT_DOMAINS,
+  PUBLIC_GARDEN_IMPACT_MAX_RECENT_LIMIT,
+  PUBLIC_GARDEN_IMPACT_VERSION,
+  type PublicGardenImpactActionBreakdown,
+  type PublicGardenImpactCount,
+  type PublicGardenImpactDomain,
+  type PublicGardenImpactDomainBreakdown,
+  type PublicGardenImpactRecentWork,
+  type PublicGardenImpactResponseV1,
+  type PublicGardenImpactSource,
+} from "./garden-impact";
+export {
   createPublicImpactSlice,
   PUBLIC_IMPACT_DEFAULT_PAGE_SIZE,
   PUBLIC_IMPACT_GARDEN_FETCH_CAP,
@@ -19,7 +32,7 @@ export {
   type PublicImpactGardenSource,
   type PublicImpactSlice,
 } from "./public-impact";
-export { PUBLIC_AGENT_ROUTES } from "./routes";
+export { buildPublicGardenImpactPath, PUBLIC_AGENT_ROUTES } from "./routes";
 
 export {
   PUBLIC_UPLOAD_SIGN_ALLOWED_CATEGORIES,

--- a/packages/shared/src/public-contracts/routes.ts
+++ b/packages/shared/src/public-contracts/routes.ts
@@ -1,3 +1,5 @@
+import type { Address } from "./core";
+
 export const PUBLIC_AGENT_ROUTES = {
   subscribe: "/public/subscribe",
   fundingIntents: "/public/funding-intents",
@@ -10,7 +12,7 @@ export const PUBLIC_AGENT_ROUTES = {
 
 export function buildPublicGardenImpactPath(
   chainId: number | string,
-  gardenAddress: string
+  gardenAddress: Address
 ): string {
   return `/public/gardens/${encodeURIComponent(String(chainId))}/${encodeURIComponent(gardenAddress)}/impact`;
 }

--- a/packages/shared/src/public-contracts/routes.ts
+++ b/packages/shared/src/public-contracts/routes.ts
@@ -3,6 +3,14 @@ export const PUBLIC_AGENT_ROUTES = {
   fundingIntents: "/public/funding-intents",
   fundingIntentProof: "/public/funding-intents/proof",
   fundingIntentReceipt: "/public/funding-intents/:id",
+  gardenImpact: "/public/gardens/:chainId/:gardenAddress/impact",
   uploadSign: "/api/uploads/sign",
   thirdwebWebhook: "/webhooks/thirdweb",
 } as const;
+
+export function buildPublicGardenImpactPath(
+  chainId: number | string,
+  gardenAddress: string
+): string {
+  return `/public/gardens/${encodeURIComponent(String(chainId))}/${encodeURIComponent(gardenAddress)}/impact`;
+}


### PR DESCRIPTION
## Summary
- Add a versioned, read-only public garden impact endpoint with canonical chain/address routing.
- Aggregate Work, approval, action, assessment, and Hypercert data with provenance-aware partial results.
- Add rate limiting, caching, CORS handling, shared contracts/readers, tests, and developer documentation.

## Validation
- [x] Unit tests added for shared contracts, readers, aggregation, and Agent API behavior
- [x] `bun run test` passes
- [x] `bun format && bun lint` passes

Automated PR labels: `automated/codex`  
Draft: yes