### PR TITLE
fix(agent): preserve QA slices beyond the Todo queue budget

### DIFF
--- a/.claude/context/qa.md
+++ b/.claude/context/qa.md
@@ -179,12 +179,20 @@ ID, tester, and verdict, before assigning dispositions or clustering.
 
 | Disposition | What it is | Where it lands |
 | --- | --- | --- |
-| `defect` | The product does not do what the case expects | A slice, or an existing tracked Issue |
+| `defect` | The product does not do what the case expects | Every accepted cluster becomes a slice, or links an existing tracked Issue; the Todo queue budget limits ordering, never filing — overflow is `Backlog` at its derived priority, never `Not sliced` |
 | `polish` | It works but looks or reads wrong; it may sit beside a Pass verdict | A slice at Low priority regardless of case priority, clustered by seam: `Todo` when at least one member entry was recorded inside the session window (a pass with a note counts), `Backlog` when reconstructed from notes alone |
 | `decision` | Needs a product or design ruling before a fix is honest (limits, copy direction, flow choices) | The parent's `Decisions needed` section plus the session's single decisions child |
 | `investigate` | A symptom whose cause or intent is unknown; not fixable until someone looks | A `Not sliced · investigate` line in the parent; a slice only after the look |
 | `catalog` | Feedback about the test case itself: split it, rename it, move it, unclear, missing twin | `tmp/qa-triage/<slug>/catalog-feedback.md` from the skill, copied at close into the plan hub that owns the next catalog change (de-attributed: no verdicts, no tester names, because the repository is public), or one `Catalog feedback` comment on the parent from the routine; never a slice |
 | `environment` | Behaviour caused by the harness or environment, not the product (cold start, beta-only data, wrong wallet) | One environment line in the parent; never a slice |
+
+The same queue budget applies to `polish`: derive state and priority first, then keep only the
+first N Todo-eligible slices by priority in `Todo` and file the rest as `Backlog`. The default is 8;
+the interactive gate may raise it. List every accepted slice in the parent's `Slices`, including
+Backlog. Session-window acceptance and Test ID linkage still apply; the budget never admits
+standing state or guesses a case. `Not sliced` holds note-only follow-ups without an exact Test ID
+and uncorrelated telemetry, plus investigate and environment lines; catalog feedback keeps its
+separate disposition above.
 
 Observations that already carry a tracked Issue (exact Test ID or error hash, or a title match a
 human confirmed at the gate) are linked, not re-filed. A tester's own words carry severity: "major

--- a/.claude/skills/qa-triage/SKILL.md
+++ b/.claude/skills/qa-triage/SKILL.md
@@ -74,9 +74,15 @@ Phase 3b dedupe catches the other's records if both ran.
   broken" proposes Urgent for its cluster; the priority stays derived until the gate confirms.
 - **Phases 3-5** — `defect` and `polish` observations cluster into slices: same catalog area +
   same suspected seam, split past 3 Test IDs or a package boundary, ordered by priority. The
-  default cap is 8 slices; the gate may raise it when the week's fixing capacity matches (12 on
-  2026-09-04) — record the cap used in the parent's Slices intro and name overflow in
-  `Not sliced`. Standing fail/blocked entries **outside** the window are never slices by default;
+  cap is a **Todo queue budget**, default 8; the gate may raise it when the week's fixing
+  capacity matches. File every accepted defect and polish cluster, or link its existing tracked
+  Issue. After deriving state and priority below, the first N Todo-eligible slices by priority
+  propose `Todo`; file every remaining slice as `Backlog`, keeping its derived priority. Record
+  the budget and the Todo/Backlog split in the parent's Slices intro and list all slices there;
+  the cap never sends a formed slice to `Not sliced`. That section holds note-only follow-ups
+  without an exact Test ID and uncorrelated telemetry, alongside investigate and environment
+  lines; catalog feedback keeps its separate disposition. Standing fail/blocked entries
+  **outside** the window are never slices by default;
   the gate may accept ones that were never filed (no open Issue carries their Test ID), and such a
   slice opens with `Standing since <date>.` and is listed that way in the parent. `decision`
   observations become the parent's `Decisions needed` section plus one child issue

