### PR TITLE
docs(qa): finding dispositions, decisions child, run-aware call mode, and the qa-runs hub

### DIFF
--- a/.claude/context/qa.md
+++ b/.claude/context/qa.md
@@ -166,8 +166,9 @@ skipped case recorded as `N/A` overstates coverage and hides the gap the next wa
 
 Environment attribution: the session header and the Linear parent lede name the session's default
 environment (production, beta/staging, or local). A tester who crosses to another environment for
-one case prefixes that note with `[beta]` or `[prod]`. Until the QA app records runs with their own
-environment field, the prefix is the only per-verdict environment record.
+one case prefixes that note with `[beta]`, `[prod]`, or `[local]`: every verdict taken outside the
+session default carries its prefix, whichever of the three the default is. Until the QA app records
+runs with their own environment field, the prefix is the only per-verdict environment record.
 
 ## Finding dispositions
 
@@ -179,10 +180,10 @@ ID, tester, and verdict, before assigning dispositions or clustering.
 | Disposition | What it is | Where it lands |
 | --- | --- | --- |
 | `defect` | The product does not do what the case expects | A slice, or an existing tracked Issue |
-| `polish` | It works but looks or reads wrong | A slice at Low priority, clustered by seam |
+| `polish` | It works but looks or reads wrong; it may sit beside a Pass verdict | A slice at Low priority regardless of case priority, clustered by seam: `Todo` when at least one member entry was recorded inside the session window (a pass with a note counts), `Backlog` when reconstructed from notes alone |
 | `decision` | Needs a product or design ruling before a fix is honest (limits, copy direction, flow choices) | The parent's `Decisions needed` section plus the session's single decisions child |
 | `investigate` | A symptom whose cause or intent is unknown; not fixable until someone looks | A `Not sliced · investigate` line in the parent; a slice only after the look |
-| `catalog` | Feedback about the test case itself: split it, rename it, move it, unclear, missing twin | `tmp/qa-triage/<slug>/catalog-feedback.md` from the skill, or one `Catalog feedback` comment on the parent from the routine; folded into the next catalog change; never a slice |
+| `catalog` | Feedback about the test case itself: split it, rename it, move it, unclear, missing twin | `tmp/qa-triage/<slug>/catalog-feedback.md` from the skill, copied at close into the plan hub that owns the next catalog change (de-attributed: no verdicts, no tester names, because the repository is public), or one `Catalog feedback` comment on the parent from the routine; never a slice |
 | `environment` | Behaviour caused by the harness or environment, not the product (cold start, beta-only data, wrong wallet) | One environment line in the parent; never a slice |
 
 Observations that already carry a tracked Issue (exact Test ID or error hash, or a title match a

--- a/.claude/context/qa.md
+++ b/.claude/context/qa.md
@@ -147,6 +147,41 @@ slice's Linear *priority* from case priority plus verdict — a queue-ordering d
 session re-judges at take-up, not a severity judgment; Sheet severity stays independently
 assigned.
 
+## Verdict vocabulary
+
+`Pass`, `Fail`, and `Blocked` describe what happened on the walk. `N/A` means the case was
+intentionally outside the run's agreed scope: a device or role nobody on the walk could hold, or a
+surface consciously excluded when scope was set. A case nobody walked has **no entry**. Do not
+record `N/A` to mean "skipped this time": the report counts `N/A` as walked and judged, so a
+skipped case recorded as `N/A` overstates coverage and hides the gap the next walk should close.
+(Decided 2026-09-05, after the 2026-09-04 call recorded thirteen skipped commitment cases as N/A.)
+
+Environment attribution: the session header and the Linear parent lede name the session's default
+environment (production, beta/staging, or local). A tester who crosses to another environment for
+one case prefixes that note with `[beta]` or `[prod]`. Until the QA app records runs with their own
+environment field, the prefix is the only per-verdict environment record.
+
+## Finding dispositions
+
+Every observation a session produces (an app note, a dictated OBS record, or a meeting-notes item)
+resolves to exactly one disposition before anything is filed. A dictated app note usually carries
+several observations; split it into one observation per distinct symptom, each keeping its Test
+ID, tester, and verdict, before assigning dispositions or clustering.
+
+| Disposition | What it is | Where it lands |
+| --- | --- | --- |
+| `defect` | The product does not do what the case expects | A slice, or an existing tracked Issue |
+| `polish` | It works but looks or reads wrong | A slice at Low priority, clustered by seam |
+| `decision` | Needs a product or design ruling before a fix is honest (limits, copy direction, flow choices) | The parent's `Decisions needed` section plus the session's single decisions child |
+| `investigate` | A symptom whose cause or intent is unknown; not fixable until someone looks | A `Not sliced · investigate` line in the parent; a slice only after the look |
+| `catalog` | Feedback about the test case itself: split it, rename it, move it, unclear, missing twin | `tmp/qa-triage/<slug>/catalog-feedback.md` from the skill, or one `Catalog feedback` comment on the parent from the routine; folded into the next catalog change; never a slice |
+| `environment` | Behaviour caused by the harness or environment, not the product (cold start, beta-only data, wrong wallet) | One environment line in the parent; never a slice |
+
+Observations that already carry a tracked Issue (exact Test ID or error hash, or a title match a
+human confirmed at the gate) are linked, not re-filed. A tester's own words carry severity: "major
+regression", "major blocker", or "completely broken" in a note proposes Urgent at the gate, where a
+human confirms it.
+
 ## Roster and attribution
 
 The deployed roster is the unique address list in `QA_ALLOWLIST`; it is discovered at runtime and is

--- a/.claude/context/qa.md
+++ b/.claude/context/qa.md
@@ -80,7 +80,7 @@ deferred handoff, or a live session — works in this order:
 | Coverage report | Standard output from `bun run qa:status` | Read-only command; nothing is persisted |
 | Defect tracking | Linear plus the private Green Goods v1.1 QA Sheet | `qa-triage`, after explicit scope and write confirmation |
 | Session report and fix slices | Linear Product team — `QA session YYYY-MM-DD` parent plus slice sub-issues | [`qa-call-report`](../../docs/routines/qa-call-report.md) after a team call, or `/qa-triage --call` interactively |
-| Full session report, attributed | Linear document `QA session YYYY-MM-DD · full report` attached to the session parent | [`qa-call-report`](../../docs/routines/qa-call-report.md), `/qa-triage --call`, or the `qa-session` close, after the privacy grep |
+| Full session report, attributed | Linear document `QA session YYYY-MM-DD · full report` attached to the session parent; beside the receipt in the restricted Drive QA folder when a solo session has no parent | [`qa-call-report`](../../docs/routines/qa-call-report.md), `/qa-triage --call`, or the `qa-session` close, after the privacy grep |
 | Session receipts, screenshots, and recordings | Restricted Drive QA folder | `qa-session`, after content inspection |
 | Locked design decisions | `.claude/skills/design/decision-log.md` in git | `qa-session`, after the decision lock gate |
 

--- a/.claude/context/qa.md
+++ b/.claude/context/qa.md
@@ -34,7 +34,8 @@ connects them.
    that pull — results by priority and by kind, the fail/blocked list, coverage gaps, standing
    state, and per-tester coverage, private and attributed — and, with `--public`,
    `report.public.md` under the `qa:status` projection rule. The public file exists only for the
-   docs example and the Discord lede; every session record embeds the private one.
+   docs example and the Discord lede. The private file is attached to the session's Linear parent
+   as a document (§ Artifact ownership), so the full record outlives the laptop that pulled it.
 5. **Triage** — [`qa-triage`](../skills/qa-triage/SKILL.md) enriches and scope-locks accepted
    findings, then writes safe Issue and Customer Need records to Linear and appends private defect
    rows to the Green Goods v1.1 QA Sheet. After a team QA call, the
@@ -75,11 +76,12 @@ deferred handoff, or a live session — works in this order:
 | --- | --- | --- |
 | Test-case definitions | `scripts/data/qa-test-catalog.json` in git | Product or engineering change, reviewed like code |
 | Verdicts and notes | QA app private Blob store | The allowlisted signing address through the app |
-| Session log, pulled results, generated report, local handoff | `tmp/qa-session/<slug>/` | `qa-session`, `qa:pull`, and `qa:report`; local and gitignored — only `report.public.md` may leave, for the docs example or the Discord lede |
+| Session log, pulled results, generated report, local handoff | `tmp/qa-session/<slug>/` | `qa-session`, `qa:pull`, and `qa:report`; local and gitignored — `report.md` leaves only as the session parent's attached Linear document (below), `report.public.md` only for the docs example or the Discord lede |
 | Coverage report | Standard output from `bun run qa:status` | Read-only command; nothing is persisted |
 | Defect tracking | Linear plus the private Green Goods v1.1 QA Sheet | `qa-triage`, after explicit scope and write confirmation |
 | Session report and fix slices | Linear Product team — `QA session YYYY-MM-DD` parent plus slice sub-issues | [`qa-call-report`](../../docs/routines/qa-call-report.md) after a team call, or `/qa-triage --call` interactively |
-| Session receipts and cleared evidence | Restricted Drive QA folder | `qa-session`, after content inspection |
+| Full session report, attributed | Linear document `QA session YYYY-MM-DD · full report` attached to the session parent | [`qa-call-report`](../../docs/routines/qa-call-report.md), `/qa-triage --call`, or the `qa-session` close, after the privacy grep |
+| Session receipts, screenshots, and recordings | Restricted Drive QA folder | `qa-session`, after content inspection |
 | Locked design decisions | `.claude/skills/design/decision-log.md` in git | `qa-session`, after the decision lock gate |
 
 ## Public-repository boundary
@@ -87,17 +89,23 @@ deferred handoff, or a live session — works in this order:
 This repository is public. QA results, notes, wallet addresses, the address allowlist, and the identity
 attached to a tester's results never enter it. `QA_ALLOWLIST` lives in the deployment environment;
 display names live inside private address-owned shards. Operational artifacts stay under gitignored
-`tmp/` until cleared receipts and evidence move to the restricted Drive QA folder.
+`tmp/` until the full report is attached to the session parent in Linear and cleared media moves to
+the restricted Drive QA folder.
 
 `qa:status` is safe to print because it projects only catalog IDs, aggregate verdict counts, entry
 timestamps, and optional Linear issue keys. It never prints notes or shard-owner names. Do not add a
 notes, attribution, or per-person flag.
 
-Linear receives only the public-safe issue narrative allowed by
-[`linear-routing-rules.md`](linear-routing-rules.md). The private QA Sheet is the one narrow
-exception that may hold a PostHog session ID and replay URL after its permissions are verified.
-Distinct IDs, wallet addresses, and reporter identifiers stay out of both. Media must be inspected
-visually before upload; a text scan cannot clear pixels.
+Linear issue bodies and comments receive only the public-safe narrative allowed by
+[`linear-routing-rules.md`](linear-routing-rules.md). One carve-out, decided 2026-09-05: the full
+session report is attached to the `QA session YYYY-MM-DD` parent as a Linear **document**, and that
+document may carry team members' display names and their own notes, because the workspace is
+private and the report is useless without them. Wallet addresses, session IDs, replay URLs, and the
+identity of anyone outside the team stay out of the document too: the privacy grep that gates every
+Linear write runs on it first, and a hit is redacted before the document is saved. The private QA
+Sheet remains the one place that may hold a PostHog session ID and replay URL after its permissions
+are verified. Media must be inspected visually before upload; a text scan cannot clear pixels, so
+screenshots and recordings go to the restricted Drive QA folder, never into Linear.
 
 ## Wallet authentication and trust boundary
 

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -176,7 +176,9 @@ branch = one PR, and the posture is repair, not feature building.
    IDs re-record as pass in the QA app (whoever recorded the fail re-records).
 10. **Next slice or stop** — the user's call at each boundary. When the parent report's last
     open slice lands, close the parent against its `Done when` (every slice Done or explicitly
-    deferred, re-QA re-recorded) — or say what still holds it open.
+    deferred with re-QA re-recorded, the decisions child Done or Canceled, no open investigate
+    line) — or say what still holds it open: an unruled decisions child or investigate line
+    keeps a parent open after its last slice lands.
 
 ### User-Observed UI Regression Protocol
 

--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -141,7 +141,9 @@ branch = one PR, and the posture is repair, not feature building.
    list its open sub-issues **and its related already-tracked Issues** in priority order. Only
    `Todo`/`Backlog` items are available to take — a related Issue already `In Progress` or
    `In Review` is someone's active work: show it as context, keep its state, never select it as
-   a slice. Confirm which slice to take — or take the top available one when the user already
+   a slice. A sub-issue with no `package:*` label is not a slice either — the
+   `Product decisions from QA session YYYY-MM-DD` child is that case — so it is context for a design
+   call and never selected. Confirm which slice to take — or take the top available one when the user already
    said to work through them.
 2. **Take ONE slice.** Move it to `In Progress` only when work actually starts — after the
    grounding below and the branch go in step 5; a slice stopped before then (design call,

--- a/.claude/skills/qa-session/SKILL.md
+++ b/.claude/skills/qa-session/SKILL.md
@@ -238,12 +238,15 @@ Per accepted fix (or batched in a fix window):
    and results-by-kind blocks and the fail/blocked list from `report.md` (never re-counted), OBS
    totals by disposition, fix list (OBS → commit SHA →
    revalidated), deferred list, locked DL IDs, environment notes (watchdog trips,
-   dep-optimization reloads, restarts), remaining risk. When the session has a Linear parent (a team call, or a solo session that
-   produced slices), show the user the privacy-grepped `report.md` and ask, in one line, whether to attach it to that
+   dep-optimization reloads, restarts), remaining risk. When the session ran under a `QA session` parent (a team call filed through
+   call mode), show the user the privacy-grepped `report.md` and ask, in one line, whether to attach it to that
    parent as the `QA session <slug> · full report` document per
    [linear-templates.md § Full report document](../qa-triage/linear-templates.md); attach only on
    an explicit yes — this is the one Linear write this skill makes itself, and the review of that
-   exact payload is its confirmation gate — then upload the receipt; the receipt and any media go to the restricted Drive QA folder. Apply the text,
+   exact payload is its confirmation gate — then upload the receipt. A solo session has no parent
+   today (decision 1 in `.plans/active/qa-report/spec.md` tracks that follow-up), so its
+   privacy-grepped `report.md` uploads beside the receipt instead; the receipt, that report, and
+   any media go to the restricted Drive QA folder. Apply the text,
    media, destination, and public-repository boundary in
    [`.claude/context/qa.md`](../../context/qa.md). An unresolved
    privacy finding fails closed; do not upload or delete the local evidence.

--- a/.claude/skills/qa-session/SKILL.md
+++ b/.claude/skills/qa-session/SKILL.md
@@ -238,8 +238,12 @@ Per accepted fix (or batched in a fix window):
    and results-by-kind blocks and the fail/blocked list from `report.md` (never re-counted), OBS
    totals by disposition, fix list (OBS → commit SHA →
    revalidated), deferred list, locked DL IDs, environment notes (watchdog trips,
-   dep-optimization reloads, restarts), remaining risk. Apply the text, media, destination, and
-   public-repository boundary in [`.claude/context/qa.md`](../../context/qa.md). An unresolved
+   dep-optimization reloads, restarts), remaining risk. When the session has a Linear parent (a team call, or a solo session that
+   produced slices), attach `report.md` to it as the `QA session <slug> · full report` document per
+   [linear-templates.md § Full report document](../qa-triage/linear-templates.md) before uploading
+   the receipt; the receipt and any media go to the restricted Drive QA folder. Apply the text,
+   media, destination, and public-repository boundary in
+   [`.claude/context/qa.md`](../../context/qa.md). An unresolved
    privacy finding fails closed; do not upload or delete the local evidence.
 6. **Ship — only when the session changed the repo.** If the session produced commits, run the
    full `bun run validation:plan -- --intent review` on the accumulated branch, then the

