### PR TITLE
fix(shared): repair passkey signing without moving accounts — v1.2.2

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
@@ -86,7 +86,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
@@ -124,7 +124,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
@@ -211,7 +211,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
@@ -303,7 +303,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@908c540300062bd5a7e473851cdb4282204cee09 # v1.9.1
         with:
-          version: stable
+          version: v1.7.1
 
       - name: Setup Node.js
         uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Security fixes target the active `develop` branch and the latest tagged release line, currently `v1.2.1`. Historical pre-1.0 releases are not maintained unless maintainers explicitly scope a backport.
+Security fixes target the active `develop` branch and the latest tagged release line, currently `v1.2.2`. Historical pre-1.0 releases are not maintained unless maintainers explicitly scope a backport.
 
 ## Reporting a Vulnerability
 

--- a/docs/docs/reference/changelog.md
+++ b/docs/docs/reference/changelog.md
@@ -30,7 +30,7 @@ The complete, auto-generated changelog lives on [GitHub Releases](https://github
 
 **Passkey sign-in can approve actions again**
 
-- **Passkey accounts** — if you sign in with a passkey, approving an action (joining a garden, submitting work) no longer fails with a prompt that appears to time out. Sign-in itself was always working; it was the approval step that could not read your saved passkey. Existing passkeys are repaired automatically the next time you open the app — there is nothing to re-register.
+- **Passkey accounts** — if you sign in with a passkey, approving an action (joining a garden, submitting work) no longer fails with a prompt that appears to time out. Sign-in itself was always working; it was the approval step that could not find your saved passkey. Once the app updates, your existing passkey and your account work as before — there is nothing to re-register.
 
 Full notes: [GitHub Releases](https://github.com/greenpill-dev-guild/green-goods/releases).
 

--- a/docs/docs/reference/changelog.md
+++ b/docs/docs/reference/changelog.md
@@ -3,7 +3,7 @@ title: Changelog / Release Notes
 slug: /reference/changelog
 audience: all
 owner: docs
-last_verified: 2026-07-30
+last_verified: 2026-09-12
 feature_status: Live
 source_of_truth:
   - https://github.com/greenpill-dev-guild/green-goods/releases
@@ -25,6 +25,14 @@ The complete, auto-generated changelog lives on [GitHub Releases](https://github
 ---
 
 ## 2026
+
+### v1.2.2 - September 2026
+
+**Passkey sign-in can approve actions again**
+
+- **Passkey accounts** — if you sign in with a passkey, approving an action (joining a garden, submitting work) no longer fails with a prompt that appears to time out. Sign-in itself was always working; it was the approval step that could not read your saved passkey. Existing passkeys are repaired automatically the next time you open the app — there is nothing to re-register.
+
+Full notes: [GitHub Releases](https://github.com/greenpill-dev-guild/green-goods/releases).
 
 ### v1.2.1 - July 2026
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "green-goods",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "private": true,
   "keywords": [

--- a/packages/admin/package.json
+++ b/packages/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@green-goods/admin",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@green-goods/agent",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "main": "src/index.ts",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@green-goods/client",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@green-goods/contracts",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "description": "Contracts for Green Goods Protocol",
   "exports": {

--- a/packages/indexer/package.json
+++ b/packages/indexer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@green-goods/indexer",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "scripts": {
     "clean": "tsc --clean",
     "build": "tsc --build",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@green-goods/shared",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "private": true,
   "type": "module",
   "engines": {

--- a/packages/shared/src/__tests__/workflows/authPasskeyOwner.test.ts
+++ b/packages/shared/src/__tests__/workflows/authPasskeyOwner.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Passkey owner signing ceremony.
+ *
+ * Exercised through the real viem and ox implementations rather than a mock of
+ * `viem/account-abstraction`: the production failure lived in how ox encodes the
+ * credential ID, so a mock would hide exactly the behaviour under test.
+ */
+
+import { type P256Credential, toWebAuthnAccount } from "viem/account-abstraction";
+import { describe, expect, it, vi } from "vitest";
+
+import { createPasskeyOwner } from "../../workflows/authServices";
+
+// One 20-byte credential (the length Apple passkeys use), in both encodings it is stored in.
+const CREDENTIAL_BYTES = [
+  0x1f, 0x8b, 0x3c, 0xd2, 0x47, 0x90, 0xae, 0x05, 0x6e, 0xb1, 0x22, 0xf4, 0x9d, 0x38, 0xc7, 0x61,
+  0x0a, 0xe5, 0x7b, 0x54,
+];
+/** How the passkey server reports it. */
+const HEX_ID = "1f8b3cd24790ae056eb122f49d38c7610ae57b54";
+/** How the browser reports it after a local registration. */
+const BASE64URL_ID = "H4s80keQrgVusSL0nTjHYQrle1Q";
+
+const RP_ID = "greengoods.app";
+
+function credentialWithId(id: string): P256Credential {
+  return {
+    id,
+    publicKey: "0x1234",
+    raw: undefined as unknown as PublicKeyCredential,
+  };
+}
+
+type CredentialGetter = NonNullable<Parameters<typeof createPasskeyOwner>[2]>;
+type CredentialRequest = Parameters<CredentialGetter>[0];
+
+function toBytes(source: ArrayBufferView | ArrayBuffer | undefined): number[] {
+  if (!source) return [];
+  const view = ArrayBuffer.isView(source)
+    ? new Uint8Array(source.buffer, source.byteOffset, source.byteLength)
+    : new Uint8Array(source);
+  return Array.from(view);
+}
+
+/** Run a signing ceremony and return the request the authenticator would receive. */
+async function captureCeremony(
+  sign: (getCredential: CredentialGetter) => {
+    sign: (parameters: { hash: `0x${string}` }) => Promise<unknown>;
+  }
+) {
+  let request: CredentialRequest;
+  const getCredential: CredentialGetter = vi.fn(async (options: CredentialRequest) => {
+    request = options;
+    return null;
+  });
+
+  await expect(sign(getCredential).sign({ hash: "0x010203" })).rejects.toThrow(
+    "Failed to request credential"
+  );
+
+  return {
+    request,
+    credentialBytes: toBytes(request?.publicKey?.allowCredentials?.[0]?.id),
+  };
+}
+
+describe("createPasskeyOwner", () => {
+  it("names the real credential when the passkey server stored a hex ID", async () => {
+    const { credentialBytes } = await captureCeremony((getCredential) =>
+      createPasskeyOwner(credentialWithId(HEX_ID), RP_ID, getCredential)
+    );
+
+    expect(credentialBytes).toEqual(CREDENTIAL_BYTES);
+  });
+
+  it("keeps the credential ID the smart-account address is derived from", () => {
+    const owner = createPasskeyOwner(credentialWithId(HEX_ID), RP_ID);
+
+    expect(owner.id).toBe(HEX_ID);
+  });
+
+  it("leaves base64URL credential IDs from local registration unchanged", async () => {
+    const owner = createPasskeyOwner(credentialWithId(BASE64URL_ID), RP_ID);
+    const { credentialBytes } = await captureCeremony((getCredential) =>
+      createPasskeyOwner(credentialWithId(BASE64URL_ID), RP_ID, getCredential)
+    );
+
+    expect(owner.id).toBe(BASE64URL_ID);
+    expect(credentialBytes).toEqual(CREDENTIAL_BYTES);
+  });
+
+  it("keeps the RP ID and user verification ox requested", async () => {
+    const { request } = await captureCeremony((getCredential) =>
+      createPasskeyOwner(credentialWithId(HEX_ID), RP_ID, getCredential)
+    );
+
+    expect(request?.publicKey?.rpId).toBe(RP_ID);
+    expect(request?.publicKey?.userVerification).toBe("required");
+  });
+
+  // Pins the premise of the fix. If a future viem or ox release starts decoding hex IDs
+  // itself, this fails and the correction in createPasskeyOwner can be retired.
+  it("guards against ox naming the wrong credential for a hex ID", async () => {
+    const { credentialBytes } = await captureCeremony((getCredential) =>
+      toWebAuthnAccount({ credential: credentialWithId(HEX_ID), rpId: RP_ID, getFn: getCredential })
+    );
+
+    expect(credentialBytes).not.toEqual(CREDENTIAL_BYTES);
+  });
+});

--- a/packages/shared/src/__tests__/workflows/authServices.test.ts
+++ b/packages/shared/src/__tests__/workflows/authServices.test.ts
@@ -76,7 +76,10 @@ if (typeof global.navigator === "undefined") {
 // Mock viem/account-abstraction
 vi.mock("viem/account-abstraction", () => ({
   createWebAuthnCredential: vi.fn(),
-  toWebAuthnAccount: vi.fn(() => ({ address: "0xWebAuthnAccount" })),
+  toWebAuthnAccount: vi.fn(({ credential }: { credential: { id: string } }) => ({
+    id: credential.id,
+    address: "0xWebAuthnAccount",
+  })),
   entryPoint07Address: "0x0000000000000000000000000000000000000007",
 }));
 
@@ -196,6 +199,7 @@ vi.mock("../../modules/auth/session", () => ({
 }));
 
 // Import after mocks
+import { toKernelSmartAccount } from "permissionless/accounts";
 import { createWebAuthnCredential, toWebAuthnAccount } from "viem/account-abstraction";
 import { createPasskey } from "../../config/passkeyServer";
 import {
@@ -484,50 +488,47 @@ describe("workflows/authServices (Pimlico Server Flow)", () => {
   });
 
   // ==========================================================================
-  // CREDENTIAL ID ENCODING FOR SIGNING
+  // ACCOUNT IDENTITY
   // ==========================================================================
 
-  describe("credential ID encoding for the signing ceremony", () => {
-    // ox base64URL-decodes the credential ID with no hex fallback, so a hex ID
-    // reaches the authenticator as unrelated bytes and the ceremony rejects with
-    // NotAllowedError. Authentication is unaffected because decodeCredentialId
-    // parses hex as well — which is why sign-in kept working while every
-    // signature failed.
+  describe("account identity across the signing fix", () => {
+    // Kernel derives the smart-account address from the owner's credential ID, so the
+    // passkey server's hex ID must reach it untouched. Normalizing it to base64URL would
+    // move every existing passkey user to a different account.
     const HEX_ID = "746573742d63726564656e7469616c2d6964";
-    const BASE64URL_ID = "dGVzdC1jcmVkZW50aWFsLWlk";
 
-    it("normalizes a hex credential ID to base64URL before signing", async () => {
+    it("hands Kernel the stored credential ID unchanged", async () => {
       mockStoredCredential = { ...MOCK_CREDENTIAL, id: HEX_ID };
       mockStoredUsername = MOCK_USERNAME;
 
-      await invokeService(restoreSessionService, { chainId: MOCK_CHAIN_ID });
+      const result = await invokeService(restoreSessionService, { chainId: MOCK_CHAIN_ID });
 
-      expect(toWebAuthnAccount).toHaveBeenCalledWith(
-        expect.objectContaining({
-          credential: expect.objectContaining({ id: BASE64URL_ID }),
-        })
+      expect(result?.smartAccountAddress).toBe(MOCK_SMART_ACCOUNT_ADDRESS);
+      expect(toKernelSmartAccount).toHaveBeenCalledWith(
+        expect.objectContaining({ owners: [expect.objectContaining({ id: HEX_ID })] })
       );
     });
 
-    it("rewrites the repaired credential ID back to storage", async () => {
+    it("does not rewrite the stored credential while restoring", async () => {
       mockStoredCredential = { ...MOCK_CREDENTIAL, id: HEX_ID };
-      mockStoredUsername = MOCK_USERNAME;
-
-      await invokeService(restoreSessionService, { chainId: MOCK_CHAIN_ID });
-
-      expect(mockStoredCredential).toMatchObject({ id: BASE64URL_ID });
-    });
-
-    it("leaves an already base64URL credential ID untouched", async () => {
-      mockStoredCredential = { ...MOCK_CREDENTIAL, id: BASE64URL_ID };
       mockStoredUsername = MOCK_USERNAME;
 
       await invokeService(restoreSessionService, { chainId: MOCK_CHAIN_ID });
 
       expect(setStoredCredential).not.toHaveBeenCalled();
+      expect(mockStoredCredential).toMatchObject({ id: HEX_ID });
+    });
+
+    it("signs through a credential getter that corrects the ceremony request", async () => {
+      mockStoredCredential = { ...MOCK_CREDENTIAL, id: HEX_ID };
+      mockStoredUsername = MOCK_USERNAME;
+
+      await invokeService(restoreSessionService, { chainId: MOCK_CHAIN_ID });
+
       expect(toWebAuthnAccount).toHaveBeenCalledWith(
         expect.objectContaining({
-          credential: expect.objectContaining({ id: BASE64URL_ID }),
+          credential: expect.objectContaining({ id: HEX_ID }),
+          getFn: expect.any(Function),
         })
       );
     });
@@ -650,10 +651,8 @@ describe("workflows/authServices (Pimlico Server Flow)", () => {
       expect(createPasskey).not.toHaveBeenCalled();
       expect(setStoredUsername).toHaveBeenCalledWith(MOCK_USERNAME);
       expect(setStoredSmartAccountAddress).toHaveBeenCalledWith(MOCK_SMART_ACCOUNT_ADDRESS);
-      // The public key is the server's, but the ID is the browser's: only
-      // base64URL survives the signing ceremony.
       expect(result.credential).toEqual({
-        id: MOCK_CREDENTIAL.raw.id,
+        id: MOCK_SERVER_CREDENTIAL.id,
         publicKey: MOCK_SERVER_CREDENTIAL.publicKey,
         raw: MOCK_CREDENTIAL.raw,
       });
@@ -1132,12 +1131,11 @@ describe("workflows/authServices (Pimlico Server Flow)", () => {
       expect(clearStoredSmartAccountAddress).not.toHaveBeenCalled();
     });
 
-    it("keeps the browser credential ID rather than the passkey server's encoding", async () => {
-      // The server reports the same credential in its own hex encoding. Storing
-      // that is what left production unable to sign.
+    it("keeps the passkey server's hex credential ID so recovery lands on the same account", async () => {
+      const serverHexId = "746573742d63726564656e7469616c2d6964";
       mockPasskeyServerClient.verifyAuthentication.mockResolvedValue({
         success: true,
-        id: "746573742d63726564656e7469616c2d6964",
+        id: serverHexId,
         publicKey: MOCK_SERVER_CREDENTIAL.publicKey,
         userName: MOCK_USERNAME,
       });
@@ -1147,7 +1145,10 @@ describe("workflows/authServices (Pimlico Server Flow)", () => {
         chainId: MOCK_CHAIN_ID,
       });
 
-      expect(result.credential.id).toBe(MOCK_SERVER_CREDENTIAL.id);
+      expect(result.credential.id).toBe(serverHexId);
+      expect(toKernelSmartAccount).toHaveBeenCalledWith(
+        expect.objectContaining({ owners: [expect.objectContaining({ id: serverHexId })] })
+      );
     });
   });
 

--- a/packages/shared/src/__tests__/workflows/authServices.test.ts
+++ b/packages/shared/src/__tests__/workflows/authServices.test.ts
@@ -196,7 +196,7 @@ vi.mock("../../modules/auth/session", () => ({
 }));
 
 // Import after mocks
-import { createWebAuthnCredential } from "viem/account-abstraction";
+import { createWebAuthnCredential, toWebAuthnAccount } from "viem/account-abstraction";
 import { createPasskey } from "../../config/passkeyServer";
 import {
   clearAuthMode,
@@ -204,6 +204,7 @@ import {
   clearStoredCredential,
   clearStoredSmartAccountAddress,
   clearStoredUsername,
+  setStoredCredential,
   setStoredSmartAccountAddress,
   setStoredUsername,
 } from "../../modules/auth/session";
@@ -483,6 +484,56 @@ describe("workflows/authServices (Pimlico Server Flow)", () => {
   });
 
   // ==========================================================================
+  // CREDENTIAL ID ENCODING FOR SIGNING
+  // ==========================================================================
+
+  describe("credential ID encoding for the signing ceremony", () => {
+    // ox base64URL-decodes the credential ID with no hex fallback, so a hex ID
+    // reaches the authenticator as unrelated bytes and the ceremony rejects with
+    // NotAllowedError. Authentication is unaffected because decodeCredentialId
+    // parses hex as well — which is why sign-in kept working while every
+    // signature failed.
+    const HEX_ID = "746573742d63726564656e7469616c2d6964";
+    const BASE64URL_ID = "dGVzdC1jcmVkZW50aWFsLWlk";
+
+    it("normalizes a hex credential ID to base64URL before signing", async () => {
+      mockStoredCredential = { ...MOCK_CREDENTIAL, id: HEX_ID };
+      mockStoredUsername = MOCK_USERNAME;
+
+      await invokeService(restoreSessionService, { chainId: MOCK_CHAIN_ID });
+
+      expect(toWebAuthnAccount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credential: expect.objectContaining({ id: BASE64URL_ID }),
+        })
+      );
+    });
+
+    it("rewrites the repaired credential ID back to storage", async () => {
+      mockStoredCredential = { ...MOCK_CREDENTIAL, id: HEX_ID };
+      mockStoredUsername = MOCK_USERNAME;
+
+      await invokeService(restoreSessionService, { chainId: MOCK_CHAIN_ID });
+
+      expect(mockStoredCredential).toMatchObject({ id: BASE64URL_ID });
+    });
+
+    it("leaves an already base64URL credential ID untouched", async () => {
+      mockStoredCredential = { ...MOCK_CREDENTIAL, id: BASE64URL_ID };
+      mockStoredUsername = MOCK_USERNAME;
+
+      await invokeService(restoreSessionService, { chainId: MOCK_CHAIN_ID });
+
+      expect(setStoredCredential).not.toHaveBeenCalled();
+      expect(toWebAuthnAccount).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credential: expect.objectContaining({ id: BASE64URL_ID }),
+        })
+      );
+    });
+  });
+
+  // ==========================================================================
   // REGISTER PASSKEY SERVICE (Client-Only)
   // ==========================================================================
 
@@ -599,8 +650,10 @@ describe("workflows/authServices (Pimlico Server Flow)", () => {
       expect(createPasskey).not.toHaveBeenCalled();
       expect(setStoredUsername).toHaveBeenCalledWith(MOCK_USERNAME);
       expect(setStoredSmartAccountAddress).toHaveBeenCalledWith(MOCK_SMART_ACCOUNT_ADDRESS);
+      // The public key is the server's, but the ID is the browser's: only
+      // base64URL survives the signing ceremony.
       expect(result.credential).toEqual({
-        id: MOCK_SERVER_CREDENTIAL.id,
+        id: MOCK_CREDENTIAL.raw.id,
         publicKey: MOCK_SERVER_CREDENTIAL.publicKey,
         raw: MOCK_CREDENTIAL.raw,
       });
@@ -1077,6 +1130,24 @@ describe("workflows/authServices (Pimlico Server Flow)", () => {
       expect(clearStoredUsername).not.toHaveBeenCalled();
       expect(clearAuthMode).not.toHaveBeenCalled();
       expect(clearStoredSmartAccountAddress).not.toHaveBeenCalled();
+    });
+
+    it("keeps the browser credential ID rather than the passkey server's encoding", async () => {
+      // The server reports the same credential in its own hex encoding. Storing
+      // that is what left production unable to sign.
+      mockPasskeyServerClient.verifyAuthentication.mockResolvedValue({
+        success: true,
+        id: "746573742d63726564656e7469616c2d6964",
+        publicKey: MOCK_SERVER_CREDENTIAL.publicKey,
+        userName: MOCK_USERNAME,
+      });
+
+      const result = await invokeService(authenticatePasskeyService, {
+        userName: MOCK_USERNAME,
+        chainId: MOCK_CHAIN_ID,
+      });
+
+      expect(result.credential.id).toBe(MOCK_SERVER_CREDENTIAL.id);
     });
   });
 

--- a/packages/shared/src/workflows/authServices.ts
+++ b/packages/shared/src/workflows/authServices.ts
@@ -143,35 +143,62 @@ function decodeCredentialId(id: string): Uint8Array {
   }
 }
 
-/**
- * Encode credential ID bytes as the unpadded base64URL string WebAuthn uses.
- */
-function encodeCredentialId(bytes: Uint8Array): string {
-  let binary = "";
-  for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-  }
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-/**
- * Normalize a stored credential ID to base64URL.
- *
- * The passkey server returns hex-encoded credential IDs, and those were written
- * straight to storage. Authentication tolerates that because decodeCredentialId
- * parses hex as well as base64URL, but the signing ceremony does not: viem's
- * toWebAuthnAccount hands the ID to ox, which only ever base64URL-decodes it. A
- * hex ID therefore reaches the authenticator as unrelated bytes, matches no
- * credential, and the ceremony rejects with NotAllowedError.
- */
-function toBase64UrlCredentialId(id: string): string {
-  return encodeCredentialId(decodeCredentialId(id));
-}
-
 function toStrictArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   const buffer = new ArrayBuffer(bytes.byteLength);
   new Uint8Array(buffer).set(bytes);
   return buffer;
+}
+
+type CredentialGetter = NonNullable<Parameters<typeof toWebAuthnAccount>[0]["getFn"]>;
+
+// ox models WebAuthn requests with its own structural types while the browser API takes
+// the DOM ones; ox bridges the same gap the same way when it calls its default getter.
+const getBrowserCredential: CredentialGetter = (options) =>
+  window.navigator.credentials.get(options as never);
+
+/**
+ * Build the WebAuthn owner that signs for a passkey smart account.
+ *
+ * The stored credential ID is load-bearing in two incompatible ways:
+ *
+ * - Kernel derives the smart-account address from `keccak256(Base64.toBytes(owner.id))`,
+ *   so the ID must reach the account exactly as it was when the account was first built.
+ *   Normalizing it moves the user to a different address, which the restore and recovery
+ *   guards then reject.
+ * - ox names the credential for the signing ceremony by base64URL-decoding that same ID.
+ *   Credentials from the passkey server carry hex IDs, so the authenticator is asked for
+ *   bytes it does not hold and the ceremony fails with NotAllowedError.
+ *
+ * So the ID stays untouched and only the ceremony request is corrected, using the same
+ * hex-aware decoding that authentication already relies on. The on-chain signature does
+ * not include the credential ID, so the account is unaffected.
+ */
+export function createPasskeyOwner(
+  credential: P256Credential,
+  rpId: string,
+  getCredential: CredentialGetter = getBrowserCredential
+) {
+  return toWebAuthnAccount({
+    credential,
+    rpId,
+    getFn: (options) => {
+      const publicKey = options?.publicKey;
+      if (!publicKey?.allowCredentials) {
+        return getCredential(options);
+      }
+
+      // Decoded per ceremony, so a malformed ID fails signing (as it already did) rather
+      // than failing session restore.
+      const id = toStrictArrayBuffer(decodeCredentialId(credential.id));
+      return getCredential({
+        ...options,
+        publicKey: {
+          ...publicKey,
+          allowCredentials: publicKey.allowCredentials.map((descriptor) => ({ ...descriptor, id })),
+        },
+      });
+    },
+  });
 }
 
 function decodeChallenge(challenge: Hex | Uint8Array | ArrayBuffer): Uint8Array {
@@ -293,15 +320,16 @@ function toVerifiedCredential(
   raw: P256Credential["raw"],
   failureMessage: string
 ): P256Credential {
-  if (!verification.success || !verification.publicKey) {
+  if (!verification.success || !verification.id || !verification.publicKey) {
     throw new Error(failureMessage);
   }
 
-  // The browser's credential ID is authoritative: it is already base64URL, the
-  // only encoding the signing ceremony can consume. verification.id is the same
-  // credential in the passkey server's own hex encoding.
+  // Keep the server's credential ID exactly as returned, even though it is hex rather
+  // than base64URL. The smart-account address is derived from it, so rewriting it would
+  // move the user to a different account; createPasskeyOwner corrects the encoding only
+  // where the signing ceremony needs it.
   return {
-    id: raw.id,
+    id: verification.id,
     publicKey: verification.publicKey,
     raw,
   };
@@ -379,18 +407,7 @@ async function buildSmartAccountFromCredential(
   // CRITICAL: Must pass rpId to match what was used during registration
   // Without this, Android's Credential Manager rejects the credential on sign
   const rpId = getPasskeyRpId();
-
-  // Repair credential IDs already written to storage in hex. Rewriting the
-  // stored value keeps the repair to one pass per device and leaves the
-  // credential in the encoding every later reader expects.
-  const signingId = toBase64UrlCredentialId(credential.id);
-  const signingCredential =
-    signingId === credential.id ? credential : { ...credential, id: signingId };
-  if (signingCredential !== credential) {
-    setStoredCredential(signingCredential);
-  }
-
-  const webAuthnAccount = toWebAuthnAccount({ credential: signingCredential, rpId });
+  const webAuthnAccount = createPasskeyOwner(credential, rpId);
 
   // Create Kernel smart account with WebAuthn owner
   const account = await toKernelSmartAccount({

--- a/packages/shared/src/workflows/authServices.ts
+++ b/packages/shared/src/workflows/authServices.ts
@@ -143,6 +143,31 @@ function decodeCredentialId(id: string): Uint8Array {
   }
 }
 
+/**
+ * Encode credential ID bytes as the unpadded base64URL string WebAuthn uses.
+ */
+function encodeCredentialId(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Normalize a stored credential ID to base64URL.
+ *
+ * The passkey server returns hex-encoded credential IDs, and those were written
+ * straight to storage. Authentication tolerates that because decodeCredentialId
+ * parses hex as well as base64URL, but the signing ceremony does not: viem's
+ * toWebAuthnAccount hands the ID to ox, which only ever base64URL-decodes it. A
+ * hex ID therefore reaches the authenticator as unrelated bytes, matches no
+ * credential, and the ceremony rejects with NotAllowedError.
+ */
+function toBase64UrlCredentialId(id: string): string {
+  return encodeCredentialId(decodeCredentialId(id));
+}
+
 function toStrictArrayBuffer(bytes: Uint8Array): ArrayBuffer {
   const buffer = new ArrayBuffer(bytes.byteLength);
   new Uint8Array(buffer).set(bytes);
@@ -268,12 +293,15 @@ function toVerifiedCredential(
   raw: P256Credential["raw"],
   failureMessage: string
 ): P256Credential {
-  if (!verification.success || !verification.id || !verification.publicKey) {
+  if (!verification.success || !verification.publicKey) {
     throw new Error(failureMessage);
   }
 
+  // The browser's credential ID is authoritative: it is already base64URL, the
+  // only encoding the signing ceremony can consume. verification.id is the same
+  // credential in the passkey server's own hex encoding.
   return {
-    id: verification.id,
+    id: raw.id,
     publicKey: verification.publicKey,
     raw,
   };
@@ -351,7 +379,18 @@ async function buildSmartAccountFromCredential(
   // CRITICAL: Must pass rpId to match what was used during registration
   // Without this, Android's Credential Manager rejects the credential on sign
   const rpId = getPasskeyRpId();
-  const webAuthnAccount = toWebAuthnAccount({ credential, rpId });
+
+  // Repair credential IDs already written to storage in hex. Rewriting the
+  // stored value keeps the repair to one pass per device and leaves the
+  // credential in the encoding every later reader expects.
+  const signingId = toBase64UrlCredentialId(credential.id);
+  const signingCredential =
+    signingId === credential.id ? credential : { ...credential, id: signingId };
+  if (signingCredential !== credential) {
+    setStoredCredential(signingCredential);
+  }
+
+  const webAuthnAccount = toWebAuthnAccount({ credential: signingCredential, rpId });
 
   // Create Kernel smart account with WebAuthn owner
   const account = await toKernelSmartAccount({


### PR DESCRIPTION
Hotfix to production. Refs PRD-842.

## The defect

Passkey users on production can sign in but cannot approve anything. Every signature fails with `Failed to request credential. Details: The operation either timed out or was not allowed.` The same error surfaces in Sentry (`GREEN-GOODS-CLIENT-1W`, `WebAuthnP256.CredentialRequestFailedError`) on the profile page, so it affects every passkey-signed action, not only joining a garden.

After a passkey-server login or registration, the stored credential ID is the one Pimlico's passkey server returns, which is hex-encoded. The two WebAuthn ceremonies read that string under different rules:

- **Login** uses our own `decodeCredentialId()`, which tries hex first and then base64URL, so sign-in works.
- **Signing** hands `credential.id` to viem's `toWebAuthnAccount` → ox `Base64.toBytes()`, which is base64URL-only. The hex string decodes into unrelated bytes, `allowCredentials` names a credential the authenticator does not hold, and the platform rejects with `NotAllowedError`.

It never reproduced locally because only the passkey-server path stores a server-supplied ID, and `.env.template` ships `VITE_PASSKEY_SERVER_ENABLED=false`. Introduced in #556 (2026-06-10), shipped in v1.2.1 (2026-07-30), first seen in telemetry 2026-08-07.

## The change

**The credential ID is left exactly as it is; only the signing ceremony is corrected.**

That constraint matters. Kernel derives the smart-account address from `keccak256(Base64.toBytes(owner.id))`, so rewriting the ID to base64URL would move every existing passkey user to a different account, and the restore and recovery guards would then sign them out and refuse to let them back in. The first commit on this branch did exactly that; it is corrected by `04dc264c9`. **Please squash-merge** so that intermediate commit never lands on `main`.

- `createPasskeyOwner` gives `toWebAuthnAccount` a credential getter that swaps in the ID bytes decoded with the same hex-aware parser authentication uses. ox never compares the returned credential ID with the one it requested, and the on-chain signature (authenticator data, client data JSON, r, s) carries no credential ID. Nothing is written to storage and no address changes.
- `toVerifiedCredential` still keeps the server's ID, now with a comment saying why.
- Base64URL IDs from local registration decode to the same bytes as before, so those users see no change.

## Tests

- Identity tests fail if the ID reaching Kernel changes or storage is rewritten. The WebAuthn owner mock now echoes the credential ID it was given, so a normalization can no longer hide behind a fixed mock address. Each of these tests fails against the first commit on this branch.
- `authPasskeyOwner.test.ts` runs the ceremony through the **real** viem and ox: the corrected request names the real credential, the owner ID is unchanged, base64URL IDs are unaffected, and one test pins the premise that ox cannot decode a hex ID on its own.
- Mutation-checked: removing the byte correction fails only the ceremony test.

## CI: Foundry pinned to v1.7.1

The CI Gate was red for a reason outside this fix. `testGas_isGardenerOfCheck` exceeded its 20,000 gas budget because `main`'s contracts workflow floated on Foundry `stable`, which moved from 1.7.1 (July's passing run) to 1.8.1. The version bump touched root `package.json`, which re-ran that workflow on `main` for the first time since July 30. `develop` already pins every Foundry install to v1.7.1; this applies the same pin to all five installs. On forge 1.7.1 the benchmark passes against `main`'s contracts at 4,748 gas.

**Security-sensitive surfaces changed:** `.github/workflows/contracts.yml` (Foundry version input only) and the `version` field of all seven `package.json` files. `bun.lock` is untouched, as it was for v1.2.1.

## Version

1.2.1 → 1.2.2 across all 7 packages, with a changelog entry and the SECURITY.md supported-release line.

## Validation

Worktree off `main`, at `b2dd4717f`:

- shared `vitest`: 3363 passed, 13 skipped, 0 failures (286 files)
- shared `tsc --noEmit`: clean · `oxlint src`: 0 errors · `biome format`: clean
- forge 1.7.1, `testGas_isGardenerOfCheck`: pass (4,748 gas)

The Vercel docs and qa preview failures are pre-existing on PRs to `main` (#815 failed identically) and are not required checks.

## Verifying after deploy

A preview cannot exercise this: production builds block passkeys on `*.vercel.app`. After deploy:

1. Sign in on `www.greengoods.app` with an **existing** passkey and join a garden. A fresh registration does not prove the fix.
2. `auth_session_restored` must show no `address_mismatch` failures. There were none in the six weeks before deploy, so any at all means account identity moved. Roll back immediately if so.
3. `garden_join_success` should resume (none since 2026-08-26), and "Failed to request credential" should stop on `garden_join_failed` and in Sentry `GREEN-GOODS-CLIENT-1W`.

## After merge

- Tag `v1.2.2` on the merged `main` HEAD.
- Back-merge `main` into `develop`. `develop`'s `5f124418f` stores the browser's ID and has the same account-identity problem, so the ceremony correction should replace it there before v1.3.0 ships. Details on PRD-842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
