### PR TITLE
fix(qa): the slice cap orders the queue, it never drops a recorded finding

### DIFF
--- a/.claude/context/qa.md
+++ b/.claude/context/qa.md
@@ -179,7 +179,7 @@ ID, tester, and verdict, before assigning dispositions or clustering.
 
 | Disposition | What it is | Where it lands |
 | --- | --- | --- |
-| `defect` | The product does not do what the case expects | A slice, or an existing tracked Issue |
+| `defect` | The product does not do what the case expects | A slice, or an existing tracked Issue — always one or the other, whatever the session's slice cap |
 | `polish` | It works but looks or reads wrong; it may sit beside a Pass verdict | A slice at Low priority regardless of case priority, clustered by seam: `Todo` when at least one member entry was recorded inside the session window (a pass with a note counts), `Backlog` when reconstructed from notes alone |
 | `decision` | Needs a product or design ruling before a fix is honest (limits, copy direction, flow choices) | The parent's `Decisions needed` section plus the session's single decisions child |
 | `investigate` | A symptom whose cause or intent is unknown; not fixable until someone looks | A `Not sliced · investigate` line in the parent; a slice only after the look |

--- a/.claude/skills/qa-triage/SKILL.md
+++ b/.claude/skills/qa-triage/SKILL.md
@@ -73,10 +73,14 @@ Phase 3b dedupe catches the other's records if both ran.
   workspace is removed, so cleanup cannot lose it. A note that says "major regression", "major blocker", or "completely
   broken" proposes Urgent for its cluster; the priority stays derived until the gate confirms.
 - **Phases 3-5** — `defect` and `polish` observations cluster into slices: same catalog area +
-  same suspected seam, split past 3 Test IDs or a package boundary, ordered by priority. The
-  default cap is 8 slices; the gate may raise it when the week's fixing capacity matches (12 on
-  2026-09-04) — record the cap used in the parent's Slices intro and name overflow in
-  `Not sliced`. Standing fail/blocked entries **outside** the window are never slices by default;
+  same suspected seam, split past 3 Test IDs or a package boundary, ordered by priority. **Every
+  `defect` and `polish` cluster is filed as a slice.** The cap orders the queue, it does not decide
+  what exists: the first N clusters by priority propose `Todo`, and everything past N is filed all
+  the same at `Backlog`, so a finding a tester recorded always has a work item someone can pick
+  up. The default cap is 8; the gate may raise it when the week's fixing capacity matches (12 on
+  2026-09-04). Record the cap used in the parent's Slices intro and mark the overflow slices
+  `Backlog`. A recorded cluster never becomes a `Not sliced` line — that list holds only items no
+  fix could be verified against. Standing fail/blocked entries **outside** the window are never slices by default;
   the gate may accept ones that were never filed (no open Issue carries their Test ID), and such a
   slice opens with `Standing since <date>.` and is listed that way in the parent. `decision`
   observations become the parent's `Decisions needed` section plus one child issue

--- a/.claude/skills/qa-triage/linear-templates.md
+++ b/.claude/skills/qa-triage/linear-templates.md
@@ -223,9 +223,11 @@ Slice cap <N> this session.
   accepted as a slice — one line>
 
 ## Not sliced
-- <note-only follow-ups, anything past the slice cap, and `[derived:telemetry]`
-  uncorrelated window errors (testers or ordinary production traffic — the
-  telemetry has no tester predicate) — one line each>
+- <note-only follow-ups (no Test ID, so no fix could be verified against them)
+  and `[derived:telemetry]` uncorrelated window errors (testers or ordinary
+  production traffic — the telemetry has no tester predicate) — one line each.
+  A defect or polish cluster a tester recorded never appears here: it is a
+  slice, `Backlog` when it fell past the cap>
 - investigate: <a symptom whose cause or intent is unknown — one line; a slice
   only after someone looks>
 - environment: <behaviour caused by the harness or environment, not the product —

--- a/docs/docs/builders/agentic/task-routing.mdx
+++ b/docs/docs/builders/agentic/task-routing.mdx
@@ -22,7 +22,7 @@ generated_from:
   - .claude/skills/review/SKILL.md
   - .claude/skills/ship/SKILL.md
   - scripts/quality/task-routing-contract.mjs
-source_digest: "sha256:cf38754890f643e79bc92c3067bee120617025d153b031e63d0fe0cec633d58a"
+source_digest: "sha256:7807a7ff1341bfd9a3783e38101069023429876db7a639dbd9cb50f5106d69da"
 source_of_truth:
   - .claude/context/task-routing.json
   - .claude/skills/audit/SKILL.md

--- a/docs/routines/qa-call-report.md
+++ b/docs/routines/qa-call-report.md
@@ -165,8 +165,11 @@ not product work.
    cluster whose root cause sits in shared code is ONE slice on the shared package. Each slice
    states where it can be verified — `local`, `device`, or `production`, from its cases'
    `requiresDevice` and `requiresProduction` flags — so a fix session takes `local` first.
-4. Cap **8 slices**, ordered by highest member priority; overflow findings are listed in the
-   parent's "Not sliced" section, not silently dropped. Standing fail/blocked entries outside the
+4. Order clusters by highest member priority and file **every** `defect` and `polish` cluster as
+   a slice. The cap of **8** governs the queue, not what exists: the first eight propose `Todo`,
+   and every cluster past eight is filed at `Backlog`, so nothing a tester recorded is left as
+   prose for a human to notice later. Say in the parent's Slices intro how many landed `Todo` and
+   how many `Backlog`. Standing fail/blocked entries outside the
    window are never slices unattended; those with no open Issue carrying their Test ID are listed
    in `Not sliced` as `standing since <date>` lines for a human to promote at the desk.
 


### PR DESCRIPTION
## Why

On the 2026-09-04 session, seven recorded defect and polish clusters were flattened into the parent's `Not sliced` prose because they fell past the slice cap. They had already been clustered as slices S13 through S18 in the triage workspace, with priorities and packages assigned. The cap then discarded them into text.

Nothing downstream reads `Not sliced`. So a tester's dictated bugs, including off-centre media icons, a clipped thumbnail border, mismatched type sizes, and a footer whose links had regressed, had no work item and no path to a fix.

## What changes

The cap now governs queue ordering only. Every `defect` and `polish` cluster is filed as a slice: the first N by priority propose `Todo`, and everything past N is filed at `Backlog`.

`Not sliced` keeps only what no fix could be verified against, which is note-only follow-ups without a Test ID and uncorrelated telemetry, alongside the existing `investigate`, `environment`, and catalog lines.

Touched: the qa-triage skill's Phases 3-5, the unattended routine's Phase 3, the parent template's `Not sliced` block, and the `defect` row in the dispositions table.

## The backlog it created

The eight clusters from 2026-09-04 are now filed as PRD-882 through PRD-889 and listed in PRD-864's Slices section. Three are `Todo` because their entries sit inside the session window; five are `Backlog` because they were reconstructed from standing state.

## Proof

`bun run check:guidance-links`, `bun run test:review-guardrails` (205 pass), and `bun run check:docs-generated` all pass on this head. Projections regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)