--- a/.claude/skills/qa-session/SKILL.md
+++ b/.claude/skills/qa-session/SKILL.md
@@ -239,9 +239,11 @@ Per accepted fix (or batched in a fix window):
    totals by disposition, fix list (OBS → commit SHA →
    revalidated), deferred list, locked DL IDs, environment notes (watchdog trips,
    dep-optimization reloads, restarts), remaining risk. When the session has a Linear parent (a team call, or a solo session that
-   produced slices), attach `report.md` to it as the `QA session <slug> · full report` document per
-   [linear-templates.md § Full report document](../qa-triage/linear-templates.md) before uploading
-   the receipt; the receipt and any media go to the restricted Drive QA folder. Apply the text,
+   produced slices), show the user the privacy-grepped `report.md` and ask, in one line, whether to attach it to that
+   parent as the `QA session <slug> · full report` document per
+   [linear-templates.md § Full report document](../qa-triage/linear-templates.md); attach only on
+   an explicit yes — this is the one Linear write this skill makes itself, and the review of that
+   exact payload is its confirmation gate — then upload the receipt; the receipt and any media go to the restricted Drive QA folder. Apply the text,
    media, destination, and public-repository boundary in
    [`.claude/context/qa.md`](../../context/qa.md). An unresolved
    privacy finding fails closed; do not upload or delete the local evidence.

--- a/.claude/skills/qa-triage/SKILL.md
+++ b/.claude/skills/qa-triage/SKILL.md
@@ -38,36 +38,65 @@ The post-QA-call variant: same phases, three deltas. The unattended sibling is t
 write rules; this mode runs them interactively at the desk. Run one of the two per session; the
 Phase 3b dedupe catches the other's records if both ran.
 