--- a/.claude/skills/qa-triage/linear-templates.md
+++ b/.claude/skills/qa-triage/linear-templates.md
@@ -214,16 +214,16 @@ Full report: [QA session YYYY-MM-DD · full report](<linear-document-url>)
 - <a product or design ruling the testing surfaced but nobody has made — one line each, with the Test IDs it blocks; mirrored in the session's decisions child (§ Product decisions child) — drop the section when none>
 
 ## Slices
-Slice cap <N> this session.
+Todo queue budget <N> this session: <T> Todo, <B> Backlog. Every accepted cluster is tracked.
 - <one line per slice: what it covers and its Test IDs — Linear renders the
-  sub-issue links; this list gives the reading order and the overflow context>
+  sub-issue links; include its priority and Todo/Backlog state, in queue order>
 - already tracked: <PRD-NNN> — <one line> (an existing open Issue, related to
   this parent so the fix queue still sees it)
 - standing since <date>: <a never-filed fail from an earlier walk that the gate
   accepted as a slice — one line>
 
 ## Not sliced
-- <note-only follow-ups, anything past the slice cap, and `[derived:telemetry]`
+- <note-only follow-ups without an exact Test ID, and `[derived:telemetry]`
   uncorrelated window errors (testers or ordinary production traffic — the
   telemetry has no tester predicate) — one line each>
 - investigate: <a symptom whose cause or intent is unknown — one line; a slice
@@ -341,7 +341,7 @@ link carries no session or replay identifier. Replay URLs, session IDs, and dist
 reach Linear; the parent's recipe line points a human at the recordings view instead. A slice the
 gate accepted from standing state opens its body with `Standing since <date>.`
 