-- **Phases 1-2** — the source is twofold: `bun run qa:pull --slug <date>` (the QA app's verdicts
-  and notes, exact Test IDs) plus the call's Gemini notes from Drive (title contains "QA" or
-  "Build Sync"). App verdicts recorded **during the call window** are ground truth — the store
-  is long-lived and the pull merges every shard ever written, so filter joined entries by their
-  `at` timestamps (the routine's session-window rule) before calling anything verdict-backed;
-  older entries are standing state. Then `bun run qa:report --slug <date> --window <start>..<end>`
-  — with `--out <the directory you pulled into>` whenever the collision branch below sent the pull
-  to `tmp/qa-session/<date>-call`, so the report reads that pull and not the earlier session's
-  (add `--build client=<sha>,admin=<sha>` once Phase 6 has the deploys): the `report.md` written
-  beside that pull is where both results blocks of the parent come from — never count by hand.
-  Note items without a Test ID may be fuzzy-matched into
-  *proposals* here, because the Phase 4 gate confirms each one with you — the unattended routine
-  never guesses an ID. If `tmp/qa-session/<date>/` already holds a pulled session (a local
-  close, or an earlier failed run), `qa:pull` refuses to overwrite it: pull to a fresh directory
-  with `--out tmp/qa-session/<date>-call` and continue from that path — never `--force` over an
-  existing pull, whose severity edits and redactions are sacred.
-- **Phases 3-5** — findings cluster into slices: same catalog area + same suspected seam, split
-  past 3 Test IDs or a package boundary, cap 8 by priority with overflow named in the report.
-  Payloads use [linear-templates.md § QA session report / § QA slice](./linear-templates.md) —
-  one `QA session <date>` parent, slices as sub-issues via `parentId`. Before drafting the
-  parent, look for an existing one — use the `qa-sync:<date>` label to narrow candidates, but
-  require the parent shape before reuse: the exact `QA session <date>` title and no `package:*`
-  label (the pulse stamps the same label on its pre-staged tracking Issues, and Phase 3b's
-  package-scoped scan cannot see the parent at all); an existing parent is reused, never
-  duplicated. Verdict-backed slices
-  propose `Todo` + derived priority (P0-case fail → High, P1 → Medium, else Low; Urgent only for
-  call-flagged release blockers); note-only items propose `Backlog`. The Phase 4 scope-lock gate
-  runs unchanged over the slice list.
+- **Phases 1-2** — the source is threefold: `bun run qa:pull --slug <date>` (the QA app's verdicts
+  and notes, exact Test IDs), the call's Gemini notes from Drive (title contains "QA" or "Build
+  Sync"), and any evidence page a tester linked from a note (a Notion or Drive URL beside an issue
+  number, carried into the slice's evidence comment as a link, never re-typed). App verdicts
+  recorded **during the call window** are ground truth — the store is long-lived and the pull
+  merges every shard ever written, so filter joined entries by their `at` timestamps (the
+  routine's session-window rule) before calling anything verdict-backed; older entries are
+  standing state. `N/A` means out of scope, never skipped
+  ([`.claude/context/qa.md § Verdict vocabulary`](../../context/qa.md)); ask the tester to clear a
+  skipped case in the app before the pull rather than caveating the report. Then
+  `bun run qa:report --slug <date> --window <start>..<end>` — with `--out <the directory you
+  pulled into>` whenever the collision branch below sent the pull to `tmp/qa-session/<date>-call`,
+  so the report reads that pull and not the earlier session's (add `--build client=<sha>,admin=<sha>`
+  once Phase 6 has the deploys): the `report.md` written beside that pull is where both results
+  blocks of the parent come from — never count by hand. Note items without a Test ID may be
+  fuzzy-matched into *proposals* here, because the Phase 4 gate confirms each one with you — the
+  unattended routine never guesses an ID. If `tmp/qa-session/<date>/` already holds a pulled
+  session (a local close, or an earlier failed run), `qa:pull` refuses to overwrite it: pull to a
+  fresh directory with `--out tmp/qa-session/<date>-call` and continue from that path — never
+  `--force` over an existing pull, whose severity edits and redactions are sacred.
+- **Phase 2b — split, then classify.** A dictated app note is several observations, not one
+  finding: on 2026-09-04 one note carried six polish items and the session's only release blocker
+  in a single paragraph. Before anything clusters, extract one numbered observation per distinct
+  symptom from every app note (the Phase 2 extraction rule, applied to app notes exactly as to
+  meeting notes), each tagged with its Test ID, tester, and verdict, and give each observation one
+  disposition from [`.claude/context/qa.md § Finding dispositions`](../../context/qa.md):
+  `defect`, `polish`, `decision`, `investigate`, `catalog`, or `environment`. Write the `catalog`
+  observations to `tmp/qa-triage/<slug>/catalog-feedback.md` — they feed the next catalog change
+  and never reach Linear. A note that says "major regression", "major blocker", or "completely
+  broken" proposes Urgent for its cluster; the gate confirms.
+- **Phases 3-5** — `defect` and `polish` observations cluster into slices: same catalog area +
+  same suspected seam, split past 3 Test IDs or a package boundary, ordered by priority. The
+  default cap is 8 slices; the gate may raise it when the week's fixing capacity matches (12 on
+  2026-09-04) — record the cap used in the parent's Slices intro and name overflow in
+  `Not sliced`. Standing fail/blocked entries **outside** the window are never slices by default;
+  the gate may accept ones that were never filed (no open Issue carries their Test ID), and such a
+  slice opens with `Standing since <date>.` and is listed that way in the parent. `decision`
+  observations become the parent's `Decisions needed` section plus one child issue
+  ([linear-templates.md § Product decisions child](./linear-templates.md)); `investigate`
+  observations become `Not sliced · investigate` lines; `environment` observations become one line
+  in the parent. Each slice states where its Test IDs can be verified — `local` (dev:prod on a
+  laptop), `device` (a case marked `requiresDevice`), or `production` (`requiresProduction`) — so
+  the fix loop takes local-verifiable slices first. Payloads use
+  [linear-templates.md § QA session report / § QA slice](./linear-templates.md) — one
+  `QA session <date>` parent, slices as sub-issues via `parentId`. Before drafting the parent,
+  look for an existing one — use the `qa-sync:<date>` label to narrow candidates, but require the
+  parent shape before reuse: the exact `QA session <date>` title and no `package:*` label (the
+  pulse stamps the same label on its pre-staged tracking Issues, and Phase 3b's package-scoped
+  scan cannot see the parent at all); an existing parent is reused, never duplicated.
+  Verdict-backed slices propose `Todo` + derived priority (P0-case fail → High, P1 → Medium, else
+  Low; Urgent when the call or a tester's note flagged it release-blocking); note-only items
+  propose `Backlog`. **Human-filed issues**: list Product Issues created since the window opened,
+  whatever their labels (a teammate filing from the call rarely stamps `activity:qa`); propose a
+  match per slice by title and surface; the gate confirms each. A confirmed match is linked as
+  `already tracked`, and the slice's Test IDs are posted as a comment on that Issue so the reverse
+  lookup works next time. The Phase 4 scope-lock gate runs over the slice list, the decisions
+  list, and the proposed matches together.
 - **Phase 6** — write the parent first — Results by priority and Results by kind pasted verbatim
-  from `report.md` — then the children. The routine's window-scoped
+  from `report.md` — then the decisions child, then the slices. The routine's window-scoped
   enrichment runs here too (build under test via Vercel; PostHog/Sentry safe summaries into each
   slice's first comment — see `qa-call-report.md` § Phase 4); Sheet Defects rows are still
   offered per slice member with the usual confirmation (the routine never writes the Sheet), and

--- a/.claude/skills/qa-triage/SKILL.md
+++ b/.claude/skills/qa-triage/SKILL.md
@@ -47,7 +47,9 @@ Phase 3b dedupe catches the other's records if both ran.
   routine's session-window rule) before calling anything verdict-backed; older entries are
   standing state. `N/A` means out of scope, never skipped
   ([`.claude/context/qa.md § Verdict vocabulary`](../../context/qa.md)); ask the tester to clear a
-  skipped case in the app before the pull rather than caveating the report. Then
+  skipped case in the app before the pull; when that cannot happen, pass those IDs to
+  `qa:report --skipped <ID,ID>` so the generator counts them as not walked and lists them in its
+  header, never as covered. Then
   `bun run qa:report --slug <date> --window <start>..<end>` — with `--out <the directory you
   pulled into>` whenever the collision branch below sent the pull to `tmp/qa-session/<date>-call`,
   so the report reads that pull and not the earlier session's (add `--build client=<sha>,admin=<sha>`
@@ -66,8 +68,10 @@ Phase 3b dedupe catches the other's records if both ran.
   disposition from [`.claude/context/qa.md § Finding dispositions`](../../context/qa.md):
   `defect`, `polish`, `decision`, `investigate`, `catalog`, or `environment`. Write the `catalog`
   observations to `tmp/qa-triage/<slug>/catalog-feedback.md` — they feed the next catalog change
-  and never reach Linear. A note that says "major regression", "major blocker", or "completely
-  broken" proposes Urgent for its cluster; the gate confirms.
+  and never reach Linear; at Phase 7 copy the file, de-attributed (no verdicts, no tester names),
+  into the plan hub that owns the next catalog change (today `.plans/backlog/qa-runs/`) before the
+  workspace is removed, so cleanup cannot lose it. A note that says "major regression", "major blocker", or "completely
+  broken" proposes Urgent for its cluster; the priority stays derived until the gate confirms.
 - **Phases 3-5** — `defect` and `polish` observations cluster into slices: same catalog area +
   same suspected seam, split past 3 Test IDs or a package boundary, ordered by priority. The
   default cap is 8 slices; the gate may raise it when the week's fixing capacity matches (12 on
@@ -88,13 +92,19 @@ Phase 3b dedupe catches the other's records if both ran.
   pulse stamps the same label on its pre-staged tracking Issues, and Phase 3b's package-scoped
   scan cannot see the parent at all); an existing parent is reused, never duplicated.
   Verdict-backed slices propose `Todo` + derived priority (P0-case fail → High, P1 → Medium, else
-  Low; Urgent when the call or a tester's note flagged it release-blocking); note-only items
-  propose `Backlog`. **Human-filed issues**: list Product Issues created since the window opened,
+  Low; Urgent when the call flagged it release-blocking, or proposed from a tester's note and
+  confirmed at the gate); `polish` slices propose Low (`Todo` when a member entry sits inside the
+  window, else `Backlog`); note-only items propose `Backlog`. **Human-filed issues**: list Product Issues created since the window opened,
   whatever their labels (a teammate filing from the call rarely stamps `activity:qa`); propose a
   match per slice by title and surface; the gate confirms each. A confirmed match is linked as
-  `already tracked`, and the slice's Test IDs are posted as a comment on that Issue so the reverse
-  lookup works next time. The Phase 4 scope-lock gate runs over the slice list, the decisions
-  list, and the proposed matches together.
+  `already tracked`, and the slice's Test IDs are posted as a comment on that Issue; the routine's
+  exact-key scan reads pipeline comments as well as source lines, so the reverse lookup works next
+  time. The Phase 4 scope-lock gate runs once over everything the run proposes, with this reply
+  grammar in place of the default prompt's tags: slice numbers, `all`, or `none`; `S3:urgent` /
+  `S3:high` / `S3:medium` / `S3:low` to override a priority; `D2:drop` to drop a decision line;
+  `I1:slice` to promote an investigate line into a slice; `M2:PRD-849` to confirm a proposed match
+  or `M2:none` to reject it; catalog and environment lines are recorded as listed unless the reply
+  says `C3:slice` or `E1:slice`. Nothing outside the reply is filed.
 - **Phase 6** — write the parent first — Results by priority and Results by kind pasted verbatim
   from `report.md` — then attach the full `report.md` to the parent as a Linear document
   ([linear-templates.md § Full report document](./linear-templates.md), after the privacy grep;
@@ -137,6 +147,7 @@ Contents:
 - `schema-bootstrap.csv` — emitted only when the Defects tab needs the 6 new PostHog/Linear columns
 - `codex-merge.json` — idempotency ledger for the background Codex result (result digest, stable item keys, assigned item numbers, and merge status)
 - `report.md` — Phase 7 final summary
+- `catalog-feedback.md` — call mode only: the `catalog` observations from Phase 2b; copied de-attributed into the catalog-owning plan hub at Phase 7 before cleanup
 
 Skill-wide cache: `~/.config/qa-triage/cache.json` — stores the resolved Sheet file
 id, column ordering, and last-verified permissions snapshot. User-specific assignment
@@ -497,7 +508,8 @@ Write `report.md` and print:
 ```
 
 Then run Codex worktree cleanup for the current run only if dispatched (unless
-`--dry-run`). After all confirmed Linear and Sheet writes succeed, remove only
+`--dry-run`). After all confirmed Linear and Sheet writes succeed — and, in call mode, after
+`catalog-feedback.md` has been copied into its plan hub — remove only
 `tmp/qa-triage/<slug>/`; for dry runs, failed writes, or incomplete runs, keep it and
 surface the resume path.
 

--- a/.claude/skills/qa-triage/SKILL.md
+++ b/.claude/skills/qa-triage/SKILL.md
@@ -96,7 +96,10 @@ Phase 3b dedupe catches the other's records if both ran.
   lookup works next time. The Phase 4 scope-lock gate runs over the slice list, the decisions
   list, and the proposed matches together.
 - **Phase 6** — write the parent first — Results by priority and Results by kind pasted verbatim
-  from `report.md` — then the decisions child, then the slices. The routine's window-scoped
+  from `report.md` — then attach the full `report.md` to the parent as a Linear document
+  ([linear-templates.md § Full report document](./linear-templates.md), after the privacy grep;
+  team display names allowed, nothing else private) and link it from the lede, then the decisions
+  child, then the slices. The routine's window-scoped
   enrichment runs here too (build under test via Vercel; PostHog/Sentry safe summaries into each
   slice's first comment — see `qa-call-report.md` § Phase 4); Sheet Defects rows are still
   offered per slice member with the usual confirmation (the routine never writes the Sheet), and

--- a/.claude/skills/qa-triage/linear-templates.md
+++ b/.claude/skills/qa-triage/linear-templates.md
@@ -195,6 +195,7 @@ review actions; two cross-surface failures trace to shared date handling.">
 
 Build under test: client `<sha>` · admin `<sha>`
 Environment: <production | beta (staging) | local — the session default; a verdict taken elsewhere carries a `[beta]`/`[prod]` note prefix>
+Full report: [QA session YYYY-MM-DD · full report](<linear-document-url>)
 
 ## Results by priority
 - P0: <walked>/<total> — <pass> pass · <fail> fail · <blocked> blocked · <na> n/a · <noted> noted only
@@ -249,11 +250,28 @@ Both results blocks are pasted verbatim from `tmp/qa-session/<slug>/report.md`, 
 per-case priority and kind, never hand-counted — and cover **this session's entries only** (the
 call-window rule; the store is long-lived). The generator already includes the `n/a` and
 noted-without-a-verdict counts (recorded states without which the walked numerator does not
-reconcile) and drops zero segments rather than rendering them. No tester attribution, wallet addresses, session IDs, or replay URLs anywhere;
-per-tester detail stays in the pulled results and the private Sheet. Parent labels:
+reconcile) and drops zero segments rather than rendering them. No tester attribution, wallet addresses, session IDs, or replay URLs in the body or its
+comments; per-tester detail lives in the full report attached to this parent as a Linear document
+(§ Full report document) and in the private Sheet. Parent labels:
 `protocol:green-goods` + `activity:qa` + `source:qa-session` + `qa-sync:<date>` + one `ai:*` —
 no `package:*` (a session spans surfaces). The parent closes when its `Done when` holds — the
 fix flow closes it, never the writer that filed it.
+
+## Full report document — one per session parent
+
+The private `report.md` that `qa:report` writes is attached to the session parent as a Linear
+document, so the attributed notes and per-tester coverage outlive the laptop that pulled them and
+an agent with only Linear access can read the whole session. Rules:
+
+- Title exactly `QA session YYYY-MM-DD · full report` (a second same-day call appends its counter
+  to the date, as the parent does). Parent = the session issue (`issue`), never a project.
+- Content = `report.md` verbatim after the privacy grep: redact `0x` strings, replay or session
+  identifiers, and any name outside the team; team members' display names and their own notes stay
+  (decided 2026-09-05, [`.claude/context/qa.md`](../../context/qa.md) § Public-repository boundary).
+- Created right after the parent and before the children; the parent's lede then links it (a
+  `save_issue` update that resends the title so the length exemption holds).
+- A rerun or a refreshed pull updates the same document by id; never a second document. Media
+  never goes into it; screenshots and recordings stay in the restricted Drive QA folder.
 
 ## Product decisions child — one per session, only when testing surfaced decisions
 

--- a/.claude/skills/qa-triage/linear-templates.md
+++ b/.claude/skills/qa-triage/linear-templates.md
@@ -194,6 +194,7 @@ testers, on which surfaces, and the headline — "P0 coverage is green except
 review actions; two cross-surface failures trace to shared date handling.">
 
 Build under test: client `<sha>` · admin `<sha>`
+Environment: <production | beta (staging) | local — the session default; a verdict taken elsewhere carries a `[beta]`/`[prod]` note prefix>
 
 ## Results by priority
 - P0: <walked>/<total> — <pass> pass · <fail> fail · <blocked> blocked · <na> n/a · <noted> noted only
@@ -208,16 +209,26 @@ Build under test: client `<sha>` · admin `<sha>`
 ## Decisions from the call
 - <ruling the team aligned on, one line each — drop the section when none>
 
+## Decisions needed
+- <a product or design ruling the testing surfaced but nobody has made — one line each, with the Test IDs it blocks; mirrored in the session's decisions child (§ Product decisions child) — drop the section when none>
+
 ## Slices
+Slice cap <N> this session.
 - <one line per slice: what it covers and its Test IDs — Linear renders the
   sub-issue links; this list gives the reading order and the overflow context>
 - already tracked: <PRD-NNN> — <one line> (an existing open Issue, related to
   this parent so the fix queue still sees it)
+- standing since <date>: <a never-filed fail from an earlier walk that the gate
+  accepted as a slice — one line>
 
 ## Not sliced
 - <note-only follow-ups, anything past the slice cap, and `[derived:telemetry]`
   uncorrelated window errors (testers or ordinary production traffic — the
   telemetry has no tester predicate) — one line each>
+- investigate: <a symptom whose cause or intent is unknown — one line; a slice
+  only after someone looks>
+- environment: <behaviour caused by the harness or environment, not the product —
+  one line>
 
 **Done when**
 - every slice below — and every related already-tracked Issue — is Done or explicitly
@@ -244,6 +255,29 @@ per-tester detail stays in the pulled results and the private Sheet. Parent labe
 no `package:*` (a session spans surfaces). The parent closes when its `Done when` holds — the
 fix flow closes it, never the writer that filed it.
 
+## Product decisions child — one per session, only when testing surfaced decisions
+
+Title exactly `Product decisions from QA session YYYY-MM-DD`, a sub-issue of the session parent via
+`parentId`, state `Backlog`, labels = the parent set, no `package:*`. The interactive skill assigns
+the product owner; the routine leaves it unassigned. It exists so a ruling has a place to land that
+outlives the parent, and so a Linear-only agent reads the open questions before touching the slices
+they block.
+
+```markdown
+<One sentence: what testing surfaced that needs a product or design ruling before a fix is
+honest, and which slices wait on it.>
+
+- <Decision one, as a question a person can answer in a sentence, with the Test IDs and slice it
+  blocks — "Should the cookie-jar withdraw floor stay at one cent for DAI? (`PWA-028`)">
+- <Decision two …>
+
+**Done when**
+- every question above has a ruling recorded here, and design rulings are also locked in
+  `.claude/skills/design/decision-log.md`
+
+QA session — <slug>.
+```
+
 ## QA slice — sub-issue (one slice = one branch = one PR)
 
 Children of the session report via `parentId`. A slice is a root-cause cluster — same catalog
@@ -261,6 +295,11 @@ a paraphrase would lose.>
 <One or two lines mapping the feature: the owning module/component paths and
 the seam the failures share. A starting map, not a certified diagnosis.>
 
+**Verify on**
+<local | device | production — from the member cases' `requiresDevice` and
+`requiresProduction` flags; `local` is the dev:prod stack on a laptop, `device` an
+installed phone, `production` the deployed origin. The fix loop takes `local` first.>
+
 **Done when**
 - <each Test ID's expected result holds and is re-recorded as pass in the QA app>
 - <second observable outcome when the slice has two halves>
@@ -271,8 +310,11 @@ Validation: `<command>`. QA session — <slug>. Test IDs: `<ID>, <ID>`.
 
 **Evidence comment (slice)**: window-scoped enrichment — PostHog safe summary, Sentry issue link
 and top frame, deploy correlation — goes in the slice's first comment per § Evidence comment
-above, never the body. Replay URLs, session IDs, and distinct IDs never reach Linear; the
-parent's recipe line points a human at the recordings view instead.
+above, never the body. Evidence pages a tester linked from a note (a Notion or Drive page beside
+an issue number) go in the same comment as links, never re-typed; the page stays private and the
+link carries no session or replay identifier. Replay URLs, session IDs, and distinct IDs never
+reach Linear; the parent's recipe line points a human at the recordings view instead. A slice the
+gate accepted from standing state opens its body with `Standing since <date>.`
 
 **State + priority**: verdict-backed (a tester recorded fail/blocked in the QA app during the
 session window, exact Test IDs) → `Todo`; priority High for a P0-case fail, Medium for P1, Low
@@ -346,5 +388,9 @@ Linear's API constraint that Customer Needs must link to an Issue eliminates the
 | `[derived:recurring]` accepted in Phase 4 | linked to parent Issue | yes (recurring-pattern parent) |
 | Verdict-backed cluster (call report) | QA slice sub-issue of the session report | `Todo` + derived priority | No — the report is the record |
 | Notes-only cluster (call report) | QA slice sub-issue of the session report | `Backlog` | No |
+| Decision needed (call report) | Line under the parent's `Decisions needed` + the session's decisions child | `Backlog` | No |
+| Investigate (call report) | `Not sliced · investigate` line in the parent; no Issue until someone looks | — | No |
+| Catalog feedback (call report) | Never a slice — `tmp/qa-triage/<slug>/catalog-feedback.md` (skill) or one `Catalog feedback` comment on the parent (routine) | — | No |
+| Never-filed standing fail accepted at the gate (call report) | QA slice sub-issue opening with `Standing since <date>.` | `Todo` + derived priority | No |
 
 The default for ambiguous items is **track-only** — create a Customer Need linked to a lightweight Backlog tracking Issue. The Issue exists only because Linear requires a link target; it is not committed work until a human promotes it.

--- a/.claude/skills/qa-triage/linear-templates.md
+++ b/.claude/skills/qa-triage/linear-templates.md
@@ -194,7 +194,7 @@ testers, on which surfaces, and the headline — "P0 coverage is green except
 review actions; two cross-surface failures trace to shared date handling.">
 
 Build under test: client `<sha>` · admin `<sha>`
-Environment: <production | beta (staging) | local — the session default; a verdict taken elsewhere carries a `[beta]`/`[prod]` note prefix>
+Environment: <production | beta (staging) | local — the session default; a verdict taken elsewhere carries a `[beta]`, `[prod]`, or `[local]` note prefix>
 Full report: [QA session YYYY-MM-DD · full report](<linear-document-url>)
 
 ## Results by priority
@@ -265,7 +265,8 @@ an agent with only Linear access can read the whole session. Rules:
 
 - Title exactly `QA session YYYY-MM-DD · full report` (a second same-day call appends its counter
   to the date, as the parent does). Parent = the session issue (`issue`), never a project.
-- Content = `report.md` verbatim after the privacy grep: redact `0x` strings, replay or session
+- Content = the `report.md` of the pull the results blocks were pasted from — the `-final`
+  directory when the routine re-pulled after the window closed — verbatim after the privacy grep: redact `0x` strings, replay or session
   identifiers, and any name outside the team; team members' display names and their own notes stay
   (decided 2026-09-05, [`.claude/context/qa.md`](../../context/qa.md) § Public-repository boundary).
 - Created right after the parent and before the children; the parent's lede then links it (a
@@ -276,7 +277,9 @@ an agent with only Linear access can read the whole session. Rules:
 ## Product decisions child — one per session, only when testing surfaced decisions
 
 Title exactly `Product decisions from QA session YYYY-MM-DD`, a sub-issue of the session parent via
-`parentId`, state `Backlog`, labels = the parent set, no `package:*`. The interactive skill assigns
+`parentId`, state `Backlog`, labels = the parent set, no `package:*`. The missing package label is
+load-bearing: slice pickup (`debug` § QA Slice Fix Protocol) takes only sub-issues that carry one, so
+this record is never mistaken for a slice. The interactive skill assigns
 the product owner; the routine leaves it unassigned. It exists so a ruling has a place to land that
 outlives the parent, and so a Linear-only agent reads the open questions before touching the slices
 they block.
@@ -336,7 +339,10 @@ gate accepted from standing state opens its body with `Standing since <date>.`
 
 **State + priority**: verdict-backed (a tester recorded fail/blocked in the QA app during the
 session window, exact Test IDs) → `Todo`; priority High for a P0-case fail, Medium for P1, Low
-otherwise — Urgent only when the call flagged it release-blocking. The seeded priority is a
+otherwise — Urgent only when the call flagged it release-blocking, or when a tester's note proposed
+it and the gate confirmed. A `polish` slice lands Low whatever its cases' priority: `Todo` when at
+least one member entry was recorded inside the window (a pass with a note counts), `Backlog` when
+reconstructed from notes alone. The seeded priority is a
 queue-ordering default (walk priority × verdict), **not a severity judgment** — the fix session
 re-judges it at take-up, and Sheet severity stays independently assigned
 (`.claude/context/qa.md` § Verdict and severity rules). Reconstructed from meeting notes alone
@@ -390,7 +396,7 @@ The Customer Need then links to this Issue via the `issue` parameter and carries
 
 ## Disposition resolution
 
-Linear's API constraint that Customer Needs must link to an Issue eliminates the standalone Need column. Every accepted item gets an Issue — main or lightweight track-only.
+Linear's API constraint that Customer Needs must link to an Issue eliminates the standalone Need column. Every accepted defect, polish, idea, or feedback item gets an Issue — main or lightweight track-only. The call-report dispositions that record without an Issue (decision lines plus the one decisions child, investigate lines, catalog feedback, environment lines) are the named exceptions in the table below.
 
 | Item shape | Issue type | Issue status | Customer Need |
 |---|---|---|---|
@@ -408,7 +414,8 @@ Linear's API constraint that Customer Needs must link to an Issue eliminates the
 | Notes-only cluster (call report) | QA slice sub-issue of the session report | `Backlog` | No |
 | Decision needed (call report) | Line under the parent's `Decisions needed` + the session's decisions child | `Backlog` | No |
 | Investigate (call report) | `Not sliced · investigate` line in the parent; no Issue until someone looks | — | No |
-| Catalog feedback (call report) | Never a slice — `tmp/qa-triage/<slug>/catalog-feedback.md` (skill) or one `Catalog feedback` comment on the parent (routine) | — | No |
+| Catalog feedback (call report) | Never a slice — `tmp/qa-triage/<slug>/catalog-feedback.md` (skill), copied de-attributed into the catalog-owning plan hub at close, or one `Catalog feedback` comment on the parent (routine) | — | No |
+| Environment finding (call report) | One `environment:` line under the parent's `Not sliced`; never a slice | — | No |
 | Never-filed standing fail accepted at the gate (call report) | QA slice sub-issue opening with `Standing since <date>.` | `Todo` + derived priority | No |
 
 The default for ambiguous items is **track-only** — create a Customer Need linked to a lightweight Backlog tracking Issue. The Issue exists only because Linear requires a link target; it is not committed work until a human promotes it.

--- a/.claude/skills/qa-triage/linear-templates.md
+++ b/.claude/skills/qa-triage/linear-templates.md
@@ -234,6 +234,9 @@ Slice cap <N> this session.
 **Done when**
 - every slice below — and every related already-tracked Issue — is Done or explicitly
   deferred, and the re-QA walk has re-recorded its Test IDs
+- every `Decisions needed` line has its ruling recorded on the decisions child and that child
+  is Done or Canceled, and every `investigate:` line under Not sliced is promoted to a slice or
+  closed with a finding
 
 Session <slug>. [Meeting notes](<drive-url>)
 ```
@@ -255,7 +258,8 @@ comments; per-tester detail lives in the full report attached to this parent as 
 (§ Full report document) and in the private Sheet. Parent labels:
 `protocol:green-goods` + `activity:qa` + `source:qa-session` + `qa-sync:<date>` + one `ai:*` —
 no `package:*` (a session spans surfaces). The parent closes when its `Done when` holds — the
-fix flow closes it, never the writer that filed it.
+fix flow closes it, never the writer that filed it — and an open decisions child or investigate
+line holds it open after the last slice lands.
 
 ## Full report document — one per session parent
 

--- a/.plans/active/qa-report/spec.md
+++ b/.plans/active/qa-report/spec.md
@@ -17,6 +17,7 @@ open to challenge before implementation starts.
 | 8 | Report sections are additive to the parent template; the "Results by priority" lines are byte-identical to the template's line shape, zero segments dropped | The routine and `--call` paste them verbatim, so the template and the generator cannot drift |
 | 9 | The public projection follows the `qa:status` rule: catalog IDs, counts, and timestamps only — no notes, no person labels or addresses; per-tester coverage collapses to a tester count | Reuses the privacy contract that already exists instead of inventing a second one |
 | 10 | `report.md` is a derived artifact and regenerating overwrites it | Unlike `results.csv`, it carries no hand edits; determinism from inputs is the whole point |
+| 11 | (2026-09-05) `report.md` is also attached to the session's Linear parent as the document `QA session YYYY-MM-DD · full report`; team display names and notes may appear there, nothing else private | Team calls produce no receipt, so the attributed report lived only in `tmp/`; Linear is where the session is tracked and what Linear-only agents can read. The privacy grep still bans wallets, session and replay identifiers, and names outside the team; decision 2's public projection is unchanged |
 
 ## Inputs
 

--- a/.plans/active/qa-report/spec.md
+++ b/.plans/active/qa-report/spec.md
@@ -98,9 +98,13 @@ or baseline fails before any file is written. Error text never includes note con
 
 ## Privacy
 
-The private report lives in gitignored `tmp/qa-session/<slug>/` and follows the receipt's upload
-gate. The public projection reuses the `qa:status` rule and is the only variant that may leave the
-private folder — and only for the two uses in Decision 2.
+The private report lives in gitignored `tmp/qa-session/<slug>/`. It leaves that folder by exactly
+one route: the privacy-gated Linear document attached to the session parent (Decision 11), after
+the same grep that gates every Linear write has redacted wallet addresses, session and replay
+identifiers, and names outside the team; team display names and notes may remain. The public
+projection reuses the `qa:status` rule and is the only variant that may reach a public surface —
+and only for the two uses in Decision 2. Wiring: the routine, `/qa-triage --call`, and the
+qa-session close attach the document right after the parent exists and link it from the lede.
 
 ## Non-goals
 

--- a/.plans/backlog/qa-runs/brief.md
+++ b/.plans/backlog/qa-runs/brief.md
@@ -17,9 +17,13 @@ cases to their successors.
 
 1. A run is one team pass over the catalog; sessions are timestamps inside it. The store keeps one
    shard per run per tester; a small run index carries label, opened/closed time, opener, catalog
-   version, default environment, and build SHAs.
-2. Today's shards migrate as Run 1 ("Baseline · 2026-08-29 → 2026-09-04"). Closed runs are
-   read-only server-side; nothing is ever erased.
+   version, default environment, and build SHAs. Exactly one run is open at any time: closing is
+   a rollover that closes the current run and opens its successor in one conditional write, so
+   there is never a zero-open state.
+2. Today's shards migrate as Run 1 ("Baseline"): legacy latest-state, not a session snapshot. Its
+   window is the earliest and latest migrated entry timestamps and the index says so. Closed runs
+   are read-only server-side; nothing is ever erased, and a write that arrives for a closed run
+   is re-targeted at the open run by the page, never dropped.
 3. Any allowlisted tester may open or close a run; the index records who did.
 4. `N/A` means intentionally out of scope; a skipped case has no entry. The app's N/A control says
    so. Environment is a run-level field; a note prefixed `[beta]` or `[prod]` marks a verdict taken

--- a/.plans/backlog/qa-runs/brief.md
+++ b/.plans/backlog/qa-runs/brief.md
@@ -1,0 +1,44 @@
+# QA Runs
+
+**Stage**: `backlog`
+**Status**: Decisions locked 2026-09-05; implementation planned for the 2026-09-06/07 weekend, before the 2026-09-08 re-QA
+**Approved**: 2026-09-05 (Afo, three alignment rounds after the 2026-09-04 team QA call)
+
+## Summary
+
+The QA app keeps one verdict per case per tester and overwrites it on re-record, so a re-QA erases
+the session it is checking. A **run** is one team pass over the catalog (several sessions may feed
+it). Runs make past sessions immutable and comparable: a tester opens a run, records into it, closes
+it, and the next run shows what was fixed, what still fails, and what regressed. The same change
+carries the test-case cleanup the 2026-09-04 call asked for, because the compare must map retired
+cases to their successors.
+
+## Locked Decisions
+
+1. A run is one team pass over the catalog; sessions are timestamps inside it. The store keeps one
+   shard per run per tester; a small run index carries label, opened/closed time, opener, catalog
+   version, default environment, and build SHAs.
+2. Today's shards migrate as Run 1 ("Baseline · 2026-08-29 → 2026-09-04"). Closed runs are
+   read-only server-side; nothing is ever erased.
+3. Any allowlisted tester may open or close a run; the index records who did.
+4. `N/A` means intentionally out of scope; a skipped case has no entry. The app's N/A control says
+   so. Environment is a run-level field; a note prefixed `[beta]` or `[prod]` marks a verdict taken
+   elsewhere.
+5. Compare is run-vs-run: a Run select beside View, a "compare with Run N" toggle showing the prior
+   verdict and notes on each row, a delta tally (fixed, still failing, regressed, newly walked), and
+   a Re-QA filter (fail or blocked in the compared run). Retired IDs map through `replacedBy`.
+6. `qa:pull` and `qa:report` become run-aware; the report's delta compares runs, not snapshots.
+7. Catalog split before Tuesday, scoped to rows walked or failing on 2026-09-04 plus the Android
+   twins; the broader area re-cut waits until after Tuesday. Catalog lifecycle rules unchanged.
+
+## Boundaries
+
+Changes the QA app (store API, page, dev server), the pull and report scripts, the catalog and its
+ledger, and the QA guidance. Does not change contracts, the indexer, Admin, or Client. Product
+defects found while rehearsing become QA findings, not work in this hub.
+
+## Completion Signal
+
+Run 1 migrated and closed; Run 2 opened for 2026-09-08; the compare shows the 2026-09-04 fails
+against Tuesday's re-record; split cases ship with `replacedBy` and the compare honours them; the
+deployed QA app completes a two-tester smoke; guidance names runs where it names snapshots today.

--- a/.plans/backlog/qa-runs/catalog-feedback-2026-09-04.md
+++ b/.plans/backlog/qa-runs/catalog-feedback-2026-09-04.md
@@ -14,8 +14,8 @@ C10 PWA-043 — mixes local dev and hosted production; performance belongs to Po
 C11 PWA-044 — identity parity spans three surfaces; one row per surface instead.
 C12 PWA-IOS-003/004/005 — no Android twins; add PWA-AND rows for login recovery, camera capture/draft, HEIC/library image.
 C13 PWA-IOS-006 — expectation assumes a queue "flushes once"; rewrite to the real offline-queue behaviour.
-C14 PWA-IOS-008 — incoherent scenario; the PWA-IOS/PWA-AND/PWA-ROLE ID scheme reads oddly (Afo).
-C15 Principle (Afo, PWA-036 note): isolate actions from viewing — split reading from writing across the PWA rows.
+C14 PWA-IOS-008 — incoherent scenario; the PWA-IOS/PWA-AND/PWA-ROLE ID scheme reads oddly.
+C15 Principle (from a PWA-036 note): isolate actions from viewing — split reading from writing across the PWA rows.
 C16 N/A is being used to mean "skipped this pass"; the app's N/A control should say what N/A means (qa.md § Verdict vocabulary), and a skipped case should simply have no entry.
 
 From reading all 142 active rows (2026-09-05):

--- a/.plans/backlog/qa-runs/catalog-feedback-2026-09-04.md
+++ b/.plans/backlog/qa-runs/catalog-feedback-2026-09-04.md
@@ -1,0 +1,25 @@
+## Catalog feedback · QA session 2026-09-04 (never Linear; feeds the pre-Tuesday catalog split)
+
+From tester notes:
+C1  PWA-020 — wording says "desktop shell"; it is the PWA/the app. Rename.
+C2  PWA-021 — combines open join, request-to-join + withdraw, steward welcome/decline, resubmit. Split by actor and act.
+C3  PWA-023 — "deep links" undefined. Rewrite with concrete URLs: /home/:id/work/:workId, /home/:id/commitments/:commitmentId, /home/:id/assessments/:assessmentId.
+C4  PWA-025 — locale quality is too broad for a human sweep; candidate for an automated/AI-driven check, keep a narrow human spot-check.
+C5  PWA-035 — desktop review belongs to the admin dashboard; move (ADM) or retire.
+C6  PWA-036 — governance drawer: split reading (drawer visibility, current stake) from writing (allocate).
+C7  PWA-037 — endowment drawer: one case per action (deposit, withdraw own deposit, jar claim).
+C8  PWA-038 — profile: split into avatar edit/remove (+draft recovery), theme + language, ENS claim/release, badges, logout.
+C9  PWA-042 — keyboard/focus smoke does not fit a mobile PWA; rescope to the desktop shell or retire.
+C10 PWA-043 — mixes local dev and hosted production; performance belongs to PostHog benchmarks. Split or retire the human row.
+C11 PWA-044 — identity parity spans three surfaces; one row per surface instead.
+C12 PWA-IOS-003/004/005 — no Android twins; add PWA-AND rows for login recovery, camera capture/draft, HEIC/library image.
+C13 PWA-IOS-006 — expectation assumes a queue "flushes once"; rewrite to the real offline-queue behaviour.
+C14 PWA-IOS-008 — incoherent scenario; the PWA-IOS/PWA-AND/PWA-ROLE ID scheme reads oddly (Afo).
+C15 Principle (Afo, PWA-036 note): isolate actions from viewing — split reading from writing across the PWA rows.
+C16 N/A was recorded as "skipped" on PWA-032/033/034/046–050 and PWA-IOS-002; app copy should say what N/A means (qa.md § Verdict vocabulary).
+
+From reading all 142 active rows (2026-09-05):
+C17 Expectations that encode current bugs ("currently silent", "currently a silent no-op", "currently opens the wallet modal"): PWA-038, ADM-020, ADM-026, ADM-028, PUB-003, PUB-020, PUB-024. Expected results must state the intended behaviour only.
+C18 Grouped admin transaction rows, all still never walked: ADM-020, 021, 022, 023, 025, 027, 028, 029. Split by act like the PWA rows.
+C19 Areas: 33 areas for 53 PWA cases and 33 for 46 admin cases; five PWA areas hold one case. Re-cut to where the walker sits (Home, Garden, Work, Commitments, Wallet, Profile, Auth/Install/Update, Offline) — after Tuesday.
+C20 Missing read-only PWA rows: garden detail, Insights/assessments list, members, commitments list/drawer, notifications on the desktop shell.

--- a/.plans/backlog/qa-runs/catalog-feedback-2026-09-04.md
+++ b/.plans/backlog/qa-runs/catalog-feedback-2026-09-04.md
@@ -23,3 +23,4 @@ C17 Expectations that encode current bugs ("currently silent", "currently a sile
 C18 Grouped admin transaction rows, all still never walked: ADM-020, 021, 022, 023, 025, 027, 028, 029. Split by act like the PWA rows.
 C19 Areas: 33 areas for 53 PWA cases and 33 for 46 admin cases; five PWA areas hold one case. Re-cut to where the walker sits (Home, Garden, Work, Commitments, Wallet, Profile, Auth/Install/Update, Offline) — after Tuesday.
 C20 Missing read-only PWA rows: garden detail, Insights/assessments list, members, commitments list/drawer, notifications on the desktop shell.
+C21 No admin case covers submitting an assessment outside the journey relay: ADM-005 tests gating only and ADM-037 is the relay's starting assessment. Add a P0 transaction row for assessment submission (found via the admin evidence page, item 8, 2026-09-05).

--- a/.plans/backlog/qa-runs/catalog-feedback-2026-09-04.md
+++ b/.plans/backlog/qa-runs/catalog-feedback-2026-09-04.md
@@ -16,7 +16,7 @@ C12 PWA-IOS-003/004/005 — no Android twins; add PWA-AND rows for login recover
 C13 PWA-IOS-006 — expectation assumes a queue "flushes once"; rewrite to the real offline-queue behaviour.
 C14 PWA-IOS-008 — incoherent scenario; the PWA-IOS/PWA-AND/PWA-ROLE ID scheme reads oddly (Afo).
 C15 Principle (Afo, PWA-036 note): isolate actions from viewing — split reading from writing across the PWA rows.
-C16 N/A was recorded as "skipped" on PWA-032/033/034/046–050 and PWA-IOS-002; app copy should say what N/A means (qa.md § Verdict vocabulary).
+C16 N/A is being used to mean "skipped this pass"; the app's N/A control should say what N/A means (qa.md § Verdict vocabulary), and a skipped case should simply have no entry.
 
 From reading all 142 active rows (2026-09-05):
 C17 Expectations that encode current bugs ("currently silent", "currently a silent no-op", "currently opens the wallet modal"): PWA-038, ADM-020, ADM-026, ADM-028, PUB-003, PUB-020, PUB-024. Expected results must state the intended behaviour only.

--- a/.plans/backlog/qa-runs/eval.md
+++ b/.plans/backlog/qa-runs/eval.md
@@ -1,0 +1,39 @@
+# QA Runs Evaluation Plan
+
+## Release Gates
+
+1. Correctness:
+2. Usability:
+3. Regression safety:
+4. Evidence quality: research evidence and open assumptions are recorded before implementation.
+5. Human judgment: protected surfaces and maintainer-call decisions are called out before merge.
+
+## Acceptance Checks
+
+| ID | Behavior Boundary | Check | Owner | Evidence |
+|---|---|---|---|---|
+| AC-1 | | | `ui` | |
+| AC-2 | | | `state_api` | |
+| AC-3 | | | `contracts` | |
+| AC-4 | QA review | | `qa_pass_1` | |
+| AC-5 | Regression review | | `qa_pass_2` | |
+
+## Test Strategy
+
+- Unit:
+- Integration:
+- E2E / Playwright:
+- Manual checks:
+- TDD proof: RED/GREEN commands and evidence are recorded in lane handoffs and summarized in `status.json`.
+
+## QA Sequence
+
+### Claude QA Pass 1
+
+- Focus on UX issues, missing requirements, and test gaps
+- If blocked, record the blocker in `handoffs/claude-qa-pass-1.md`
+
+### Codex QA Pass 2
+
+- Start only after `qa_pass_1` is passed
+- Re-run targeted validation and close the loop on remaining defects

--- a/.plans/backlog/qa-runs/eval.md
+++ b/.plans/backlog/qa-runs/eval.md
@@ -2,9 +2,9 @@
 
 ## Release Gates
 
-1. Correctness:
-2. Usability:
-3. Regression safety:
+1. Correctness: every acceptance check below passes at the head that ships; the migration is proven on a copy of the live store before it runs on the store.
+2. Usability: two testers complete the 2026-09-08 rollover and re-QA on the deployed app without reading code.
+3. Regression safety: existing `qa-app-*` and `qa-report` suites stay green; the legacy read path keeps serving until the migration is verified.
 4. Evidence quality: research evidence and open assumptions are recorded before implementation.
 5. Human judgment: protected surfaces and maintainer-call decisions are called out before merge.
 
@@ -12,18 +12,19 @@
 
 | ID | Behavior Boundary | Check | Owner | Evidence |
 |---|---|---|---|---|
-| AC-1 | | | `ui` | |
-| AC-2 | | | `state_api` | |
-| AC-3 | | | `contracts` | |
-| AC-4 | QA review | | `qa_pass_1` | |
-| AC-5 | Regression review | | `qa_pass_2` | |
+| AC-1 | Migration moves every legacy shard into Run 1 unchanged (same entries, statuses, notes, timestamps), records Run 1 as legacy latest-state with its window, and is idempotent | `qa-app-store.test.ts`: migrate a fixture store twice; entries byte-equal, index unchanged on the second run | `state_api` | test names + green run in the lane handoff |
+| AC-2 | A write against a closed run is refused with the open run's id and never mutates the closed shard; a rollover closes and opens in one conditional index write | `qa-app-store.test.ts`: POST to a closed run → refusal payload names the open run; closed shard ETag unchanged; concurrent rollovers → one winner, one retry | `state_api` | test names + green run |
+| AC-3 | The page re-targets a refused outbox at the open run and says so; Run select, compare toggle, delta tally (fixed, still failing, regressed, newly walked), and Re-QA filter render from two fixture runs; the N/A hint reads "out of scope for this run" | `qa-app-client.test.ts` against the built page; authenticated Brave screenshots at desktop and 375×812 | `ui` | test names + screenshot paths in the lane handoff |
+| AC-4 | A verdict on an ID retired between runs appears on each `replacedBy` successor in the compare, labelled inherited; `qa:pull --run` and `qa:report --previous <run>` name both runs in the delta | `qa-report.test.ts` and `qa-state-pull.test.ts` fixtures with one retired ID and two runs | `state_api` | test names + green run |
+| AC-5 | QA review: rollover, re-record, and compare completed by two testers on the deployed app for the 2026-09-08 session | manual, recorded in `handoffs/claude-qa-pass-1.md` | `qa_pass_1` | session parent link + compare screenshot |
+| AC-6 | Regression review: the full `test:agent-tools`, `test:review-guardrails`, and `check:docs-generated` gates pass at the shipping head | `bun run test:agent-tools && bun run test:review-guardrails && bun run check:docs-generated` | `qa_pass_2` | command output in `handoffs/codex-qa-pass-2.md` |
 
 ## Test Strategy
 
-- Unit:
-- Integration:
-- E2E / Playwright:
-- Manual checks:
+- Unit: store migration, rollover, closed-run refusal, run index validation (`qa-app-store.test.ts`, `qa-app-auth.test.ts`); run-aware pull and report (`qa-state-pull.test.ts`, `qa-report.test.ts`).
+- Integration: the built page against `dev.mjs` with two fixture runs (`qa-app-client.test.ts`, `qa-app-build.test.ts` for the catalog `replacedBy` projection).
+- E2E / Playwright: none new; the built-page harness above is the real-page proof.
+- Manual checks: authenticated Brave rehearsal at desktop and mobile widths; the 2026-09-08 two-tester smoke on the deployed app.
 - TDD proof: RED/GREEN commands and evidence are recorded in lane handoffs and summarized in `status.json`.
 
 ## QA Sequence

--- a/.plans/backlog/qa-runs/plan.todo.md
+++ b/.plans/backlog/qa-runs/plan.todo.md
@@ -1,0 +1,35 @@
+# QA Runs Plan
+
+**Feature Slug**: `qa-runs`
+**Stage**: `backlog`
+**Status**: PLANNED
+**Created**: 2026-09-05
+**Last Updated**: 2026-09-05
+
+## Requirements Coverage
+
+| Requirement | Lane | Status |
+|---|---|---|
+| Run index + per-run shards + migration (spec 1–4) | `state_api` | ⏳ |
+| Run select, compare, delta tally, Re-QA filter, retired mapping (spec 5–7) | `ui` | ⏳ |
+| `qa:pull --run`, `qa:report --previous <run>` (spec 8) | `state_api` | ⏳ |
+| Catalog split with `replacedBy`, Android twins, redeploy (spec 9) | `state_api` | ⏳ |
+| Guidance + docs name runs; two-tester smoke on 2026-09-08 | `qa_pass_1` | ⏳ |
+
+## Implementation Steps
+
+1. **Store and API** — run index, per-run shard paths, open/close endpoints, closed-run refusal,
+   migration of the legacy shards to Run 1 (tests in `qa-app-store.test.ts` / `qa-app-auth.test.ts`).
+2. **Page** — Run select, compare toggle, delta tally, Re-QA filter, N/A hint, environment line;
+   outbox keyed by owner and run (tests in `qa-app-client.test.ts`).
+3. **Scripts** — run-aware pull and report; delta by run; `qa:status` reads the open run.
+4. **Catalog split** — retire and replace per `catalog-feedback-2026-09-04.md`; ledger append;
+   build; redeploy the QA app; verify the compare honours `replacedBy`.
+5. **Guidance and docs** — `qa.md`, qa-session/qa-triage/routine wording, product-experience-qa
+   and test-cases pages.
+6. **Tuesday** — close Run 1, open Run 2 on beta, two-tester smoke, first real compare.
+
+## Validation
+
+- `bun run test:agent-tools`, `bun run test:review-guardrails`, `bun run check:docs-generated`
+- `bun run validation:plan -- --intent push` before the push gate

--- a/.plans/backlog/qa-runs/spec.md
+++ b/.plans/backlog/qa-runs/spec.md
@@ -1,0 +1,59 @@
+# QA Runs Specification
+
+## Users
+
+The two or three allowlisted testers who walk Green Goods before and after a fix cycle, and the
+agents that pull the store to write the session report and slices.
+
+## Requirements
+
+1. **Run model.** A run has an id, label, `openedAt`, `openedBy`, `closedAt`, `closedBy`,
+   `catalogVersion`, `environment` (`production | beta | local`), and optional build SHAs per
+   surface. Exactly one run is open at a time. The run index lives beside the shards
+   (`qa/runs.json`); shards move to `qa/runs/<runId>/entries/<address>.json`.
+2. **Migration.** The existing `qa/entries/<address>.json` shards become Run 1 by a one-time
+   server-side move; the legacy path is read only until the move completes, then never written.
+3. **Immutability.** `POST /api/state` writes only to the open run; a write against a closed run is
+   refused with a message the page shows. The outbox is keyed by owner and run.
+4. **Open and close.** Any allowlisted session may open a run (label, environment, optional build
+   SHAs) or close the open one; both are recorded in the index. Closing never deletes.
+5. **View.** A Run select beside View defaults to the open run; closed runs are readable. A compare
+   toggle shows, per row, the compared run's rollup verdict and notes; the tally adds fixed, still
+   failing, regressed, and newly walked. A Re-QA filter lists cases that were fail or blocked in the
+   compared run.
+6. **Retired IDs.** When a compared run holds a verdict for an ID the current catalog retired, the
+   compare shows it on each successor named in `replacedBy`, labelled as inherited.
+7. **Vocabulary.** The N/A control's hint says "out of scope for this run"; a not-walked case has
+   no entry. The run's environment shows in the header; the `[beta]`/`[prod]` note prefix is
+   documented in the app's help line.
+8. **Scripts.** `qa:pull --run <id>` pulls one run (default: the open run); `qa:report --previous`
+   accepts a run id or a pulled directory; the delta section names both runs.
+9. **Catalog split (lane input: catalog-feedback-2026-09-04.md).** Retire grouped rows walked or
+   failing on 2026-09-04 with `replacedBy` successors, add the Android twins, fix wrong-surface and
+   bug-encoding expectations; ledger append-only; QA app redeployed before Tuesday.
+
+## Existing Sources
+
+- `packages/qa/api/state.ts`, `packages/qa/auth.ts`, `packages/qa/index.html`, `packages/qa/dev.mjs`
+- `scripts/agents/qa-state.ts`, `qa-state-pull.ts`, `qa-report.ts`, `qa-status.ts`
+- `scripts/data/qa-test-catalog.json`, `qa-test-id-ledger.json`, `scripts/agents/qa-app-build.test.ts`
+- `.claude/context/qa.md` (verdict vocabulary, dispositions), `docs/docs/builders/quality/*.mdx`
+
+## Human Judgment
+
+Closing Run 1 and opening Run 2 on 2026-09-08 is a human act on the deployed app with two wallets;
+the compare's usefulness is judged on that call, not in tests.
+
+## Risks and Mitigations
+
+- A malformed run index or shard fails every poll: validate on read, refuse the write on shape
+  errors, and keep the migration reversible (legacy path untouched until verified).
+- Two testers opening runs at once: the index write is conditional on its ETag, like shards.
+- The split lands after a run opened on the old catalog: a run pins the catalog version it opened
+  with; the compare maps by `replacedBy` either way.
+
+## Decision Log
+
+1–7 in brief.md, locked 2026-09-05. Sources: the 2026-09-04 call (versioning promise, split
+request), the qa-report hub's delta constraint, and the three alignment rounds recorded in the
+session that filed PRD-864.

--- a/.plans/backlog/qa-runs/spec.md
+++ b/.plans/backlog/qa-runs/spec.md
@@ -9,14 +9,24 @@ agents that pull the store to write the session report and slices.
 
 1. **Run model.** A run has an id, label, `openedAt`, `openedBy`, `closedAt`, `closedBy`,
    `catalogVersion`, `environment` (`production | beta | local`), and optional build SHAs per
-   surface. Exactly one run is open at a time. The run index lives beside the shards
-   (`qa/runs.json`); shards move to `qa/runs/<runId>/entries/<address>.json`.
+   surface. Exactly one run is open at a time: the only close is a rollover that closes the current run and
+   opens its successor in one ETag-conditional write of the index, so no request can observe a
+   zero-open state. The run index lives beside the shards (`qa/runs.json`); shards move to
+   `qa/runs/<runId>/entries/<address>.json`.
 2. **Migration.** The existing `qa/entries/<address>.json` shards become Run 1 by a one-time
    server-side move; the legacy path is read only until the move completes, then never written.
+   Run 1 is legacy latest-state, not a bounded session: its index entry records
+   `openedAt` = the earliest migrated entry timestamp, `closedAt` = the migration time, and
+   `legacy: true`, and the compare treats it as a baseline of last-known verdicts rather than a
+   dated walk.
 3. **Immutability.** `POST /api/state` writes only to the open run; a write against a closed run is
-   refused with a message the page shows. The outbox is keyed by owner and run.
-4. **Open and close.** Any allowlisted session may open a run (label, environment, optional build
-   SHAs) or close the open one; both are recorded in the index. Closing never deletes.
+   refused with the open run's id in the response. The page then re-targets that pending outbox at
+   the open run, saves it there, and tells the tester which run received it, so a tester who was
+   offline or mid-save when a teammate rolled the run over loses nothing; the closed run stays
+   immutable. The outbox is keyed by owner and run.
+4. **Open and close.** Any allowlisted session may roll the run over (close the open one and open
+   its successor with a label, environment, and optional build SHAs) in one action; the index
+   records who did it and when. Closing never deletes, and there is no standalone close.
 5. **View.** A Run select beside View defaults to the open run; closed runs are readable. A compare
    toggle shows, per row, the compared run's rollup verdict and notes; the tally adds fixed, still
    failing, regressed, and newly walked. A Re-QA filter lists cases that were fail or blocked in the
@@ -26,7 +36,11 @@ agents that pull the store to write the session report and slices.
 7. **Vocabulary.** The N/A control's hint says "out of scope for this run"; a not-walked case has
    no entry. The run's environment shows in the header; the `[beta]`/`[prod]` note prefix is
    documented in the app's help line.
-8. **Scripts.** `qa:pull --run <id>` pulls one run (default: the open run); `qa:report --previous`
+8. **Scripts.** `qa:pull --run <id | open | latest-closed>` pulls one run; the default is `open`
+   for a live session, but the call-report flow pulls the run the call recorded into: `qa-session`
+   writes the run id into the session header, `/qa-triage --call` and the routine read it from
+   there (or from the parent's lede on a rerun) and pass it explicitly, and `latest-closed` is the
+   documented fallback when the run was rolled over before the report ran. `qa:report --previous`
    accepts a run id or a pulled directory; the delta section names both runs.
 9. **Catalog split (lane input: catalog-feedback-2026-09-04.md).** Retire grouped rows walked or
    failing on 2026-09-04 with `replacedBy` successors, add the Android twins, fix wrong-surface and

--- a/.plans/backlog/qa-runs/status.json
+++ b/.plans/backlog/qa-runs/status.json
@@ -10,7 +10,7 @@
     "overall_status": "backlog",
     "priority": "p2",
     "created_at": "2026-09-05T04:08:09.130Z",
-    "updated_at": "2026-09-05T04:16:34.577Z"
+    "updated_at": "2026-09-05T19:02:47.910Z"
   },
   "links": {
     "brief": "brief.md",
@@ -45,7 +45,7 @@
       "owner": "claude",
       "status": "todo",
       "branch": null,
-      "depends_on": [],
+      "depends_on": ["state_api"],
       "handoff": "handoffs/claude-ui.md",
       "tdd": {
         "mode": "required",
@@ -85,7 +85,7 @@
     },
     "contracts": {
       "owner": "codex",
-      "status": "todo",
+      "status": "n/a",
       "branch": null,
       "depends_on": [],
       "handoff": "handoffs/codex-contracts.md",
@@ -102,7 +102,8 @@
         },
         "note": ""
       },
-      "skill_tags": ["contracts"]
+      "skill_tags": ["contracts"],
+      "manual_blocked": false
     },
     "qa_pass_1": {
       "owner": "claude",
@@ -110,7 +111,7 @@
       "ready_when_dependencies_met": true,
       "manual_blocked": false,
       "branch": null,
-      "depends_on": ["ui", "state_api", "contracts"],
+      "depends_on": ["ui", "state_api"],
       "handoff": "handoffs/claude-qa-pass-1.md",
       "skill_tags": ["testing", "review"]
     },
@@ -141,6 +142,14 @@
       "status": "linear_recorded",
       "branch": null,
       "note": "Recorded Linear parent/lane issue identifiers"
+    },
+    {
+      "timestamp": "2026-09-05T19:02:47.913Z",
+      "actor": "claude",
+      "lane": "contracts",
+      "status": "n/a",
+      "branch": null,
+      "note": "No contract changes in scope; see brief.md Boundaries"
     }
   ]
 }