-**State + priority**: verdict-backed (a tester recorded fail/blocked in the QA app during the
+**State + priority (before the Todo queue budget)**: verdict-backed (a tester recorded fail/blocked in the QA app during the
 session window, exact Test IDs) → `Todo`; priority High for a P0-case fail, Medium for P1, Low
 otherwise — Urgent only when the call flagged it release-blocking, or when a tester's note proposed
 it and the gate confirmed. A `polish` slice lands Low whatever its cases' priority: `Todo` when at
@@ -352,6 +352,12 @@ re-judges it at take-up, and Sheet severity stays independently assigned
 (`.claude/context/qa.md` § Verdict and severity rules). Reconstructed from meeting notes alone
 (no app verdict) → `Backlog`, priority unset. **Labels**: the parent set plus ONE `package:*` for the slice's
 primary surface (secondary packages named in the prose, as always).
+
+**Queue budget**: file every accepted defect and polish cluster, or link its existing tracked
+Issue. The first N Todo-eligible slices by priority land in `Todo`; every remaining slice lands in
+`Backlog` with its derived priority unchanged. N defaults to 8 and may be raised at the interactive
+gate. A slice already assigned `Backlog` by the rules above stays there even when Todo slots remain.
+List all slices under `Slices`; `Not sliced` never holds overflow.
 
 ---
 
@@ -421,5 +427,8 @@ Linear's API constraint that Customer Needs must link to an Issue eliminates the
 | Catalog feedback (call report) | Never a slice — `tmp/qa-triage/<slug>/catalog-feedback.md` (skill), copied de-attributed into the catalog-owning plan hub at close, or one `Catalog feedback` comment on the parent (routine) | — | No |
 | Environment finding (call report) | One `environment:` line under the parent's `Not sliced`; never a slice | — | No |
 | Never-filed standing fail accepted at the gate (call report) | QA slice sub-issue opening with `Standing since <date>.` | `Todo` + derived priority | No |
+
+The call-report states above are subject to the QA slice's Todo queue budget; overflow lands in
+`Backlog`, with priority unchanged.
 
 The default for ambiguous items is **track-only** — create a Customer Need linked to a lightweight Backlog tracking Issue. The Issue exists only because Linear requires a link target; it is not committed work until a human promotes it.

--- a/docs/docs/builders/agentic/task-routing.mdx
+++ b/docs/docs/builders/agentic/task-routing.mdx
@@ -22,7 +22,7 @@ generated_from:
   - .claude/skills/review/SKILL.md
   - .claude/skills/ship/SKILL.md
   - scripts/quality/task-routing-contract.mjs
-source_digest: "sha256:cf38754890f643e79bc92c3067bee120617025d153b031e63d0fe0cec633d58a"
+source_digest: "sha256:7533df027f9770756f8bd5c51c30779c6b93c57974ea6ad6b17ee3b975fbf77d"
 source_of_truth:
   - .claude/context/task-routing.json
   - .claude/skills/audit/SKILL.md

--- a/docs/routines/qa-call-report.md
+++ b/docs/routines/qa-call-report.md
@@ -165,10 +165,16 @@ not product work.
    cluster whose root cause sits in shared code is ONE slice on the shared package. Each slice
    states where it can be verified — `local`, `device`, or `production`, from its cases'
    `requiresDevice` and `requiresProduction` flags — so a fix session takes `local` first.
-4. Cap **8 slices**, ordered by highest member priority; overflow findings are listed in the
-   parent's "Not sliced" section, not silently dropped. Standing fail/blocked entries outside the
-   window are never slices unattended; those with no open Issue carrying their Test ID are listed
-   in `Not sliced` as `standing since <date>` lines for a human to promote at the desk.
+4. Use a **Todo queue budget of 8**, not a limit on filing. File every defect and polish cluster
+   admitted by the join and session-window rules, or link its existing tracked Issue. Derive state
+   and priority from the QA slice template, then put the first 8 Todo-eligible slices by priority
+   in `Todo` and every remaining slice in `Backlog`, keeping its derived priority. Record the
+   budget and the Todo/Backlog split in the parent's Slices intro and list all slices there;
+   overflow never goes in `Not sliced`. That section holds note-only follow-ups without an exact
+   Test ID and uncorrelated telemetry, alongside investigate and environment lines; catalog
+   feedback keeps its separate disposition. Standing fail/blocked entries outside the window
+   remain standing-state context (Phase 2), never slices unattended; a human may accept never-filed
+   findings at the desk.
 
 ## Phase 4: Enrich from the product (non-blocking)
 
@@ -282,6 +288,8 @@ exposure: redact in place and fail loud in the Discord summary.
 4. **Then each slice** as a sub-issue via `parentId`, body per the § QA slice template (problem
    cluster in prose with Test IDs and verdicts, "Where to start" map, "Done when" = the Test IDs
    re-record as pass, fix-posture pointer, validation command, source line).
+   Derive state and priority below, then apply Phase 3's Todo queue budget before writing: overflow
+   is `Backlog` at the same priority, and every admitted cluster gets a slice or existing Issue.
    - **Verdict-backed** (a tester recorded fail/blocked in the app **during the session
      window**): `Todo`; priority High for a P0-case fail, Medium for P1, Low otherwise — Urgent
      only when the call notes flag it release-blocking. A tester's own note calling it a major
@@ -317,7 +325,7 @@ filed, the admin review pair is the one to take first."}
 
 {Top slices — up to 3, one line each:} - **{slice title}** · {priority} → <{linear-url}>
 
-Report: <{parent-url}> · {N} slices ({T} Todo · {B} Backlog){if overflow: " · {M} findings not sliced"}
+Report: <{parent-url}> · {N} slices ({T} Todo · {B} Backlog){if not_sliced: " · {M} follow-ups not sliced"}
 {if any_failure: "⚠ {short failure list}"}
 ```
 


### PR DESCRIPTION
## Summary
- Preserve every accepted defect and polish cluster as a QA slice or existing issue. The default limit of eight now controls the Todo queue; overflow is filed Backlog with its derived priority unchanged.
- Keep the interactive skill, unattended routine, parent/slice templates, and finding dispositions consistent, including the routine’s write and summary steps. Regenerate the task-routing projection.
- Preserve clustering, priority derivation, session-window acceptance, and Test ID linkage. This changes `.claude` agent guidance; no product runtime or QA plan-hub files change.

Relates to PRD-864

## Validation
- [x] `bun run check:guidance-links`
- [x] `bun run test:review-guardrails` — 205 tests pass
- [x] `bun run check:docs-generated`
- [x] `node scripts/dev/ci-local.js --intent push --reuse-passing-receipts`
- [x] Docs build and search-index check — 70 routes

The three requested checks and Push Gate passed on `0f3f7bd81a3ba9d29fa471e90fa05e7c4ff6380d` with a clean checkout. Published through the GitHub connector because this task’s Git transport is unavailable. CI is checked on this PR’s current head; this PR remains a draft.