--- a/.plans/backlog/qa-runs/status.json
+++ b/.plans/backlog/qa-runs/status.json
@@ -10,7 +10,7 @@
     "overall_status": "backlog",
     "priority": "p2",
     "created_at": "2026-09-05T04:08:09.130Z",
-    "updated_at": "2026-09-05T04:08:09.130Z"
+    "updated_at": "2026-09-05T04:16:34.577Z"
   },
   "links": {
     "brief": "brief.md",
@@ -19,12 +19,13 @@
     "eval": "eval.md"
   },
   "linear": {
-    "parentIssue": null,
+    "parentIssue": "PRD-878",
     "project": null,
     "initiative": null,
     "syncDirection": "plans_to_linear_visibility",
     "lastSyncedAt": null,
-    "lanes": {}
+    "lanes": {},
+    "laneSyncMode": "parent_only"
   },
   "taxonomy": {
     "initiative": "engineering-quality",
@@ -132,6 +133,14 @@
       "status": "scaffolded",
       "branch": null,
       "note": "Scaffolded feature hub in backlog"
+    },
+    {
+      "timestamp": "2026-09-05T04:16:34.577Z",
+      "actor": "claude",
+      "lane": "system",
+      "status": "linear_recorded",
+      "branch": null,
+      "note": "Recorded Linear parent/lane issue identifiers"
     }
   ]
 }

--- a/.plans/backlog/qa-runs/status.json
+++ b/.plans/backlog/qa-runs/status.json
@@ -1,0 +1,137 @@
+{
+  "version": 2,
+  "feature": {
+    "slug": "qa-runs",
+    "title": "QA Runs",
+    "kind": "feature",
+    "stage": "backlog"
+  },
+  "workflow": {
+    "overall_status": "backlog",
+    "priority": "p2",
+    "created_at": "2026-09-05T04:08:09.130Z",
+    "updated_at": "2026-09-05T04:08:09.130Z"
+  },
+  "links": {
+    "brief": "brief.md",
+    "spec": "spec.md",
+    "plan": "plan.todo.md",
+    "eval": "eval.md"
+  },
+  "linear": {
+    "parentIssue": null,
+    "project": null,
+    "initiative": null,
+    "syncDirection": "plans_to_linear_visibility",
+    "lastSyncedAt": null,
+    "lanes": {}
+  },
+  "taxonomy": {
+    "initiative": "engineering-quality",
+    "tracks": [],
+    "work_types": ["implementation"],
+    "surfaces": [],
+    "depends_on_features": []
+  },
+  "notes": [
+    "Mark unused lanes as n/a before promoting QA.",
+    "status.json is authoritative; set a concrete <type>/<work-description> branch only when work begins.",
+    "Use targeted bun run test or bun run test as the iterative gate for the touched surface; coverage is scheduled or pre-merge evidence.",
+    ".plans/ is the durable repo truth; any tool-local or .claude/agent-memory surface stays environment-local until freshness and ownership rules exist."
+  ],
+  "lanes": {
+    "ui": {
+      "owner": "claude",
+      "status": "todo",
+      "branch": null,
+      "depends_on": [],
+      "handoff": "handoffs/claude-ui.md",
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": ""
+      },
+      "skill_tags": ["ui", "frontend-design", "react"]
+    },
+    "state_api": {
+      "owner": "codex",
+      "status": "todo",
+      "branch": null,
+      "depends_on": [],
+      "handoff": "handoffs/codex-state-api.md",
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": ""
+      },
+      "skill_tags": ["react", "tanstack-query", "data-layer"]
+    },
+    "contracts": {
+      "owner": "codex",
+      "status": "todo",
+      "branch": null,
+      "depends_on": [],
+      "handoff": "handoffs/codex-contracts.md",
+      "tdd": {
+        "mode": "required",
+        "status": "pending",
+        "red": {
+          "command": "",
+          "evidence": ""
+        },
+        "green": {
+          "command": "",
+          "evidence": ""
+        },
+        "note": ""
+      },
+      "skill_tags": ["contracts"]
+    },
+    "qa_pass_1": {
+      "owner": "claude",
+      "status": "blocked",
+      "ready_when_dependencies_met": true,
+      "manual_blocked": false,
+      "branch": null,
+      "depends_on": ["ui", "state_api", "contracts"],
+      "handoff": "handoffs/claude-qa-pass-1.md",
+      "skill_tags": ["testing", "review"]
+    },
+    "qa_pass_2": {
+      "owner": "codex",
+      "status": "blocked",
+      "ready_when_dependencies_met": true,
+      "manual_blocked": false,
+      "branch": null,
+      "depends_on": ["qa_pass_1"],
+      "handoff": "handoffs/codex-qa-pass-2.md",
+      "skill_tags": ["testing", "review"]
+    }
+  },
+  "history": [
+    {
+      "timestamp": "2026-09-05T04:08:09.132Z",
+      "actor": "human",
+      "lane": "system",
+      "status": "scaffolded",
+      "branch": null,
+      "note": "Scaffolded feature hub in backlog"
+    }
+  ]
+}

--- a/docs/docs/builders/agentic/task-routing.mdx
+++ b/docs/docs/builders/agentic/task-routing.mdx
@@ -22,7 +22,7 @@ generated_from:
   - .claude/skills/review/SKILL.md
   - .claude/skills/ship/SKILL.md
   - scripts/quality/task-routing-contract.mjs
-source_digest: "sha256:0984a322f53a0fbb9b40c5f7e52131ecd8b2ce6aec9e6d805f8b652e31b88bc4"
+source_digest: "sha256:015fac6fa2dc7b5961d7b55f72ffd952c593aeb3b4608e308a5691b816d794d3"
 source_of_truth:
   - .claude/context/task-routing.json
   - .claude/skills/audit/SKILL.md

--- a/docs/docs/builders/agentic/task-routing.mdx
+++ b/docs/docs/builders/agentic/task-routing.mdx
@@ -22,7 +22,7 @@ generated_from:
   - .claude/skills/review/SKILL.md
   - .claude/skills/ship/SKILL.md
   - scripts/quality/task-routing-contract.mjs
-source_digest: "sha256:c4f220f7cd9c6224d00ee44a0812ab77b3aed46ad551755019e2b61affa01bd3"
+source_digest: "sha256:cf38754890f643e79bc92c3067bee120617025d153b031e63d0fe0cec633d58a"
 source_of_truth:
   - .claude/context/task-routing.json
   - .claude/skills/audit/SKILL.md

--- a/docs/docs/builders/agentic/task-routing.mdx
+++ b/docs/docs/builders/agentic/task-routing.mdx
@@ -22,7 +22,7 @@ generated_from:
   - .claude/skills/review/SKILL.md
   - .claude/skills/ship/SKILL.md
   - scripts/quality/task-routing-contract.mjs
-source_digest: "sha256:015fac6fa2dc7b5961d7b55f72ffd952c593aeb3b4608e308a5691b816d794d3"
+source_digest: "sha256:b1ed749a10ab44037f77fa750f0b6de0a7ce0c841d68db9e8560dce00decba5b"
 source_of_truth:
   - .claude/context/task-routing.json
   - .claude/skills/audit/SKILL.md

--- a/docs/docs/builders/agentic/task-routing.mdx
+++ b/docs/docs/builders/agentic/task-routing.mdx
@@ -22,7 +22,7 @@ generated_from:
   - .claude/skills/review/SKILL.md
   - .claude/skills/ship/SKILL.md
   - scripts/quality/task-routing-contract.mjs
-source_digest: "sha256:b1ed749a10ab44037f77fa750f0b6de0a7ce0c841d68db9e8560dce00decba5b"
+source_digest: "sha256:c4f220f7cd9c6224d00ee44a0812ab77b3aed46ad551755019e2b61affa01bd3"
 source_of_truth:
   - .claude/context/task-routing.json
   - .claude/skills/audit/SKILL.md

--- a/docs/routines/qa-call-report.md
+++ b/docs/routines/qa-call-report.md
@@ -22,7 +22,7 @@ connectors:
   - sentry        # when available — resolves projects by name through the connector, no env vars; absent = skip silently
 model: claude-opus-5
 allow-unrestricted-branch-pushes: false  # Linear + Discord only; no PRs, no Sheet writes, no GitHub Issues
-last_updated: "2026-09-02"
+last_updated: "2026-09-05"
 ---
 
 # Prompt
@@ -127,8 +127,23 @@ pulled session and `--force` would discard any redactions) — and run `qa:repor
   opaque shard reference (`shard 2 of 3 failed validation`), never the shard path or the raw
   parse error, both of which embed the tester's wallet address. Do not fall back to notes-only
   silently; rerun after the store is fixed.
+- `N/A` means intentionally out of scope, never skipped
+  ([`.claude/context/qa.md § Verdict vocabulary`](../../.claude/context/qa.md)); the report counts
+  it as judged. When a note beside an `N/A` says the case was skipped, say so in the lede's
+  coverage sentence instead of treating the case as covered.
 
 ## Phase 3: Join and cluster into slices
+
+Before keying anything, split every app note into one observation per distinct symptom (a
+dictated note often carries several: six polish items and one blocker in one paragraph on
+2026-09-04), keep the Test ID, tester, and verdict on each, and give each observation one
+disposition from [`.claude/context/qa.md § Finding dispositions`](../../.claude/context/qa.md):
+`defect`, `polish`, `decision`, `investigate`, `catalog`, or `environment`. Only `defect` and
+`polish` cluster. `decision` feeds the parent's `Decisions needed` section and the decisions child
+(Phase 7); `investigate` becomes a `Not sliced · investigate` line; `environment` one line in the
+parent; `catalog` (a tester's remark about the test case itself) becomes one `Catalog feedback`
+comment on the parent — never a slice and never a `Not sliced` line, because it is catalog work,
+not product work.
 
 1. Key every finding by **exact Test ID** where one exists (all app entries have one; notes
    items may name one). A notes item **without** an exact ID never gets one guessed for it — the
@@ -141,9 +156,13 @@ pulled session and `--force` would discard any redactions) — and run `qa:repor
    notes item separate rather than merging — a wrong merge attaches the quote to the wrong case.
 3. **Cluster into slices**: same catalog `area` + same suspected seam (the module/component the
    failures share). Split a cluster past 3 Test IDs or when it crosses packages. A cross-surface
-   cluster whose root cause sits in shared code is ONE slice on the shared package.
+   cluster whose root cause sits in shared code is ONE slice on the shared package. Each slice
+   states where it can be verified — `local`, `device`, or `production`, from its cases'
+   `requiresDevice` and `requiresProduction` flags — so a fix session takes `local` first.
 4. Cap **8 slices**, ordered by highest member priority; overflow findings are listed in the
-   parent's "Not sliced" section, not silently dropped.
+   parent's "Not sliced" section, not silently dropped. Standing fail/blocked entries outside the
+   window are never slices unattended; those with no open Issue carrying their Test ID are listed
+   in `Not sliced` as `standing since <date>` lines for a human to promote at the desk.
 
 ## Phase 4: Enrich from the product (non-blocking)
 
@@ -195,7 +214,9 @@ the call's identity, since the week's `qa-sync` label is shared) and no `package
 **reuse it** — add missing children under it and a comment for new context; never a second
 parent, and never attach slices to anything that fails the shape test.
 
-Then the findings: list open Product Issues carrying `activity:qa` or any `qa-sync:*` label.
+Then the findings: list open Product Issues carrying `activity:qa` or any `qa-sync:*` label, plus
+every Issue created on the team since the window opened whatever its labels (a teammate filing
+from the call rarely stamps `activity:qa`).
 "Already tracked" needs an **exact key**: the same catalog Test ID in the existing Issue's
 source line, or the same PostHog error hash. Wording or surface similarity alone never earns it
 unattended — an uncertain match stays in this session's record (its slice, or `Not sliced`)
@@ -219,20 +240,25 @@ exposure: redact in place and fail loud in the Discord summary.
    its counter, `QA session <YYYY-MM-DD> · 2` (only that ` · N` counter keeps the
    word-backstop exemption; a wordier suffix loses it) — body per the § QA session report
    template — lede, then Results by priority and Results by kind pasted verbatim from
-   `tmp/qa-session/<slug>/report.md`, Decisions from the call (omit in app-only mode), Slices,
-   Not sliced, `Done when`, source line with the Drive notes link. State `Todo`. Labels: `green-goods` + `qa` + `qa-session` + `routine` +
+   `tmp/qa-session/<slug>/report.md`, Decisions from the call (omit in app-only mode), Decisions needed (when
+   any), Slices, Not sliced, `Done when`, source line with the Drive notes link. The lede names
+   the session's default environment. State `Todo`. Labels: `green-goods` + `qa` + `qa-session` + `routine` +
    `qa-sync:<date>`; **no `package:*`** on the parent. The parent's `Done when` defines its
    closure — every slice Done or explicitly deferred, re-QA re-recorded; the fix flow closes it,
    never this routine. **One exception**: an all-pass session (zero slices, zero related
    Issues) creates its parent directly in `Done` — it is a record with nothing to fix, and
    nothing downstream would ever close a `Todo` shell. App-only runs use the app-state
    source-line variant from the template — never a fabricated Drive link.
-2. **Then each slice** as a sub-issue via `parentId`, body per the § QA slice template (problem
+2. **Then the decisions child** when `Decisions needed` is non-empty: `Product decisions from QA
+   session <date>` per § Product decisions child in the templates — `Backlog`, unassigned, the
+   parent label set, no `package:*`.
+3. **Then each slice** as a sub-issue via `parentId`, body per the § QA slice template (problem
    cluster in prose with Test IDs and verdicts, "Where to start" map, "Done when" = the Test IDs
    re-record as pass, fix-posture pointer, validation command, source line).
    - **Verdict-backed** (a tester recorded fail/blocked in the app **during the session
      window**): `Todo`; priority High for a P0-case fail, Medium for P1, Low otherwise — Urgent
-     only when the notes flag it release-blocking. This seeded priority is a queue-ordering
+     only when the notes flag it release-blocking or a tester's own note calls it a major
+     regression, major blocker, or completely broken. This seeded priority is a queue-ordering
      default derived from walk priority, not a severity judgment
      ([`.claude/context/qa.md`](../../.claude/context/qa.md) § Verdict and severity rules); the
      fix session re-judges it at take-up. Todo-on-write is a deliberate, owner-approved
@@ -241,7 +267,7 @@ exposure: redact in place and fail loud in the Discord summary.
      because every slice remains a proposal until a person takes it up.
    - **Notes-only** (no app verdict): `Backlog`, priority unset.
    - Labels: the parent set plus ONE `package:*` (primary surface; secondary named in prose).
-3. A failed parent write aborts the run (children without a parent are orphans); a failed child
+4. A failed parent write aborts the run (children without a parent are orphans); a failed child
    write is retried once, then reported.
 
 ## Phase 8: Discord summary to #product
@@ -286,6 +312,7 @@ the @mention.
 | Block the report on enrichment | PostHog/Vercel/Sentry are context, not the record; flag a degraded source and continue |
 | Paste replay URLs, session IDs, or distinct IDs anywhere in Linear | The privacy boundary does not move for enrichment; the recipe line replaces the link |
 | Promote a `[derived:telemetry]` line into a slice | Nobody recorded it — unattended promotion invents work; a human decides at the next triage |
+| Turn a tester's remark about the test case into a slice | Split it, rename it, move it, unclear: that is catalog work, not product work — one `Catalog feedback` comment on the parent |
 
 ## Rebuilding the cloud routine from this file
 

--- a/docs/routines/qa-call-report.md
+++ b/docs/routines/qa-call-report.md
@@ -229,8 +229,10 @@ Never a duplicate Issue.
 ## Phase 6: Privacy sweep
 
 Grep every draft body and comment for `replay`, `session_id`, `distinct_id`, `0x`, and any
-tester or reporter identifier seen this run. The report carries **no tester attribution** —
-aggregate coverage only; per-tester detail stays in the pulled results and the private Sheet.
+tester or reporter identifier seen this run. The parent body and every comment carry **no
+tester attribution** — aggregate coverage only. The full `report.md`, with its attributed notes,
+goes into the parent's attached document (Phase 7) after the same grep, with `0x` strings, replay
+or session identifiers, and any name outside the team redacted; team display names stay.
 Wallet addresses, session IDs, and replay URLs appear nowhere. A hit after a write is an
 exposure: redact in place and fail loud in the Discord summary.
 
@@ -249,10 +251,16 @@ exposure: redact in place and fail loud in the Discord summary.
    Issues) creates its parent directly in `Done` — it is a record with nothing to fix, and
    nothing downstream would ever close a `Todo` shell. App-only runs use the app-state
    source-line variant from the template — never a fabricated Drive link.
-2. **Then the decisions child** when `Decisions needed` is non-empty: `Product decisions from QA
+2. **Then the full report as a document**: `save_document` with `issue` = the parent, title exactly
+   `QA session <YYYY-MM-DD> · full report` (same counter rule as the parent), content =
+   `tmp/qa-session/<slug>/report.md` verbatim after the Phase 6 grep, per
+   [linear-templates.md § Full report document](../../.claude/skills/qa-triage/linear-templates.md).
+   Then patch the parent's lede with the document link, resending the title so the length
+   exemption holds. A rerun updates the existing document by id; never a second one.
+3. **Then the decisions child** when `Decisions needed` is non-empty: `Product decisions from QA
    session <date>` per § Product decisions child in the templates — `Backlog`, unassigned, the
    parent label set, no `package:*`.
-3. **Then each slice** as a sub-issue via `parentId`, body per the § QA slice template (problem
+4. **Then each slice** as a sub-issue via `parentId`, body per the § QA slice template (problem
    cluster in prose with Test IDs and verdicts, "Where to start" map, "Done when" = the Test IDs
    re-record as pass, fix-posture pointer, validation command, source line).
    - **Verdict-backed** (a tester recorded fail/blocked in the app **during the session
@@ -267,7 +275,7 @@ exposure: redact in place and fail loud in the Discord summary.
      because every slice remains a proposal until a person takes it up.
    - **Notes-only** (no app verdict): `Backlog`, priority unset.
    - Labels: the parent set plus ONE `package:*` (primary surface; secondary named in prose).
-4. A failed parent write aborts the run (children without a parent are orphans); a failed child
+5. A failed parent write aborts the run (children without a parent are orphans); a failed child
    write is retried once, then reported.
 
 ## Phase 8: Discord summary to #product
@@ -292,8 +300,8 @@ Report: <{parent-url}> · {N} slices ({T} Todo · {B} Backlog){if overflow: " ·
 
 No per-surface count tables in the post — they live in the report. The lede may quote the `P0:`
 line from `report.public.md`; that public projection is the only report text that reaches a public
-surface. The private `report.md` feeds the Linear parent's results blocks (Phase 7), but its
-attributed notes and per-tester sections never leave `tmp/`. Enrichment flags
+surface. The private `report.md` feeds the Linear parent's results blocks and is attached to the parent
+as a document (Phase 7); it reaches no other surface, and the Discord post never quotes it. Enrichment flags
 (`posthog: degraded`, `sentry: unavailable`) join the failure list when they occurred. Quiet
 failure is forbidden: a run that wrote nothing because something broke posts the failure with
 the @mention.

--- a/docs/routines/qa-call-report.md
+++ b/docs/routines/qa-call-report.md
@@ -64,9 +64,11 @@ decision log is a human-gated local step, never yours.
   `QA session YYYY-MM-DD` parent title is exempt from the word backstop) and the two templates in
   [`.claude/skills/qa-triage/linear-templates.md`](../../.claude/skills/qa-triage/linear-templates.md)
   § QA session report / § QA slice.
-- Pass labels to `save_issue` as **bare child names** plus the literal `qa-sync:<date>` string
-  (e.g. `["green-goods", "qa", "qa-session", "routine", "qa-sync:2026-09-02"]`); the
-  `group:child` display form is rejected, and one unresolvable entry files nothing.
+- Pass labels to `save_issue` as **bare child names**: `protocol:green-goods`, `activity:qa`,
+  `source:qa-session`, `ai:routine`, and `qa-sync:<date>` are written as
+  `["green-goods", "qa", "qa-session", "routine", "2026-09-02"]` — the `group:child` display
+  form is rejected, and one unresolvable entry files nothing. Every label list in this prompt names
+  the canonical `group:child` label; the bare child name is only the wire form.
 
 ## Phase 1: Discover the call's notes (Drive)
 
@@ -128,9 +130,11 @@ pulled session and `--force` would discard any redactions) — and run `qa:repor
   parse error, both of which embed the tester's wallet address. Do not fall back to notes-only
   silently; rerun after the store is fixed.
 - `N/A` means intentionally out of scope, never skipped
-  ([`.claude/context/qa.md § Verdict vocabulary`](../../.claude/context/qa.md)); the report counts
-  it as judged. When a note beside an `N/A` says the case was skipped, say so in the lede's
-  coverage sentence instead of treating the case as covered.
+  ([`.claude/context/qa.md § Verdict vocabulary`](../../.claude/context/qa.md)), and the generator
+  counts it as judged. When a note beside an in-window `N/A` says the case was skipped, pass those
+  IDs to `qa:report --skipped <ID,ID>`: the generator then treats them as not walked and lists them
+  in its header, so the pasted results blocks never overstate coverage. Name them on the parent's
+  environment line and add one Discord line asking the tester to clear them before the next pull.
 
 ## Phase 3: Join and cluster into slices
 
@@ -150,7 +154,9 @@ not product work.
    linkage contract ([`.claude/context/qa.md`](../../.claude/context/qa.md) § Test ID linkage)
    forbids fuzzy-guessing, and unattended is where a plausible-but-wrong match does the most
    damage: the fixing agent would repair and re-record the wrong case. ID-less items go to the
-   parent's `Not sliced` list as note-only follow-ups; the interactive `/qa-triage --call` may
+   parent's `Not sliced` list as note-only follow-ups — except `decision` observations, which need
+   no case: they go to `Decisions needed` and the decisions child whether or not an ID exists, and
+   `environment` observations, which become the parent's environment line; the interactive `/qa-triage --call` may
    propose fuzzy candidates because a human confirms each one at its gate.
 2. Dedupe notes↔app by exact Test ID; when only title similarity suggests a match, keep the
    notes item separate rather than merging — a wrong merge attaches the quote to the wrong case.
@@ -218,7 +224,8 @@ Then the findings: list open Product Issues carrying `activity:qa` or any `qa-sy
 every Issue created on the team since the window opened whatever its labels (a teammate filing
 from the call rarely stamps `activity:qa`).
 "Already tracked" needs an **exact key**: the same catalog Test ID in the existing Issue's
-source line, or the same PostHog error hash. Wording or surface similarity alone never earns it
+source line or in a comment the QA pipeline posted on it (the interactive mode records confirmed
+matches that way), or the same PostHog error hash. Wording or surface similarity alone never earns it
 unattended — an uncertain match stays in this session's record (its slice, or `Not sliced`)
 with a `possible duplicate of <key>` note for a human to settle. A confirmed match gets a
 comment on the existing Issue (today's date + the new evidence, privacy-grepped before posting)
@@ -247,16 +254,23 @@ exposure: redact in place and fail loud in the Discord summary.
    the session's default environment. State `Todo`. Labels: `green-goods` + `qa` + `qa-session` + `routine` +
    `qa-sync:<date>`; **no `package:*`** on the parent. The parent's `Done when` defines its
    closure — every slice Done or explicitly deferred, re-QA re-recorded; the fix flow closes it,
-   never this routine. **One exception**: an all-pass session (zero slices, zero related
-   Issues) creates its parent directly in `Done` — it is a record with nothing to fix, and
-   nothing downstream would ever close a `Todo` shell. App-only runs use the app-state
+   never this routine. **One exception**: an all-pass session — zero fail or blocked verdicts inside the window,
+   zero slices, zero related Issues, and no decisions child — creates its parent directly in
+   `Done`: it is a record with nothing to fix, and nothing downstream would ever close a `Todo`
+   shell. A session whose only findings are decision or investigate lines is not all-pass; it
+   stays `Todo` until those lines are ruled on or promoted. App-only runs use the app-state
    source-line variant from the template — never a fabricated Drive link.
 2. **Then the full report as a document**: `save_document` with `issue` = the parent, title exactly
-   `QA session <YYYY-MM-DD> · full report` (same counter rule as the parent), content =
-   `tmp/qa-session/<slug>/report.md` verbatim after the Phase 6 grep, per
+   `QA session <YYYY-MM-DD> · full report` (same counter rule as the parent), content = the
+   `report.md` of the pull the results blocks came from (the `-final` directory when Phase 2
+   re-pulled after the window closed) verbatim after the Phase 6 grep, per
    [linear-templates.md § Full report document](../../.claude/skills/qa-triage/linear-templates.md).
-   Then patch the parent's lede with the document link, resending the title so the length
-   exemption holds. A rerun updates the existing document by id; never a second one.
+   Idempotency and failure: look for an existing document of that title under the parent first and
+   update it by id; a failed create is retried once, and a second failure is recorded as
+   `document: failed` in the Discord summary while the run continues (the report is recoverable
+   from the pull, the slices are not). Only after the document exists, patch the parent's lede with
+   its link, resending the title so the length exemption holds; a failed lede patch is retried once
+   and then reported the same way. Children are written after these two steps, never before.
 3. **Then the decisions child** when `Decisions needed` is non-empty: `Product decisions from QA
    session <date>` per § Product decisions child in the templates — `Backlog`, unassigned, the
    parent label set, no `package:*`.
@@ -265,8 +279,12 @@ exposure: redact in place and fail loud in the Discord summary.
    re-record as pass, fix-posture pointer, validation command, source line).
    - **Verdict-backed** (a tester recorded fail/blocked in the app **during the session
      window**): `Todo`; priority High for a P0-case fail, Medium for P1, Low otherwise — Urgent
-     only when the notes flag it release-blocking or a tester's own note calls it a major
-     regression, major blocker, or completely broken. This seeded priority is a queue-ordering
+     only when the call notes flag it release-blocking. A tester's own note calling it a major
+     regression, major blocker, or completely broken keeps the derived priority unattended and adds
+     an `Urgent proposed` line to the slice's first comment and to the Discord summary, for a
+     human to confirm at the desk. A `polish` cluster lands Low whatever its cases' priority:
+     `Todo` when at least one member entry sits inside the window, `Backlog` when reconstructed
+     from notes alone. This seeded priority is a queue-ordering
      default derived from walk priority, not a severity judgment
      ([`.claude/context/qa.md`](../../.claude/context/qa.md) § Verdict and severity rules); the
      fix session re-judges it at take-up. Todo-on-write is a deliberate, owner-approved

--- a/docs/routines/qa-call-report.md
+++ b/docs/routines/qa-call-report.md
@@ -266,11 +266,16 @@ exposure: redact in place and fail loud in the Discord summary.
    re-pulled after the window closed) verbatim after the Phase 6 grep, per
    [linear-templates.md § Full report document](../../.claude/skills/qa-triage/linear-templates.md).
    Idempotency and failure: look for an existing document of that title under the parent first and
-   update it by id; a failed create is retried once, and a second failure is recorded as
-   `document: failed` in the Discord summary while the run continues (the report is recoverable
-   from the pull, the slices are not). Only after the document exists, patch the parent's lede with
-   its link, resending the title so the length exemption holds; a failed lede patch is retried once
-   and then reported the same way. Children are written after these two steps, never before.
+   update it by id; a failed create is retried once. A second failure falls back to `save_comment`
+   on the parent with the same content under a first line `Full report (document write failed)`,
+   because nothing else keeps this record: the Blob store holds one entry per case per tester, so
+   the next QA write can overwrite this session's state, and the run's `tmp/` snapshot dies with
+   the run. Record `document: failed, report in comment` in the Discord summary. If the comment
+   fails too, stop before any child is written — the parent exists, so post the failure block with
+   the parent id and re-run from a fresh pull. Only after the document (or its comment fallback)
+   exists, patch the parent's lede with its link, resending the title so the length exemption
+   holds; a failed lede patch is retried once and then reported the same way. Children are written
+   after these two steps, never before.
 3. **Then the decisions child** when `Decisions needed` is non-empty: `Product decisions from QA
    session <date>` per § Product decisions child in the templates — `Backlog`, unassigned, the
    parent label set, no `package:*`.

--- a/scripts/agents/qa-report.test.ts
+++ b/scripts/agents/qa-report.test.ts
@@ -320,6 +320,30 @@ describe("QA report delta and gaps", () => {
   });
 });
 
+describe("QA report skipped cases", () => {
+  it("sets a --skipped case's in-window N/A aside as not walked and keeps every other verdict", () => {
+    const cases = [makeCase(), makeCase({ id: "PUB-002" }), makeCase({ id: "PUB-003" })];
+    const merged = mergeShards([
+      shard("Afo", {
+        "PUB-001": { s: "na", n: "skipped for time", at: IN_WINDOW },
+        "PUB-002": { s: "na", n: "", at: IN_WINDOW },
+        "PUB-003": { s: "fail", n: "a real verdict", at: IN_WINDOW },
+      }),
+    ]);
+    const options = { slug: SLUG, window: WINDOW, pulledAt: PULLED_AT };
+    const model = buildReportModel(cases, merged, { ...options, skipped: ["PUB-001", "PUB-003"] });
+    // PUB-001's N/A is set aside; PUB-002's N/A stands as judged; PUB-003's Fail is a verdict, never a skip.
+    expect(model.byPriority.P0).toMatchObject({ walked: 2, na: 1, fail: 1 });
+    expect(model.gaps.neverWalked.P0).toEqual(["PUB-001"]);
+    expect(model.issues.map((issue) => issue.id)).toEqual(["PUB-003"]);
+    expect(model.skipped).toEqual({ ids: ["PUB-001", "PUB-003"], excluded: 1 });
+    const report = renderReport(model, { kinds: KINDS }, { variant: "private" });
+    expect(report).toContain("Skipped: `PUB-001`, `PUB-003` — recorded N/A during the walk; 1 in-window entry set aside");
+    expect(buildReportModel(cases, merged, options).skipped).toEqual({ ids: [], excluded: 0 });
+    expect(() => buildReportModel(cases, merged, { ...options, skipped: ["PUB-999"] })).toThrow(/--skipped.*PUB-999/);
+  });
+});
+
 describe("QA report CLI", () => {
   it("parses the full flag set", () => {
     expect(
@@ -331,6 +355,7 @@ describe("QA report CLI", () => {
         "--public",
         "--stale-days", "14",
         "--out", "tmp/qa-session/2026-09-02-call",
+        "--skipped", "PWA-032, PWA-IOS-002,PWA-032",
       ]),
     ).toEqual({
       slug: "2026-09-02",
@@ -340,6 +365,7 @@ describe("QA report CLI", () => {
       public: true,
       staleDays: 14,
       out: "tmp/qa-session/2026-09-02-call",
+      skipped: ["PWA-032", "PWA-IOS-002"],
     });
     expect(parseArgs(["--slug", "2026-09-02"])).toEqual({ slug: "2026-09-02", public: false, staleDays: 30 });
   });
@@ -350,6 +376,8 @@ describe("QA report CLI", () => {
     expect(() => parseArgs(["--slug", "2026-09-02", "--bogus"])).toThrow(/unknown argument/);
     expect(() => parseArgs(["--slug", "2026-09-02", "--stale-days", "0"])).toThrow(/--stale-days/);
     expect(() => parseArgs(["--slug", "2026-09-02", "--build", "web=abc"])).toThrow(/--build/);
+    expect(() => parseArgs(["--slug", "2026-09-02", "--skipped", "pwa032"])).toThrow(/--skipped/);
+    expect(() => parseArgs(["--slug", "2026-09-02", "--skipped", " , "])).toThrow(/--skipped/);
   });
 
   it("writes report.md and, with --public, report.public.md beside the pulled session", async () => {

--- a/scripts/agents/qa-report.test.ts
+++ b/scripts/agents/qa-report.test.ts
@@ -288,6 +288,7 @@ describe("QA report delta and gaps", () => {
       stillFailing: ["PUB-004"],
       stillBlocked: ["PUB-003"],
       cleared: [],
+      skipped: [],
       unknown: ["XPLAT-001"],
     });
     // The path and unknown ids are private detail; the public variant withholds them.
@@ -341,6 +342,38 @@ describe("QA report skipped cases", () => {
     expect(report).toContain("Skipped: `PUB-001`, `PUB-003` — recorded N/A during the walk; 1 in-window entry set aside");
     expect(buildReportModel(cases, merged, options).skipped).toEqual({ ids: [], excluded: 0 });
     expect(() => buildReportModel(cases, merged, { ...options, skipped: ["PUB-999"] })).toThrow(/--skipped.*PUB-999/);
+  });
+
+  it("keeps the delta and the standing lists consistent with a skipped case", () => {
+    const cases = [makeCase(), makeCase({ id: "PUB-002" }), makeCase({ id: "PUB-003" })];
+    const previous = mergeShards([
+      shard("Afo", {
+        "PUB-001": { s: "fail", n: "", at: BEFORE_WINDOW },
+        "PUB-002": { s: "fail", n: "", at: BEFORE_WINDOW },
+        "PUB-003": { s: "pass", n: "", at: BEFORE_WINDOW },
+      }),
+    ]);
+    const current = mergeShards([
+      shard("Afo", {
+        "PUB-001": { s: "na", n: "skipped for time", at: IN_WINDOW },
+        "PUB-002": { s: "na", n: "out of scope now", at: IN_WINDOW },
+        "PUB-003": { s: "fail", n: "", at: IN_WINDOW },
+      }),
+    ]);
+    const model = buildReportModel(cases, current, {
+      slug: SLUG,
+      window: WINDOW,
+      pulledAt: PULLED_AT,
+      previous: { path: "tmp/qa-session/2026-08-31/qa-state.json", entries: previous },
+      skipped: ["PUB-001", "PUB-003"],
+    });
+    // PUB-001 was not walked, so it is neither fixed nor cleared; PUB-002's N/A stands as cleared;
+    // PUB-003's Fail is a real verdict whatever --skipped says.
+    expect(model.delta).toMatchObject({ skipped: ["PUB-001"], cleared: ["PUB-002"], newlyFailing: ["PUB-003"], fixed: [] });
+    expect(model.standing).toEqual({ failing: [], blocked: [] });
+    expect(model.gaps.neverWalked.P0).toEqual(["PUB-001"]);
+    const report = renderReport(model, { kinds: KINDS }, { variant: "private" });
+    expect(report).toContain("- Cleared without a pass (1): `PUB-002`\n- Skipped (baseline fail or blocked, not walked) (1): `PUB-001`\n");
   });
 });
 

--- a/scripts/agents/qa-report.ts
+++ b/scripts/agents/qa-report.ts
@@ -101,6 +101,8 @@ export interface ReportModel {
   standing: { failing: string[]; blocked: string[] };
   delta: ReportDelta | null;
   testers: { count: number; perPerson: Record<string, { touched: number; decided: number }> };
+  /** IDs passed as --skipped and how many in-window N/A entries that set aside. */
+  skipped: { ids: string[]; excluded: number };
 }
 
 export interface ReportOptions {
@@ -121,6 +123,12 @@ export interface ReportOptions {
    * that is, when someone redacted or corrected it.
    */
   noteOverrides?: Map<string, string>;
+  /**
+   * Test IDs whose in-window N/A entries were a tester's "skipped", not an
+   * out-of-scope call. Those entries are set aside so the case counts as not
+   * walked; any other verdict on the same case stands.
+   */
+  skipped?: string[];
 }
 
 const DAY = /^\d{4}-\d{2}-\d{2}$/;
@@ -239,6 +247,19 @@ export function buildReportModel(cases: CatalogCase[], entries: MergedEntries, o
   }
   const staleDays = options.staleDays ?? DEFAULT_STALE_DAYS;
   const session = new Map(cases.map((testCase) => [testCase.id, sessionEntries(entries[testCase.id], window)]));
+  const skippedIds = [...new Set(options.skipped ?? [])];
+  const known = new Set(cases.map((testCase) => testCase.id));
+  const unknownSkipped = skippedIds.filter((id) => !known.has(id));
+  if (unknownSkipped.length) {
+    throw new Error(`--skipped names unknown or retired Test IDs: ${unknownSkipped.join(", ")}`);
+  }
+  let excluded = 0;
+  for (const id of skippedIds) {
+    const byPerson = session.get(id) ?? {};
+    const kept = Object.fromEntries(Object.entries(byPerson).filter(([, entry]) => entry.s !== "na"));
+    excluded += Object.keys(byPerson).length - Object.keys(kept).length;
+    session.set(id, kept);
+  }
   // null = nobody touched the case inside the window; "" = touched, no verdict yet.
   const verdictOf = (testCase: CatalogCase): string | null => {
     const byPerson = session.get(testCase.id) ?? {};
@@ -299,6 +320,7 @@ export function buildReportModel(cases: CatalogCase[], entries: MergedEntries, o
     },
     delta: options.previous ? compareStanding(cases, entries, options.previous) : null,
     testers: { count: perPerson.size, perPerson: sortedPeople },
+    skipped: { ids: skippedIds, excluded },
   };
 }
 
@@ -341,6 +363,11 @@ export function renderReport(model: ReportModel, catalog: Pick<Catalog, "kinds">
     `Window: ${model.window.start} – ${model.window.end} (${model.window.source === "flag" ? "from --window" : "slug day, UTC"}) · pulled ${model.pulledAt}`,
     ...(model.windowNote ? [`Caveat: ${model.windowNote}`] : []),
     ...(build.length ? [`Build under test: ${build.join(" · ")}`] : []),
+    ...(model.skipped.ids.length
+      ? [
+          `Skipped: ${idList(model.skipped.ids)} — recorded N/A during the walk; ${model.skipped.excluded} in-window entr${model.skipped.excluded === 1 ? "y" : "ies"} set aside and counted as not walked`,
+        ]
+      : []),
     ...(!isPublic && model.notesFromResults
       ? [`Notes: results.csv for ${model.notesFromResults} case(s) — redactions and corrections honored`]
       : []),
@@ -425,9 +452,20 @@ export interface CliOptions {
   public: boolean;
   staleDays: number;
   out?: string;
+  skipped?: string[];
 }
 
-const VALUE_FLAGS = new Set(["--slug", "--window", "--previous", "--build", "--stale-days", "--out"]);
+const VALUE_FLAGS = new Set(["--slug", "--window", "--previous", "--build", "--stale-days", "--out", "--skipped"]);
+// Catalog Test IDs (PWA-032, PWA-IOS-002, XPLAT-005): validated here by shape, against the catalog in the model.
+const TEST_ID = /^[A-Z][A-Z0-9]*(?:-[A-Z0-9]+)+$/;
+
+function parseSkipped(value: string): string[] {
+  const ids = value.split(",").map((id) => id.trim()).filter(Boolean);
+  if (!ids.length || ids.some((id) => !TEST_ID.test(id))) {
+    throw new Error("--skipped must be a comma-separated list of catalog Test IDs (e.g. PWA-032,PWA-IOS-002)");
+  }
+  return [...new Set(ids)];
+}
 // Both values are printed in report headers, the public one included: keep them to identifiers.
 const SLUG = /^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$/;
 const COMMIT_SHA = /^[0-9a-f]{7,40}$/;
@@ -464,6 +502,7 @@ export function parseArgs(argv: string[]): CliOptions {
     else if (flag === "--previous") options.previous = value;
     else if (flag === "--out") options.out = value;
     else if (flag === "--build") options.build = parseBuild(value);
+    else if (flag === "--skipped") options.skipped = parseSkipped(value);
     else {
       options.staleDays = Number(value);
       if (!Number.isInteger(options.staleDays) || options.staleDays <= 0) {
@@ -611,6 +650,7 @@ export async function runReport(
       staleDays: options.staleDays,
       previous,
       noteOverrides,
+      skipped: options.skipped,
     });
 
     const report = path.join(outDir, "report.md");

--- a/scripts/agents/qa-report.ts
+++ b/scripts/agents/qa-report.ts
@@ -79,6 +79,8 @@ export interface ReportDelta {
   stillBlocked: string[];
   /** Fail or Blocked in the baseline, now missing, note-only, or N/A — a cleared entry is not a fix. */
   cleared: string[];
+  /** Fail or Blocked in the baseline and set aside by --skipped this run: not walked, so neither fixed nor cleared. */
+  skipped: string[];
   /** Keys on either side that are not active catalog cases — reported, never dropped, never published. */
   unknown: string[];
 }
@@ -203,7 +205,12 @@ function groupBuckets(
   return Object.fromEntries(keys.map((key) => [key, bucket(cases.filter((testCase) => keyOf(testCase) === key), verdictOf)]));
 }
 
-function compareStanding(cases: CatalogCase[], current: MergedEntries, previous: { path: string; entries: MergedEntries }): ReportDelta {
+function compareStanding(
+  cases: CatalogCase[],
+  current: MergedEntries,
+  previous: { path: string; entries: MergedEntries },
+  skipped: Set<string>,
+): ReportDelta {
   const delta: ReportDelta = {
     baseline: previous.path,
     newlyFailing: [],
@@ -212,6 +219,7 @@ function compareStanding(cases: CatalogCase[], current: MergedEntries, previous:
     stillFailing: [],
     stillBlocked: [],
     cleared: [],
+    skipped: [],
     unknown: [],
   };
   for (const testCase of cases) {
@@ -219,7 +227,11 @@ function compareStanding(cases: CatalogCase[], current: MergedEntries, previous:
     const now = rollupVerdict(current[testCase.id]);
     if (now === "Fail") (before === "Fail" ? delta.stillFailing : delta.newlyFailing).push(testCase.id);
     else if (now === "Blocked") (before === "Blocked" ? delta.stillBlocked : delta.newlyBlocked).push(testCase.id);
-    else if (before === "Fail" || before === "Blocked") (now === "Pass" ? delta.fixed : delta.cleared).push(testCase.id);
+    else if (before === "Fail" || before === "Blocked") {
+      if (now === "Pass") delta.fixed.push(testCase.id);
+      else if (now === "" && skipped.has(testCase.id)) delta.skipped.push(testCase.id);
+      else delta.cleared.push(testCase.id);
+    }
   }
   const active = new Set(cases.map((testCase) => testCase.id));
   delta.unknown = [...new Set([...Object.keys(previous.entries), ...Object.keys(current)])]
@@ -254,11 +266,19 @@ export function buildReportModel(cases: CatalogCase[], entries: MergedEntries, o
     throw new Error(`--skipped names unknown or retired Test IDs: ${unknownSkipped.join(", ")}`);
   }
   let excluded = 0;
+  // The standing lists and the delta read the unwindowed store, so the skipped
+  // in-window N/A is set aside there too — or coverage and delta would contradict.
+  const current: MergedEntries = skippedIds.length ? { ...entries } : entries;
   for (const id of skippedIds) {
     const byPerson = session.get(id) ?? {};
     const kept = Object.fromEntries(Object.entries(byPerson).filter(([, entry]) => entry.s !== "na"));
     excluded += Object.keys(byPerson).length - Object.keys(kept).length;
     session.set(id, kept);
+    if (entries[id]) {
+      current[id] = Object.fromEntries(
+        Object.entries(entries[id]).filter(([, entry]) => !(entry.s === "na" && inWindow(entry, window))),
+      );
+    }
   }
   // null = nobody touched the case inside the window; "" = touched, no verdict yet.
   const verdictOf = (testCase: CatalogCase): string | null => {
@@ -285,7 +305,7 @@ export function buildReportModel(cases: CatalogCase[], entries: MergedEntries, o
     }];
   });
 
-  const standingVerdict = (testCase: CatalogCase) => rollupVerdict(entries[testCase.id]);
+  const standingVerdict = (testCase: CatalogCase) => rollupVerdict(current[testCase.id]);
   const neverWalked: Record<string, string[]> = {};
   for (const testCase of untouched) (neverWalked[testCase.priority] ??= []).push(testCase.id);
 
@@ -318,7 +338,7 @@ export function buildReportModel(cases: CatalogCase[], entries: MergedEntries, o
       failing: untouched.filter((testCase) => standingVerdict(testCase) === "Fail").map((testCase) => testCase.id),
       blocked: untouched.filter((testCase) => standingVerdict(testCase) === "Blocked").map((testCase) => testCase.id),
     },
-    delta: options.previous ? compareStanding(cases, entries, options.previous) : null,
+    delta: options.previous ? compareStanding(cases, current, options.previous, new Set(skippedIds)) : null,
     testers: { count: perPerson.size, perPerson: sortedPeople },
     skipped: { ids: skippedIds, excluded },
   };
@@ -392,6 +412,7 @@ export function renderReport(model: ReportModel, catalog: Pick<Catalog, "kinds">
         countedLine("Newly blocked", model.delta.newlyBlocked),
         countedLine("Fixed", model.delta.fixed),
         countedLine("Cleared without a pass", model.delta.cleared),
+        ...(model.delta.skipped.length ? [countedLine("Skipped (baseline fail or blocked, not walked)", model.delta.skipped)] : []),
         countedLine("Still failing", model.delta.stillFailing),
         countedLine("Still blocked", model.delta.stillBlocked),
         ...(model.delta.unknown.length


### PR DESCRIPTION
## Summary

The first real run of the QA call pipeline (the 2026-09-04 team session, filed as PRD-864 with twelve slices) showed three gaps: dictated app notes carry several observations each, about a third of the notes are remarks about the test cases rather than the product, and product decisions and investigate-first items had no home. This PR teaches the pipeline those categories and opens the run-versioning hub.

- `.claude/context/qa.md`: verdict vocabulary (N/A means out of scope; a skipped case has no entry), environment attribution, and six finding dispositions with where each one lands.
- `qa-triage` call mode: split notes into observations before clustering, the decisions child, human-filed issue reconciliation, tester-note Urgent proposals, a gate-raisable slice cap, standing never-filed fails as marked slices, and a Verify on line per slice.
- `linear-templates.md`: Environment line, Decisions needed section, Product decisions child template, Verify on, evidence-link rule, disposition rows.
- `docs/routines/qa-call-report.md` mirrors the same rules unattended (re-paste into the cloud routine after merge).
- `.plans/backlog/qa-runs`: the run-versioning hub with the seven decisions locked on 2026-09-05, the catalog feedback that feeds its split lane, and the Linear parent PRD-878.

## Validation

- `bun run check:guidance-links`: 61 guidance files OK
- `bun run test:review-guardrails`: 205 passed
- `bun run check:docs-generated`: 18 projections checked after regenerating task-routing
- `node scripts/harness/plan-hub.mjs validate`: 31 hubs validated
- Pre-push gate: docs-authority and agent-guidance passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)